### PR TITLE
Add namespaced trusted tool registry

### DIFF
--- a/.github/skills/robits-runtime/SKILL.md
+++ b/.github/skills/robits-runtime/SKILL.md
@@ -1,16 +1,19 @@
 ---
 name: robits-runtime
-description: Work on the Robits Python organization-simulation runtime, including role orchestration, escape-code preload/execution, JSON extraction from model responses, OpenAI-compatible model configuration, and non-interactive smoke validation.
+description: Work on the Robits Python organization-simulation runtime, including role orchestration, trusted tool loading/execution, JSON extraction from model responses, OpenAI-compatible Responses or chat model configuration, scheduling, and non-interactive smoke validation.
 ---
 
 # Robits Runtime
 
 ## Process
 
-1. Inspect `main.py`, `preload.yaml`, and `tests/test_runtime.py` before changing runtime behavior.
+1. Inspect `main.py`, `tools.yaml`, and `tests/test_runtime.py` before changing runtime behavior.
 2. Preserve support for OpenAI-compatible endpoints through environment variables; keep machine-specific endpoint and model names out of committed docs unless expressed generically.
-3. Treat escape-code handling as a high-risk path because model output is parsed and executed.
-4. Prefer focused tests around parsing, preload, and execution before relying on a live model smoke test.
+3. Treat tool execution as a high-risk path because model output can request side effects.
+4. Keep trusted tool definition loading separate from untrusted model output.
+5. Prefer focused tests around parsing, tool loading, and execution before relying on a live model smoke test.
+6. For Responses API work, test function-call routing with fake response items before using a live endpoint.
+7. For scheduling work, prefer deterministic time-share behavior with injected or seeded schedulers before adding parallel execution.
 
 ## Validation
 
@@ -21,4 +24,4 @@ description: Work on the Robits Python organization-simulation runtime, includin
 ## References
 
 - Read `resources/runtime-architecture.md` for the current runtime shape and known boundaries.
-- Use `assets/create-role-message.json` as a minimal escape-code execution payload.
+- Use `assets/create-role-message.json` as a minimal tool execution payload.

