### PR TITLE
Add runtime sessions and deterministic scheduling

### DIFF
--- a/.github/skills/robits-runtime/SKILL.md
+++ b/.github/skills/robits-runtime/SKILL.md
@@ -13,7 +13,7 @@ description: Work on the Robits Python organization-simulation runtime, includin
 4. Keep trusted tool definition loading separate from untrusted model output.
 5. Prefer focused tests around parsing, tool loading, and execution before relying on a live model smoke test.
 6. For Responses API work, test function-call routing with fake response items before using a live endpoint.
-7. For scheduling work, prefer deterministic time-share behavior with injected or seeded schedulers before adding parallel execution.
+7. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
 
 ## Validation
 

--- a/.github/skills/robits-runtime/resources/runtime-architecture.md
+++ b/.github/skills/robits-runtime/resources/runtime-architecture.md
@@ -7,6 +7,8 @@
 - `System` loads trusted tools and executes them with the current `employee_dict`.
 - `tools.yaml` defines trusted tools such as `org.create_role`.
 - `parse_tool_instruction` extracts the first valid JSON object or array from a model response.
+- `Session` owns a run ID, participants, turn count, system tool handling, and transcript entries.
+- `RoundRobinScheduler` provides deterministic time-share recipient selection when a message is not directed.
 
 ## Current vs Target
 
@@ -15,12 +17,14 @@ Current runtime:
 - Roles call Chat Completions.
 - The runtime can still parse JSON tool instructions from assistant text for compatibility.
 - Trusted tool definitions are repo-owned and loaded from `tools.yaml`.
+- Runtime sessions record structured turn transcripts and enforce bounded turn counts.
+- Undirected recipient selection is deterministic round-robin scheduling; directed messages still take precedence.
 
 Target runtime:
 
 - Roles use OpenAI-compatible Responses-style interactions when available.
 - Approved tools are exposed as function tools with JSON Schema metadata.
 - The runtime handles zero or more function calls, executes trusted tools, returns tool outputs by call ID, and then asks the model for final text.
-- Speaker selection moves from random routing to deterministic time-share scheduling with turn budgets and later parallel execution where state coordination is explicit.
+- Parallel execution is added only after state coordination is explicit.
 
 Keep tests isolated from model services. Use live model checks only as smoke validation after deterministic tests pass.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ The organization has the following roles:
 
 ## How It Works 🛠️
 
-The simulation runs in a loop, where organization members communicate through messages. The runtime can parse JSON tool instructions, load trusted tools from `tools.yaml`, and execute registered tools by name. Tools use namespaced identifiers such as `org.create_role`, with short aliases only where compatibility is useful.
+The simulation runs in a session, where organization members communicate through messages. A session owns a run ID, participant list, turn count, transcript entries, and the system tool handler. Undirected messages use deterministic round-robin scheduling; directed messages such as `HR, ...` still route to the named role.
+
+The runtime can parse JSON tool instructions, load trusted tools from `tools.yaml`, and execute registered tools by name. Tools use namespaced identifiers such as `org.create_role`, with short aliases only where compatibility is useful.
 
 The target runtime direction is OpenAI-compatible tool calling through modern Responses-style loops: approved tools are exposed with JSON Schema metadata, the model may request function calls, the runtime executes those calls, and tool outputs are returned to the model without relying on ad hoc text parsing.
 
@@ -98,6 +100,6 @@ There are many exciting ways you can improve and expand this project. Here are a
 3. Implement a graphical user interface (GUI) for a more immersive and user-friendly simulation experience.
 4. Explore ways to use real-world data to drive the simulation and make it more engaging and relevant.
 5. Experiment with different AI models or techniques to improve the performance and capabilities of the AI roles.
-6. Replace random next-speaker selection with a time-share scheduler that can run roles in deterministic, budgeted turns and eventually in parallel where the runtime can safely coordinate state.
+6. Extend the deterministic time-share scheduler toward parallel role execution once shared state coordination is explicit.
 
 Have fun exploring the AI-Powered Organization Simulation! We can't wait to see what you come up with! 🎉💡

--- a/main.py
+++ b/main.py
@@ -487,6 +487,8 @@ class Session:
         return RoutedMessage(self.participants[receiver_name], message, False)
 
     def process_tool_instruction(self, message):
+        if not isinstance(message, str) or message == "":
+            return []
         tool_instruction = parse_tool_instruction(message)
         if tool_instruction is None or tool_instruction == "":
             return []
@@ -544,6 +546,8 @@ class Session:
             if initial_message is not None
             else self.last_receiver.interact()
         )
+        if last_response is None:
+            last_response = ""
 
         while effective_max_turns is None or self.turns_completed < effective_max_turns:
             last_response = self.step(last_response)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from openai import OpenAI
 
 import random
@@ -12,6 +12,7 @@ from datetime import datetime
 from termcolor import colored
 import argparse
 from pathlib import Path
+from uuid import uuid4
 
 
 def make_client():
@@ -418,6 +419,138 @@ def load_tools(system, yaml_file_path=None):
         system_response = system.interact(json.dumps(obj), trusted=True)
         print(colored(f"System: {system_response}", "blue"))
 
+
+@dataclass
+class TranscriptEntry:
+    turn: int
+    sender: str
+    receiver: str
+    prompt: str
+    response: str
+    directed: bool = False
+    system_events: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RoutedMessage:
+    receiver: object
+    prompt: str
+    directed: bool = False
+
+
+class RoundRobinScheduler:
+    def __init__(self, participant_names):
+        self.participant_names = list(participant_names)
+        if not self.participant_names:
+            raise ValueError("Scheduler requires at least one participant.")
+        self.index = 0
+
+    def next(self, last_receiver_name=None):
+        for _ in range(len(self.participant_names)):
+            name = self.participant_names[self.index % len(self.participant_names)]
+            self.index += 1
+            if len(self.participant_names) == 1 or name != last_receiver_name:
+                return name
+        return self.participant_names[(self.index - 1) % len(self.participant_names)]
+
+    def observe(self, participant_name):
+        if participant_name in self.participant_names:
+            self.index = self.participant_names.index(participant_name) + 1
+
+    def add_participant(self, participant_name):
+        if participant_name not in self.participant_names:
+            self.participant_names.append(participant_name)
+
+
+class Session:
+    def __init__(self, participants=None, system=None, scheduler=None, run_id=None, max_turns=None):
+        self.participants = participants if participants is not None else build_employee_dict()
+        self.system = system if system is not None else System(self.participants)
+        scheduler_names = list(self.participants)
+        self.scheduler = scheduler if scheduler is not None else RoundRobinScheduler(scheduler_names)
+        self.run_id = run_id or f"run-{uuid4()}"
+        self.max_turns = max_turns
+        self.transcript = []
+        self.turns_completed = 0
+        self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
+
+    def route_message(self, message, last_receiver_name=None):
+        prompt_split = message.split(",", 1) if isinstance(message, str) else []
+        if len(prompt_split) > 1:
+            receiver_name = prompt_split[0].strip()
+            if receiver_name in self.participants:
+                print(colored(f"// Directed to {receiver_name}", "grey"))
+                self.scheduler.observe(receiver_name)
+                return RoutedMessage(self.participants[receiver_name], prompt_split[1].strip(), True)
+
+        receiver_name = self.scheduler.next(last_receiver_name)
+        return RoutedMessage(self.participants[receiver_name], message, False)
+
+    def process_tool_instruction(self, message):
+        tool_instruction = parse_tool_instruction(message)
+        if tool_instruction is None or tool_instruction == "":
+            return []
+
+        system_response = self.system.interact(tool_instruction)
+        print(colored(f"System: {system_response}", "blue"))
+        if system_response is not None and system_response != "" and "Ops" in self.participants:
+            ops = self.participants["Ops"]
+            if hasattr(ops, "update_group_conversations"):
+                ops.update_group_conversations({"role": "system", "content": system_response})
+        return [system_response]
+
+    def record_turn(self, sender, receiver, prompt, response, directed=False, system_events=None):
+        entry = TranscriptEntry(
+            turn=self.turns_completed + 1,
+            sender=sender,
+            receiver=receiver,
+            prompt=prompt,
+            response=response,
+            directed=directed,
+            system_events=system_events or [],
+        )
+        self.transcript.append(entry)
+        self.turns_completed += 1
+        return entry
+
+    def sync_scheduler_participants(self):
+        for name in self.participants:
+            self.scheduler.add_participant(name)
+
+    def step(self, message):
+        sender = self.last_receiver
+        routed = self.route_message(message, sender.name)
+        system_events = self.process_tool_instruction(message)
+        self.sync_scheduler_participants()
+        response = routed.receiver.interact(sender.name, routed.prompt)
+        response = "" if response is None else response
+        if routed.receiver.name != "CEO" and response != "":
+            print(colored(f"{routed.receiver.name} responds: {response}", "cyan"))
+        self.record_turn(
+            sender=sender.name,
+            receiver=routed.receiver.name,
+            prompt=routed.prompt,
+            response=response,
+            directed=routed.directed,
+            system_events=system_events,
+        )
+        self.last_receiver = routed.receiver
+        return response
+
+    def run(self, initial_message=None, max_turns=None):
+        effective_max_turns = self.max_turns if max_turns is None else max_turns
+        last_response = (
+            initial_message
+            if initial_message is not None
+            else self.last_receiver.interact()
+        )
+
+        while effective_max_turns is None or self.turns_completed < effective_max_turns:
+            last_response = self.step(last_response)
+
+        return self
+
+
 def build_employee_dict():
     employee_dict = {}
 