--- a/.github/skills/robits-runtime/assets/create-role-message.json
+++ b/.github/skills/robits-runtime/assets/create-role-message.json
@@ -1,5 +1,5 @@
 {
-  "exec": "create_role",
+  "exec": "org.create_role",
   "args": {
     "role_name": "QA",
     "role_description": "Tests the organization"

--- a/.github/skills/robits-runtime/resources/runtime-architecture.md
+++ b/.github/skills/robits-runtime/resources/runtime-architecture.md
@@ -4,8 +4,23 @@
 
 - `Role` stores role-specific prompt templates and calls chat completions through `interact`.
 - `Human`, `Ops`, `HR`, `SoftwareEngineer`, and `Angel` define the initial organization roles.
-- `System` stores preloaded escape-code functions and executes them with the current `employee_dict`.
-- `preload.yaml` defines the default `create_role` escape code.
-- `parse_escape_code` extracts the first valid JSON object or array from a model response.
+- `System` loads trusted tools and executes them with the current `employee_dict`.
+- `tools.yaml` defines trusted tools such as `org.create_role`.
+- `parse_tool_instruction` extracts the first valid JSON object or array from a model response.
+
+## Current vs Target
+
+Current runtime:
+
+- Roles call Chat Completions.
+- The runtime can still parse JSON tool instructions from assistant text for compatibility.
+- Trusted tool definitions are repo-owned and loaded from `tools.yaml`.
+
+Target runtime:
+
+- Roles use OpenAI-compatible Responses-style interactions when available.
+- Approved tools are exposed as function tools with JSON Schema metadata.
+- The runtime handles zero or more function calls, executes trusted tools, returns tool outputs by call ID, and then asks the model for final text.
+- Speaker selection moves from random routing to deterministic time-share scheduling with turn budgets and later parallel execution where state coordination is explicit.
 
 Keep tests isolated from model services. Use live model checks only as smoke validation after deterministic tests pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,4 +19,4 @@ This repository is a Python experiment for simulating AI organization roles. Kee
 
 ## Repo-Local Skills
 
-Repo-local AI skills live in `.github/skills/`. Start with `.github/skills/robits-runtime/SKILL.md` when changing role orchestration, escape-code execution, JSON extraction, or model endpoint configuration.
+Repo-local AI skills live in `.github/skills/`. Start with `.github/skills/robits-runtime/SKILL.md` when changing role orchestration, trusted tool execution, JSON extraction, scheduling, or model endpoint configuration.

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ The AI-Powered Organization Simulation is a Python-based project that simulates 
 The organization has the following roles:
 
 1. CEO (Human) - A human role responsible for making high-level decisions and setting the overall direction of the organization.
-2. Ops (Operations) - A role responsible for executing escape codes when needed.
-3. SE (Software Engineer) - A role responsible for designing, developing, and maintaining software applications, primarily creating escape codes when requested by other members of the organization.
+2. Ops (Operations) - A role responsible for overseeing the execution environment and operational success of the agent organization.
+3. SE (Software Engineer) - A role responsible for designing, developing, and maintaining software applications, primarily proposing trusted tools when requested by other members of the organization.
 4. HR (Human Resources) - A role responsible for managing AI resources and creating new roles within the organization.
 
 ## How It Works 🛠️
 
-The simulation runs in a loop, where the organization members communicate with each other through messages. The System role can parse JSON blobs, store escape codes, and execute them when required. The code also contains a function to parse escape codes from a response text.
+The simulation runs in a loop, where organization members communicate through messages. The runtime can parse JSON tool instructions, load trusted tools from `tools.yaml`, and execute registered tools by name. Tools use namespaced identifiers such as `org.create_role`, with short aliases only where compatibility is useful.
+
+The target runtime direction is OpenAI-compatible tool calling through modern Responses-style loops: approved tools are exposed with JSON Schema metadata, the model may request function calls, the runtime executes those calls, and tool outputs are returned to the model without relying on ad hoc text parsing.
 
 ## Installation
 
@@ -49,6 +51,16 @@ Relevant environment variables:
 - `OPENAI_BASE_URL` or `OPENAI_API_BASE`: optional compatible endpoint URL.
 - `ROBITS_MODEL` or `OPENAI_MODEL`: default chat model.
 - `ROBITS_CHEAP_MODEL` and `ROBITS_COSTLY_MODEL`: optional per-role overrides.
+
+## Tools
+
+Trusted tools live in `tools.yaml`. Each entry includes a namespaced `name`, a JSON Schema `parameters` object, and trusted repo-owned code. Untrusted model output can request registered tools, but it cannot define new executable tools.
+
+Example execution payload:
+
+```json
+{"exec": "org.create_role", "args": {"role_name": "QA", "role_description": "Tests the organization"}}
+```
 
 ## Running the Simulation
 
@@ -86,5 +98,6 @@ There are many exciting ways you can improve and expand this project. Here are a
 3. Implement a graphical user interface (GUI) for a more immersive and user-friendly simulation experience.
 4. Explore ways to use real-world data to drive the simulation and make it more engaging and relevant.
 5. Experiment with different AI models or techniques to improve the performance and capabilities of the AI roles.
+6. Replace random next-speaker selection with a time-share scheduler that can run roles in deterministic, budgeted turns and eventually in parallel where the runtime can safely coordinate state.
 
 Have fun exploring the AI-Powered Organization Simulation! We can't wait to see what you come up with! 🎉💡

--- a/main.py
+++ b/main.py
@@ -53,6 +53,7 @@ class ToolDefinition:
     description: str
     parameters: dict
     args: list[str]
+    required_args: list[str]
     func: object
     aliases: tuple[str, ...] = ()
 
@@ -104,13 +105,21 @@ class ToolRegistry:
         if not all(part.isidentifier() for part in parts):
             raise ValueError(f"Invalid tool name: {name}")
 
-    def compile_tool(self, name, arg_names, code):
+    def compile_tool(self, name, arg_names, required_arg_names, code):
         self.validate_tool_name(name)
+        for arg_name in required_arg_names:
+            if arg_name not in arg_names:
+                raise ValueError(f"Required tool argument is not defined: {arg_name}")
         for arg_name in arg_names:
             if not arg_name.isidentifier():
                 raise ValueError(f"Invalid tool argument name: {arg_name}")
+            if arg_name == "employee_dict":
+                raise ValueError("Tool argument name 'employee_dict' is reserved.")
 
-        parameters = arg_names + ["employee_dict"]
+        optional_arg_names = [arg_name for arg_name in arg_names if arg_name not in required_arg_names]
+        parameters = ["employee_dict"] + required_arg_names + [
+            f"{arg_name}=None" for arg_name in optional_arg_names
+        ]
         indented_code = "\n".join(
             f"    {line}" if line.strip() else "" for line in code.splitlines()
         )
@@ -163,33 +172,42 @@ class ToolRegistry:
         properties = parameters.get("properties", {})
         if not isinstance(properties, dict) or not isinstance(required, list):
             raise ValueError("Tool parameters must contain object properties and required list.")
-        arg_names = []
+        required_arg_names = []
         for arg_name in required:
             if not isinstance(arg_name, str) or arg_name not in properties:
                 raise ValueError("Tool required args must be named properties.")
-            arg_names.append(arg_name)
+            required_arg_names.append(arg_name)
+        arg_names = list(properties)
 
-        return name, description, parameters, arg_names, code, aliases
+        return name, description, parameters, arg_names, required_arg_names, code, aliases
 
     def register_definition(self, instruction):
-        name, description, parameters, arg_names, code, aliases = self.normalize_definition(instruction)
+        name, description, parameters, arg_names, required_arg_names, code, aliases = self.normalize_definition(instruction)
         if name in self._tools:
             raise ValueError(f"Tool '{name}' already exists.")
         for alias in aliases:
+            self.validate_tool_name(alias)
             if alias in self._aliases or alias in self._tools:
                 raise ValueError(f"Tool alias '{alias}' already exists.")
-        func = self.compile_tool(name, arg_names, code)
-        self._tools[name] = ToolDefinition(
+        func = self.compile_tool(name, arg_names, required_arg_names, code)
+        tool = ToolDefinition(
             name=name,
             description=description,
             parameters=parameters,
             args=arg_names,
+            required_args=required_arg_names,
             func=func,
             aliases=aliases,
         )
+        openai_name = tool.openai_name
+        if openai_name != name and (openai_name in self._aliases or openai_name in self._tools):
+            raise ValueError(f"Tool OpenAI name '{openai_name}' already exists.")
+        self._tools[name] = tool
         for alias in aliases:
             self._aliases[alias] = name
-        return self._tools[name]
+        if openai_name != name:
+            self._aliases[openai_name] = name
+        return tool
 
     def execute(self, name, args, employee_dict):
         try:
@@ -200,10 +218,13 @@ class ToolRegistry:
         if resolved_name not in self._tools:
             return f"Error: Tool '{name}' not found."
         tool = self._tools[resolved_name]
-        missing_args = [arg_name for arg_name in tool.args if arg_name not in args]
+        missing_args = [arg_name for arg_name in tool.required_args if arg_name not in args]
         if missing_args:
             return f"Error: Missing args for tool '{name}': {missing_args}"
-        result = tool.func(**args, employee_dict=employee_dict)
+        unexpected_args = [arg_name for arg_name in args if arg_name not in tool.args]
+        if unexpected_args:
+            return f"Error: Unexpected args for tool '{name}': {unexpected_args}"
+        result = tool.func(employee_dict=employee_dict, **args)
         return f"Executed tool '{resolved_name}' with args {args}. Result: {result}"
 
     def as_responses_tools(self):
@@ -387,8 +408,11 @@ def parse_tool_instruction(s):
 
 def load_tools(system, yaml_file_path=None):
     yaml_file_path = yaml_file_path or Path(__file__).with_name("tools.yaml")
-    with open(yaml_file_path, 'r') as file:
+    with open(yaml_file_path, "r", encoding="utf-8") as file:
         yaml_content = yaml.safe_load(file)
+
+    if not isinstance(yaml_content, list):
+        raise ValueError("Tool file must contain a list of tool definitions.")
 
     for obj in yaml_content:
         system_response = system.interact(json.dumps(obj), trusted=True)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from dataclasses import dataclass
 from openai import OpenAI
 
 import random
@@ -30,8 +31,7 @@ client = make_client()
 default_model = os.environ.get("ROBITS_MODEL") or os.environ.get("OPENAI_MODEL") or "gpt-4o-mini"
 costly_model = os.environ.get("ROBITS_COSTLY_MODEL", default_model)
 cheap_model = os.environ.get("ROBITS_CHEAP_MODEL", default_model)
-escape_codes = {}
-SAFE_ESCAPE_BUILTINS = {
+SAFE_TOOL_BUILTINS = {
     "bool": bool,
     "dict": dict,
     "float": float,
@@ -45,6 +45,175 @@ SAFE_ESCAPE_BUILTINS = {
     "sum": sum,
     "tuple": tuple,
 }
+
+
+@dataclass
+class ToolDefinition:
+    name: str
+    description: str
+    parameters: dict
+    args: list[str]
+    func: object
+    aliases: tuple[str, ...] = ()
+
+    @property
+    def openai_name(self):
+        return self.name.replace(".", "__")
+
+    def as_responses_tool(self):
+        return {
+            "type": "function",
+            "name": self.openai_name,
+            "description": self.description,
+            "parameters": self.parameters,
+        }
+
+    def as_chat_completion_tool(self):
+        return {
+            "type": "function",
+            "function": {
+                "name": self.openai_name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+
+class ToolRegistry:
+    def __init__(self):
+        self._tools = {}
+        self._aliases = {}
+
+    def clear(self):
+        self._tools.clear()
+        self._aliases.clear()
+
+    def __contains__(self, name):
+        return self.resolve_name(name) in self._tools
+
+    def resolve_name(self, name):
+        return self._aliases.get(name, name)
+
+    def get(self, name):
+        return self._tools[self.resolve_name(name)]
+
+    def validate_tool_name(self, name):
+        if not isinstance(name, str) or not name:
+            raise ValueError("Tool name must be a non-empty string.")
+        parts = name.split(".")
+        if not all(part.isidentifier() for part in parts):
+            raise ValueError(f"Invalid tool name: {name}")
+
+    def compile_tool(self, name, arg_names, code):
+        self.validate_tool_name(name)
+        for arg_name in arg_names:
+            if not arg_name.isidentifier():
+                raise ValueError(f"Invalid tool argument name: {arg_name}")
+
+        parameters = arg_names + ["employee_dict"]
+        indented_code = "\n".join(
+            f"    {line}" if line.strip() else "" for line in code.splitlines()
+        )
+        if not indented_code:
+            indented_code = "    pass"
+        function_name = f"_tool_{name.replace('.', '_')}"
+        function_source = f"def {function_name}({', '.join(parameters)}):\n{indented_code}"
+        local_dict = {}
+        exec(
+            function_source,
+            {"__builtins__": SAFE_TOOL_BUILTINS, "Role": Role, "HR": HR},
+            local_dict,
+        )
+        return local_dict[function_name]
+
+    def normalize_definition(self, instruction):
+        if "function" in instruction:
+            function = instruction["function"]
+            name = function["name"]
+            description = function.get("description", "")
+            parameters = function.get("parameters", {"type": "object", "properties": {}})
+            code = instruction["code"]
+            aliases = tuple(instruction.get("aliases", ()))
+        elif "name" in instruction:
+            name = instruction["name"]
+            description = instruction.get("description", "")
+            parameters = instruction.get("parameters", {"type": "object", "properties": {}})
+            code = instruction["code"]
+            aliases = tuple(instruction.get("aliases", ()))
+        else:
+            name = instruction["code_name"]
+            args = instruction.get("args")
+            if not isinstance(args, list):
+                raise ValueError("Tool args must be a list of objects with name fields.")
+            properties = {}
+            for arg in args:
+                if not isinstance(arg, dict) or not isinstance(arg.get("name"), str):
+                    raise ValueError("Tool args must be a list of objects with name fields.")
+                properties[arg["name"]] = {"type": "string"}
+            description = instruction.get("description", "")
+            parameters = {
+                "type": "object",
+                "properties": properties,
+                "required": list(properties),
+            }
+            code = instruction["code"]
+            aliases = tuple(instruction.get("aliases", ()))
+
+        required = parameters.get("required", [])
+        properties = parameters.get("properties", {})
+        if not isinstance(properties, dict) or not isinstance(required, list):
+            raise ValueError("Tool parameters must contain object properties and required list.")
+        arg_names = []
+        for arg_name in required:
+            if not isinstance(arg_name, str) or arg_name not in properties:
+                raise ValueError("Tool required args must be named properties.")
+            arg_names.append(arg_name)
+
+        return name, description, parameters, arg_names, code, aliases
+
+    def register_definition(self, instruction):
+        name, description, parameters, arg_names, code, aliases = self.normalize_definition(instruction)
+        if name in self._tools:
+            raise ValueError(f"Tool '{name}' already exists.")
+        for alias in aliases:
+            if alias in self._aliases or alias in self._tools:
+                raise ValueError(f"Tool alias '{alias}' already exists.")
+        func = self.compile_tool(name, arg_names, code)
+        self._tools[name] = ToolDefinition(
+            name=name,
+            description=description,
+            parameters=parameters,
+            args=arg_names,
+            func=func,
+            aliases=aliases,
+        )
+        for alias in aliases:
+            self._aliases[alias] = name
+        return self._tools[name]
+
+    def execute(self, name, args, employee_dict):
+        try:
+            self.validate_tool_name(name)
+        except ValueError as e:
+            return f"Error: {e}"
+        resolved_name = self.resolve_name(name)
+        if resolved_name not in self._tools:
+            return f"Error: Tool '{name}' not found."
+        tool = self._tools[resolved_name]
+        missing_args = [arg_name for arg_name in tool.args if arg_name not in args]
+        if missing_args:
+            return f"Error: Missing args for tool '{name}': {missing_args}"
+        result = tool.func(**args, employee_dict=employee_dict)
+        return f"Executed tool '{resolved_name}' with args {args}. Result: {result}"
+
+    def as_responses_tools(self):
+        return [tool.as_responses_tool() for tool in self._tools.values()]
+
+    def as_chat_completion_tools(self):
+        return [tool.as_chat_completion_tool() for tool in self._tools.values()]
+
+
+tool_registry = ToolRegistry()
 
 
 def interact(self, model, sender, message):
@@ -108,82 +277,31 @@ class Role:
 
 
 class System(Role):
-    def __init__(self, employee_dict=None):
+    def __init__(self, employee_dict=None, registry=None):
         self.name = "System"
-        self.template = "As the System, you can parse JSON blobs and store escape codes, as well as execute them when required."
+        self.template = "As the System, you can parse JSON blobs and store trusted tools, as well as execute them when required."
         self.conversation_history = {}
         self.temperature = 0.1 * random.randint(1, 9)
         self.max_tokens = random.randint(250, 400)
         self.employee_dict = employee_dict if employee_dict is not None else {}
-
-    def compile_escape_code(self, code_name, arg_names, code):
-        if not code_name.isidentifier():
-            raise ValueError(f"Invalid escape code name: {code_name}")
-        for arg_name in arg_names:
-            if not arg_name.isidentifier():
-                raise ValueError(f"Invalid escape code argument name: {arg_name}")
-
-        parameters = arg_names + ["employee_dict"]
-        indented_code = "\n".join(
-            f"    {line}" if line.strip() else "" for line in code.splitlines()
-        )
-        if not indented_code:
-            indented_code = "    pass"
-        function_name = f"_escape_{code_name}"
-        function_source = f"def {function_name}({', '.join(parameters)}):\n{indented_code}"
-        local_dict = {}
-        exec(
-            function_source,
-            {"__builtins__": SAFE_ESCAPE_BUILTINS, "Role": Role, "HR": HR},
-            local_dict,
-        )
-        return local_dict[function_name]
+        self.tools = registry if registry is not None else tool_registry
 
     def handle_instruction(self, instruction, trusted=False):
         if not isinstance(instruction, dict):
             return "Error: JSON instruction must be an object."
 
-        if "code_name" in instruction:
+        if "code_name" in instruction or ("code" in instruction and ("name" in instruction or "function" in instruction)):
             if not trusted:
-                return "Error: Escape code definitions can only be loaded from trusted preload files."
-            code_name = instruction["code_name"]
-            args = instruction.get("args")
-            if not isinstance(args, list):
-                return "Error: Escape code args must be a list of objects with name fields."
-            arg_names = []
-            for arg in args:
-                if not isinstance(arg, dict) or not isinstance(arg.get("name"), str):
-                    return "Error: Escape code args must be a list of objects with name fields."
-                arg_names.append(arg["name"])
-            escape_codes[code_name] = {
-                "args": arg_names,
-                "func": self.compile_escape_code(
-                    code_name, arg_names, instruction["code"]
-                ),
-            }
-            return f"Stored escape code '{code_name}' with args {arg_names}."
+                return "Error: Tool definitions can only be loaded from trusted tool files."
+            tool = self.tools.register_definition(instruction)
+            return f"Stored tool '{tool.name}' with args {tool.args}."
         elif "exec" in instruction:
-            code_name = instruction["exec"]
+            tool_name = instruction["exec"]
             args = instruction.get("args", {})
             if not isinstance(args, dict):
-                return "Error: Escape code args must be an object."
-            if code_name in escape_codes:
-                escape_code = escape_codes[code_name]
-                missing_args = [
-                    arg_name
-                    for arg_name in escape_code["args"]
-                    if arg_name not in args
-                ]
-                if missing_args:
-                    return f"Error: Missing args for escape code '{code_name}': {missing_args}"
-                result = escape_code["func"](
-                    **args,
-                    employee_dict=self.employee_dict,
-                )
-                return f"Executed escape code '{code_name}' with args {args}. Result: {result}"
-
-            return f"Error: Escape code '{code_name}' not found."
-        return "Error: JSON instruction must include code_name or exec."
+                return "Error: Tool args must be an object."
+            return self.tools.execute(tool_name, args, self.employee_dict)
+        return "Error: JSON instruction must include a tool definition or exec."
 
     def interact(self, prompt, trusted=False):
         print(colored(f"\n---\n// {self.name}\n{prompt}\n---\n", "grey"))
@@ -210,7 +328,7 @@ class System(Role):
 class Ops(Role):
     def __init__(self, employee_dict):
         role_description = """You are OPs for an AI powered organization."""
-        group_template_additions = """You are part of the Operations group.Members of this group recognize when other organization members need escape codes executed and send the appropriate escape code. You can also request new code from the Software Engineer who will create escape codes. To execute code, you send a JSON blob on a new line. You will recognize when other organization members need escape codes executed and will send the appropriate escape code, the format is a JSON object: {"exec":"escape_code_name_here", "args":{"string_var":"string", "numeric_var":123}})"""
+        group_template_additions = """You are part of the Operations group. Members of this group oversee whether the agent environment is operating successfully. Tools are available to agents through a concise registry; to request a tool, send a JSON blob on a new line in the format: {"exec":"namespace.tool_name", "args":{"string_var":"string", "numeric_var":123}}."""
         super().__init__(
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
@@ -237,8 +355,8 @@ class Angel(Role):
 
 class SoftwareEngineer(Role):
     def __init__(self, employee_dict):
-        template = """As a Software Engineer (SE), you are responsible for designing, developing, and maintaining software applications. You primarily create escape codes when requested by others in your organization."""
-        group_template_additions = """You are part of the Engineering group. To create an escape code, on a newline write a JSON object with the fields: code_name, args, and code. The code_name is the name of the escape code, the args are a list of objects which name the parameter the code will receive, the code must be a valid python function that accepts the parameters. For example, to create an escape code that fetches a URL, you may post on a newline a JSON blob like {"code_name": "add_100", "args":[{"name":"value"}], "code":"return 100+value"}"""
+        template = """As a Software Engineer (SE), you are responsible for designing, developing, and maintaining software applications. You primarily propose trusted tools when requested by others in your organization."""
+        group_template_additions = """You are part of the Engineering group. Tools are trusted, repo-loaded functions described by namespaced OpenAI-compatible metadata. Propose tool behavior in plain language; do not assume untrusted chat output can define executable tools directly."""
         super().__init__(self.__class__.__name__, template, employee_dict, group_template_additions)
 
     def interact(self, sender, prompt):
@@ -254,7 +372,7 @@ class Human(Role):
         return input(f"{self.name}: ")
 
 
-def parse_escape_code(s):
+def parse_tool_instruction(s):
     decoder = json.JSONDecoder()
     for idx, char in enumerate(s):
         if char not in "{[":
@@ -267,16 +385,14 @@ def parse_escape_code(s):
     return None
 
 
-def preload(system, yaml_file_path=None):
-    yaml_file_path = yaml_file_path or Path(__file__).with_name("preload.yaml")
+def load_tools(system, yaml_file_path=None):
+    yaml_file_path = yaml_file_path or Path(__file__).with_name("tools.yaml")
     with open(yaml_file_path, 'r') as file:
         yaml_content = yaml.safe_load(file)
 
-    # Add escape codes for HR
     for obj in yaml_content:
         system_response = system.interact(json.dumps(obj), trusted=True)
         print(colored(f"System: {system_response}", "blue"))
-
 
 def build_employee_dict():
     employee_dict = {}
@@ -292,7 +408,7 @@ def build_employee_dict():
 def run_simulation(initial_message=None, max_turns=None):
     employee_dict = build_employee_dict()
     system = System(employee_dict)
-    preload(system)
+    load_tools(system)
     last_receiver = employee_dict["CEO"]
     receiver = last_receiver
     last_response = (
@@ -315,10 +431,10 @@ def run_simulation(initial_message=None, max_turns=None):
                     receiver = new_receiver
                     break
 
-        escape_code = parse_escape_code(last_response)
-        if escape_code is not None and escape_code != "":
+        tool_instruction = parse_tool_instruction(last_response)
+        if tool_instruction is not None and tool_instruction != "":
             try:
-                system_response = system.interact(escape_code)
+                system_response = system.interact(tool_instruction)
                 print(colored(f"System: {system_response}", "blue"))
                 if system_response is not None and system_response != "":
                     employee_dict["Ops"].update_group_conversations({"role": "system", "content": system_response})

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -208,10 +208,10 @@ class RuntimeTests(unittest.TestCase):
             main.load_tools(system)
 
         tools = main.tool_registry.as_responses_tools()
+        tool = next(tool for tool in tools if tool["name"] == "org__create_role")
 
-        self.assertEqual(tools[0]["type"], "function")
-        self.assertEqual(tools[0]["name"], "org__create_role")
-        self.assertEqual(tools[0]["parameters"]["required"], ["role_name", "role_description"])
+        self.assertEqual(tool["type"], "function")
+        self.assertEqual(tool["parameters"]["required"], ["role_name", "role_description"])
 
     def test_tool_registry_exposes_chat_completion_tool_metadata(self):
         system = main.System(main.build_employee_dict())
@@ -219,11 +219,13 @@ class RuntimeTests(unittest.TestCase):
             main.load_tools(system)
 
         tools = main.tool_registry.as_chat_completion_tools()
+        tool = next(
+            tool for tool in tools if tool["function"]["name"] == "org__create_role"
+        )
 
-        self.assertEqual(tools[0]["type"], "function")
-        self.assertEqual(tools[0]["function"]["name"], "org__create_role")
+        self.assertEqual(tool["type"], "function")
         self.assertEqual(
-            tools[0]["function"]["parameters"]["required"],
+            tool["function"]["parameters"]["required"],
             ["role_name", "role_description"],
         )
 
@@ -249,6 +251,62 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("Created a new role: QA", response)
         self.assertIn("QA", employee_dict)
 
+    def test_openai_tool_name_exec_resolves_tool(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+
+        with redirect_stdout(StringIO()):
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org__create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+            )
+
+        self.assertIn("Created a new role: QA", response)
+        self.assertIn("QA", employee_dict)
+
+    def test_optional_tool_property_can_be_supplied_or_omitted(self):
+        system = main.System(main.build_employee_dict())
+        with redirect_stdout(StringIO()):
+            response = system.interact(
+                json.dumps(
+                    {
+                        "name": "test.echo",
+                        "description": "Echo a required value with an optional suffix.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "value": {"type": "string"},
+                                "suffix": {"type": "string"},
+                            },
+                            "required": ["value"],
+                        },
+                        "code": "return value + (suffix or '')",
+                    }
+                ),
+                trusted=True,
+            )
+            omitted = system.interact(
+                json.dumps({"exec": "test.echo", "args": {"value": "a"}})
+            )
+            supplied = system.interact(
+                json.dumps(
+                    {"exec": "test.echo", "args": {"value": "a", "suffix": "b"}}
+                )
+            )
+
+        self.assertIn("Stored tool", response)
+        self.assertIn("Result: a", omitted)
+        self.assertIn("Result: ab", supplied)
+
     def test_duplicate_tool_name_is_rejected(self):
         system = main.System(main.build_employee_dict())
         with redirect_stdout(StringIO()):
@@ -272,6 +330,30 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("already exists", response)
         self.assertEqual(main.tool_registry.get("create_role").name, "org.create_role")
 
+    def test_invalid_tool_alias_is_rejected(self):
+        system = main.System(main.build_employee_dict())
+
+        with redirect_stdout(StringIO()):
+            response = system.interact(
+                json.dumps(
+                    {
+                        "name": "test.alias",
+                        "aliases": ["bad-alias"],
+                        "description": "Bad alias.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                        },
+                        "code": "return 'bad'",
+                    }
+                ),
+                trusted=True,
+            )
+
+        self.assertIn("Invalid tool name", response)
+        self.assertNotIn("test.alias", main.tool_registry)
+
     def test_invalid_qualified_exec_name_is_rejected(self):
         system = main.System(main.build_employee_dict())
 
@@ -286,6 +368,18 @@ class RuntimeTests(unittest.TestCase):
             )
 
         self.assertIn("Invalid tool name", response)
+
+    def test_load_tools_requires_list_file(self):
+        system = main.System(main.build_employee_dict())
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as handle:
+            handle.write("name: not-a-list\n")
+            path = handle.name
+
+        try:
+            with self.assertRaisesRegex(ValueError, "list of tool definitions"):
+                main.load_tools(system, path)
+        finally:
+            os.unlink(path)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -10,17 +10,17 @@ import main
 
 class RuntimeTests(unittest.TestCase):
     def setUp(self):
-        main.escape_codes.clear()
+        main.tool_registry.clear()
 
-    def test_parse_escape_code_handles_surrounding_text(self):
+    def test_parse_tool_instruction_handles_surrounding_text(self):
         response = 'Ops should run this:\n{"exec": "create_role", "args": {"role_name": "QA"}}\nDone.'
 
         self.assertEqual(
-            json.loads(main.parse_escape_code(response)),
+            json.loads(main.parse_tool_instruction(response)),
             {"exec": "create_role", "args": {"role_name": "QA"}},
         )
 
-    def test_parse_escape_code_handles_multiline_json(self):
+    def test_parse_tool_instruction_handles_multiline_json(self):
         response = """Please execute:
 {
   "exec": "create_role",
@@ -32,7 +32,7 @@ class RuntimeTests(unittest.TestCase):
 """
 
         self.assertEqual(
-            json.loads(main.parse_escape_code(response)),
+            json.loads(main.parse_tool_instruction(response)),
             {
                 "exec": "create_role",
                 "args": {
@@ -42,11 +42,11 @@ class RuntimeTests(unittest.TestCase):
             },
         )
 
-    def test_preloaded_create_role_executes_against_employee_dict(self):
+    def test_loaded_create_role_executes_against_employee_dict(self):
         employee_dict = main.build_employee_dict()
         system = main.System(employee_dict)
         with redirect_stdout(StringIO()):
-            main.preload(system)
+            main.load_tools(system)
 
         with redirect_stdout(StringIO()):
             response = system.interact(
@@ -69,7 +69,7 @@ class RuntimeTests(unittest.TestCase):
         employee_dict = main.build_employee_dict()
         system = main.System(employee_dict)
         with redirect_stdout(StringIO()):
-            main.preload(system)
+            main.load_tools(system)
 
         with redirect_stdout(StringIO()):
             response = system.interact(
@@ -89,11 +89,11 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("Created a new role: QA", response)
         self.assertIn("QA", employee_dict)
 
-    def test_escape_code_reports_missing_args(self):
+    def test_tool_reports_missing_args(self):
         employee_dict = main.build_employee_dict()
         system = main.System(employee_dict)
         with redirect_stdout(StringIO()):
-            main.preload(system)
+            main.load_tools(system)
 
         with redirect_stdout(StringIO()):
             response = system.interact(
@@ -110,7 +110,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("Missing args", response)
         self.assertNotIn("QA", employee_dict)
 
-    def test_escape_code_definition_validates_args_shape(self):
+    def test_tool_definition_validates_args_shape(self):
         system = main.System(main.build_employee_dict())
 
         with redirect_stdout(StringIO()):
@@ -126,12 +126,12 @@ class RuntimeTests(unittest.TestCase):
             )
 
         self.assertIn("args must be a list", response)
-        self.assertNotIn("bad_tool", main.escape_codes)
+        self.assertNotIn("bad_tool", main.tool_registry)
 
     def test_exec_instruction_validates_args_object(self):
         system = main.System(main.build_employee_dict())
         with redirect_stdout(StringIO()):
-            main.preload(system)
+            main.load_tools(system)
 
         with redirect_stdout(StringIO()):
             response = system.interact(
@@ -145,20 +145,20 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertIn("args must be an object", response)
 
-    def test_preload_default_path_is_relative_to_module(self):
+    def test_load_tools_default_path_is_relative_to_module(self):
         system = main.System(main.build_employee_dict())
         original_cwd = os.getcwd()
         with tempfile.TemporaryDirectory() as temp_dir:
             try:
                 os.chdir(temp_dir)
                 with redirect_stdout(StringIO()):
-                    main.preload(system)
+                    main.load_tools(system)
             finally:
                 os.chdir(original_cwd)
 
-        self.assertIn("create_role", main.escape_codes)
+        self.assertIn("org.create_role", main.tool_registry)
 
-    def test_untrusted_escape_code_definition_is_rejected(self):
+    def test_untrusted_tool_definition_is_rejected(self):
         system = main.System(main.build_employee_dict())
 
         with redirect_stdout(StringIO()):
@@ -172,10 +172,10 @@ class RuntimeTests(unittest.TestCase):
                 )
             )
 
-        self.assertIn("trusted preload", response)
-        self.assertNotIn("surprise", main.escape_codes)
+        self.assertIn("trusted tool", response)
+        self.assertNotIn("surprise", main.tool_registry)
 
-    def test_escape_code_builtins_are_restricted(self):
+    def test_tool_builtins_are_restricted(self):
         system = main.System(main.build_employee_dict())
         with redirect_stdout(StringIO()):
             response = system.interact(
@@ -189,7 +189,7 @@ class RuntimeTests(unittest.TestCase):
                 trusted=True,
             )
 
-        self.assertIn("Stored escape code", response)
+        self.assertIn("Stored tool", response)
         with redirect_stdout(StringIO()):
             response = system.interact(
                 json.dumps(
@@ -201,6 +201,91 @@ class RuntimeTests(unittest.TestCase):
             )
 
         self.assertIn("__import__", response)
+
+    def test_tool_registry_exposes_responses_tool_metadata(self):
+        system = main.System(main.build_employee_dict())
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+
+        tools = main.tool_registry.as_responses_tools()
+
+        self.assertEqual(tools[0]["type"], "function")
+        self.assertEqual(tools[0]["name"], "org__create_role")
+        self.assertEqual(tools[0]["parameters"]["required"], ["role_name", "role_description"])
+
+    def test_tool_registry_exposes_chat_completion_tool_metadata(self):
+        system = main.System(main.build_employee_dict())
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+
+        tools = main.tool_registry.as_chat_completion_tools()
+
+        self.assertEqual(tools[0]["type"], "function")
+        self.assertEqual(tools[0]["function"]["name"], "org__create_role")
+        self.assertEqual(
+            tools[0]["function"]["parameters"]["required"],
+            ["role_name", "role_description"],
+        )
+
+    def test_namespaced_exec_resolves_tool(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+
+        with redirect_stdout(StringIO()):
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+            )
+
+        self.assertIn("Created a new role: QA", response)
+        self.assertIn("QA", employee_dict)
+
+    def test_duplicate_tool_name_is_rejected(self):
+        system = main.System(main.build_employee_dict())
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "name": "org.create_role",
+                        "description": "Duplicate",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {},
+                            "required": [],
+                        },
+                        "code": "return 'duplicate'",
+                    }
+                ),
+                trusted=True,
+            )
+
+        self.assertIn("already exists", response)
+        self.assertEqual(main.tool_registry.get("create_role").name, "org.create_role")
+
+    def test_invalid_qualified_exec_name_is_rejected(self):
+        system = main.System(main.build_employee_dict())
+
+        with redirect_stdout(StringIO()):
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "bad-name.create_role",
+                        "args": {},
+                    }
+                )
+            )
+
+        self.assertIn("Invalid tool name", response)
 
 
 if __name__ == "__main__":

--- a/tools.yaml
+++ b/tools.yaml
@@ -1,7 +1,19 @@
-- code_name: create_role
-  args:
-    - name: role_name
-    - name: role_description
+- name: org.create_role
+  aliases:
+    - create_role
+  description: Create a new role in the organization.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: The name of the new role.
+      role_description:
+        type: string
+        description: The responsibilities and purpose of the new role.
+    required:
+      - role_name
+      - role_description
   code: |
     if role_name not in employee_dict:
         if len(employee_dict) < HR.max_organization_members:


### PR DESCRIPTION
## Summary
- replace the legacy preload path with a trusted, namespaced tool registry backed by `tools.yaml`
- expose tool metadata for OpenAI-compatible Responses function tools and chat-completions function tools, including reverse lookup for model-facing tool names
- update runtime docs, AGENTS guidance, and repo-local skills around trusted tools, operator scope, and future scheduling direction

## Validation
- `C:\Users\displ\Documents\robits\.venv\Scripts\python.exe -m unittest` (19 tests)
- `C:\Users\displ\Documents\robits\.venv\Scripts\python.exe -m py_compile main.py tests\test_runtime.py`
- `C:\Users\displ\Documents\robits\.venv\Scripts\python.exe -c "import yaml; yaml.safe_load(open('tools.yaml', encoding='utf-8')); print('tools yaml ok')"`
- `python C:\Users\displ\.codex\skills\.system\skill-creator\scripts\quick_validate.py .github\skills\robits-runtime`
- `git diff --check`
- bounded OpenAI-compatible local smoke run with `main.py --prompt "HR, say hello in one short sentence." --turns 1`

## Review Follow-up
- Addressed all 5 Copilot comments in 433f165 and replied on each thread.
- Resolved all 5 review threads after patching.

Acting as Codex GPT-5.5 on behalf of displague.

Closes #7