@@ -430,53 +563,9 @@ def build_employee_dict():
 
 
 def run_simulation(initial_message=None, max_turns=None):
-    employee_dict = build_employee_dict()
-    system = System(employee_dict)
-    load_tools(system)
-    last_receiver = employee_dict["CEO"]
-    receiver = last_receiver
-    last_response = (
-        initial_message
-        if initial_message is not None
-        else receiver.interact()
-    )
-    turns = 0
-
-    while max_turns is None or turns < max_turns:
-        prompt_split = last_response.split(",", 1)
-        if len(prompt_split) > 1 and prompt_split[0] in employee_dict:
-            print(colored(f"// Directed to {prompt_split[0]}", "grey"))
-            receiver = employee_dict[prompt_split[0].strip()]
-            last_response = prompt_split[1].strip()
-        else:
-            while True:
-                new_receiver = employee_dict[random.choice(list(employee_dict))]
-                if new_receiver != last_receiver:
-                    receiver = new_receiver
-                    break
-
-        tool_instruction = parse_tool_instruction(last_response)
-        if tool_instruction is not None and tool_instruction != "":
-            try:
-                system_response = system.interact(tool_instruction)
-                print(colored(f"System: {system_response}", "blue"))
-                if system_response is not None and system_response != "":
-                    employee_dict["Ops"].update_group_conversations({"role": "system", "content": system_response})
-
-            except json.JSONDecodeError:
-                # Return the original response if the JSON blob cannot be processed
-                if system_response.startswith("Error:"):
-                    print(colored(f"System responds: {system_response}", "red"))
-                    continue
-
-        response = receiver.interact(last_receiver.name, last_response)
-        if response is None or response == "":
-            continue
-        if receiver.name != "CEO":
-            print(colored(f"{receiver.name} responds: {response}", "cyan"))
-        last_response = response
-        last_receiver = receiver
-        turns += 1
+    session = Session()
+    load_tools(session.system)
+    return session.run(initial_message=initial_message, max_turns=max_turns)
 
 
 def parse_args(argv=None):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -8,6 +8,33 @@ from io import StringIO
 import main
 
 
+class FakeRole:
+    def __init__(self, name, responses=None):
+        self.name = name
+        self.responses = list(responses or [])
+        self.received = []
+        self.group_conversation_history = {}
+
+    def interact(self, sender=None, prompt=None):
+        self.received.append((sender, prompt))
+        if self.responses:
+            return self.responses.pop(0)
+        return ""
+
+    def update_group_conversations(self, message):
+        self.group_conversation_history.setdefault(self.name, []).append(message)
+
+
+def build_fake_participants():
+    return {
+        "CEO": FakeRole("CEO", ["initial"]),
+        "Ops": FakeRole("Ops", ["SE, handoff"]),
+        "SE": FakeRole("SE", ["HR, handoff"]),
+        "HR": FakeRole("HR", ["Samandriel, handoff"]),
+        "Samandriel": FakeRole("Samandriel", ["CEO, done"]),
+    }
+
+
 class RuntimeTests(unittest.TestCase):
     def setUp(self):
         main.tool_registry.clear()
@@ -380,6 +407,123 @@ class RuntimeTests(unittest.TestCase):
                 main.load_tools(system, path)
         finally:
             os.unlink(path)
+
+    def test_session_creation_records_run_id_participants_and_transcript(self):
+        participants = build_fake_participants()
+        session = main.Session(participants=participants, run_id="session-1", max_turns=3)
+
+        self.assertEqual(session.run_id, "session-1")
+        self.assertIs(session.participants, participants)
+        self.assertEqual(session.max_turns, 3)
+        self.assertEqual(session.turns_completed, 0)
+        self.assertEqual(session.transcript, [])
+
+    def test_round_robin_scheduler_skips_last_receiver(self):
+        scheduler = main.RoundRobinScheduler(["CEO", "Ops", "SE"])
+
+        self.assertEqual(scheduler.next("CEO"), "Ops")
+        self.assertEqual(scheduler.next("Ops"), "SE")
+        self.assertEqual(scheduler.next("SE"), "CEO")
+        self.assertEqual(scheduler.next("CEO"), "Ops")
+
+    def test_directed_message_routes_to_named_recipient_and_strips_prefix(self):
+        session = main.Session(participants=build_fake_participants(), run_id="session-1")
+
+        with redirect_stdout(StringIO()):
+            routed = session.route_message(" HR , please handle this", "CEO")
+
+        self.assertTrue(routed.directed)
+        self.assertEqual(routed.receiver.name, "HR")
+        self.assertEqual(routed.prompt, "please handle this")
+
+    def test_unknown_directed_prefix_falls_back_to_scheduler(self):
+        session = main.Session(participants=build_fake_participants(), run_id="session-1")
+
+        with redirect_stdout(StringIO()):
+            routed = session.route_message("Finance, please handle this", "CEO")
+
+        self.assertFalse(routed.directed)
+        self.assertEqual(routed.receiver.name, "Ops")
+        self.assertEqual(routed.prompt, "Finance, please handle this")
+
+    def test_directed_message_advances_scheduler_after_recipient(self):
+        session = main.Session(participants=build_fake_participants(), run_id="session-1")
+
+        with redirect_stdout(StringIO()):
+            routed = session.route_message("HR, please handle this", "CEO")
+            next_routed = session.route_message("continue", "HR")
+
+        self.assertEqual(routed.receiver.name, "HR")
+        self.assertEqual(next_routed.receiver.name, "Samandriel")
+
+    def test_session_stops_at_configured_turn_limit_without_model_calls(self):
+        participants = build_fake_participants()
+        session = main.Session(participants=participants, run_id="session-1", max_turns=1)
+        with redirect_stdout(StringIO()):
+            result = session.run(initial_message="hello")
+
+        self.assertIs(result, session)
+        self.assertEqual(session.turns_completed, 1)
+        self.assertEqual(len(session.transcript), 1)
+        self.assertEqual(participants["Ops"].received, [("CEO", "hello")])
+        self.assertEqual(participants["SE"].received, [])
+
+    def test_run_turn_limit_overrides_session_default(self):
+        participants = build_fake_participants()
+        session = main.Session(participants=participants, run_id="session-1", max_turns=3)
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="hello", max_turns=1)
+
+        self.assertEqual(session.turns_completed, 1)
+
+    def test_session_records_directed_transcript_entries(self):
+        participants = build_fake_participants()
+        session = main.Session(participants=participants, run_id="session-1")
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="HR, status please", max_turns=1)
+
+        entry = session.transcript[0]
+
+        self.assertEqual(entry.turn, 1)
+        self.assertEqual(entry.sender, "CEO")
+        self.assertEqual(entry.receiver, "HR")
+        self.assertEqual(entry.prompt, "status please")
+        self.assertEqual(entry.response, "Samandriel, handoff")
+        self.assertTrue(entry.directed)
+
+    def test_empty_model_response_consumes_bounded_turn(self):
+        participants = build_fake_participants()
+        participants["Ops"] = FakeRole("Ops", [None])
+        session = main.Session(participants=participants, run_id="session-1")
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="hello", max_turns=1)
+
+        self.assertEqual(session.turns_completed, 1)
+        self.assertEqual(session.transcript[0].response, "")
+
+    def test_tool_execution_records_system_event_and_updates_scheduler(self):
+        participants = build_fake_participants()
+        participants["Ops"] = FakeRole("Ops", ["done"])
+        system = main.System(participants)
+        session = main.Session(participants=participants, system=system, run_id="session-1")
+        payload = json.dumps(
+            {
+                "exec": "org.create_role",
+                "args": {
+                    "role_name": "QA",
+                    "role_description": "Tests the organization",
+                },
+            }
+        )
+
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            session.run(initial_message=payload, max_turns=1)
+
+        self.assertIn("QA", participants)
+        self.assertIn("QA", session.scheduler.participant_names)
+        self.assertEqual(len(session.transcript[0].system_events), 1)
+        self.assertIn("Created a new role: QA", session.transcript[0].system_events[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -501,6 +501,22 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(session.turns_completed, 1)
         self.assertEqual(session.transcript[0].response, "")
 
+    def test_none_initial_response_is_normalized_for_session_step(self):
+        participants = build_fake_participants()
+        participants["CEO"] = FakeRole("CEO", [None])
+        session = main.Session(participants=participants, run_id="session-1")
+        with redirect_stdout(StringIO()):
+            session.run(max_turns=1)
+
+        self.assertEqual(session.turns_completed, 1)
+        self.assertEqual(session.transcript[0].prompt, "")
+
+    def test_non_string_message_does_not_parse_tool_instruction(self):
+        session = main.Session(participants=build_fake_participants(), run_id="session-1")
+
+        self.assertEqual(session.process_tool_instruction(None), [])
+        self.assertEqual(session.process_tool_instruction({"exec": "org.create_role"}), [])
+
     def test_tool_execution_records_system_event_and_updates_scheduler(self):
         participants = build_fake_participants()
         participants["Ops"] = FakeRole("Ops", ["done"])


### PR DESCRIPTION
## Summary
- add a `Session` runtime object with run IDs, participant ownership, bounded turn counts, and structured transcript entries
- replace random fallback recipient selection with deterministic round-robin time-share scheduling while preserving directed messages such as `HR, ...`
- record tool execution results in session transcript entries and sync newly created roles into the scheduler
- update README and repo-local runtime skill docs to reflect sessions and deterministic scheduling

## Validation
- `C:\Users\displ\Documents\robits\.venv\Scripts\python.exe -m unittest` (31 tests)
- `C:\Users\displ\Documents\robits\.venv\Scripts\python.exe -m py_compile main.py tests\test_runtime.py`
- `C:\Users\displ\Documents\robits\.venv\Scripts\python.exe -c "import yaml; yaml.safe_load(open(''tools.yaml'', encoding=''utf-8'')); print(''tools yaml ok'')"`
- `python C:\Users\displ\.codex\skills\.system\skill-creator\scripts\quick_validate.py .github\skills\robits-runtime`
- `git diff --check`
- bounded OpenAI-compatible local smoke run with `main.py --prompt "HR, say hello in one short sentence." --turns 1`

## Review Follow-up
- Addressed both Copilot comments in 43b5f7c and replied on each thread.
- Resolved both review threads after patching.

Acting as Codex GPT-5.5 on behalf of displague.

Closes #8
Closes #13