### PR TITLE
Add SQLite memory substrate

### DIFF
--- a/.github/skills/robits-memory/SKILL.md
+++ b/.github/skills/robits-memory/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: robits-memory
+description: Work on the Robits SQLite memory substrate, including sessions, agents, contacts, messages, thoughts, todos, tool calls, memory entries, FTS search, retrieval filters, memory digests, and tests that use temporary databases.
+---
+
+# Robits Memory
+
+## Process
+
+1. Inspect `robits/memory/sqlite.py`, `tests/test_memory_store.py`, and `docs/architecture-vision.md` before changing memory behavior.
+2. Keep the memory layer local-first and deterministic. Unit tests must use temporary SQLite databases and must not require model services.
+3. Keep raw records durable. Memory digests can summarize context, but they must preserve source links so records can be retrieved or reanalyzed later.
+4. Prefer repository APIs over direct SQL in runtime code.
+5. Preserve filters for agent, session, relationship type, conversation type, source, and date windows when adding search or prompt assembly behavior.
+6. Keep generated database files out of git.
+
+## Validation
+
+- Run `python -m unittest` after memory changes.
+- Run the repo-local skill validator after changing this skill.
+
+## References
+
+- Read `resources/sqlite-memory-schema.md` for the current schema and API boundaries.
+- Use `assets/search-filter-example.json` as a compact example of memory search filters.

--- a/.github/skills/robits-memory/assets/search-filter-example.json
+++ b/.github/skills/robits-memory/assets/search-filter-example.json
@@ -1,0 +1,10 @@
+{
+  "query": "sqlite recall",
+  "agent_id": "SE",
+  "session_id": "session-1",
+  "relationship_type": "coworker",
+  "conversation_type": "work",
+  "source": "thinking",
+  "start_at": "2026-05-07T00:00:00+00:00",
+  "end_at": "2026-05-07T23:59:59+00:00"
+}

--- a/.github/skills/robits-memory/resources/sqlite-memory-schema.md
+++ b/.github/skills/robits-memory/resources/sqlite-memory-schema.md
@@ -1,0 +1,36 @@
+# SQLite Memory Schema
+
+The memory store lives in `robits/memory/sqlite.py`.
+
+Core tables:
+
+- `sessions`: run metadata and timestamps.
+- `agents`: durable agent identity, role, display name, and lifecycle state.
+- `contacts`: per-agent relationship records such as coworker, family, therapy, or personal project.
+- `messages`: public or policy-visible conversation entries.
+- `thoughts`: private inner-monologue records.
+- `todos`: agent-owned commitments and side-project tasks.
+- `tool_calls`: requested or completed tool calls, including result content.
+- `memory_entries`: general memory records and future memory digests with source links.
+- `memory_fts`: FTS5 index over message, thought, tool-result, and memory-entry content.
+
+Repository API:
+
+- `create_session`
+- `upsert_agent`
+- `add_contact`
+- `append_message`
+- `append_thought`
+- `append_todo`
+- `append_tool_call`
+- `append_memory_entry`
+- `list_messages`
+- `list_agent_records`
+- `search`
+
+Search supports filters for agent, session, relationship type, conversation type,
+source, and date windows. Keep these filters available when adding prompt
+assembly or memory-digest retrieval.
+
+Generated local databases should live under `data/` or `var/` by default, both
+of which are ignored by git.

--- a/.github/skills/robits-memory/resources/sqlite-memory-schema.md
+++ b/.github/skills/robits-memory/resources/sqlite-memory-schema.md
@@ -24,6 +24,7 @@ Repository API:
 - `append_todo`
 - `append_tool_call`
 - `append_memory_entry`
+- `list_todos`
 - `list_messages`
 - `list_agent_records`
 - `search`

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 .venv/
 __pycache__/
 .pytest_cache/
+*.sqlite
+*.sqlite3
+*.db
+data/
+var/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,3 +20,4 @@ This repository is a Python experiment for simulating AI organization roles. Kee
 ## Repo-Local Skills
 
 Repo-local AI skills live in `.github/skills/`. Start with `.github/skills/robits-runtime/SKILL.md` when changing role orchestration, trusted tool execution, JSON extraction, scheduling, or model endpoint configuration.
+Use `.github/skills/robits-memory/SKILL.md` when changing SQLite memory storage, FTS search, memory records, thoughts, todos, tool calls, or memory digests.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ The target runtime direction is OpenAI-compatible tool calling through modern Re
 
 See `docs/architecture-vision.md` for the staged runtime plan covering sessions, tools, SQLite-backed memory, memory digests, lifecycle, observability, TUI inspection, and local-model constraints.
 
+## Memory
+
+Robits includes a local SQLite memory substrate in `robits/memory/sqlite.py`.
+It defines durable tables for sessions, agents, contacts, messages, thoughts,
+todos, tool calls, and memory entries. FTS search indexes message, thought,
+tool-result, and memory-entry content with filters for agent, session,
+relationship type, conversation type, source, and date windows.
+
+Generated local database files are ignored by git. Unit tests use temporary
+SQLite databases. Local runs should place generated databases under `data/` or
+`var/` unless the runtime is configured with another gitignored path.
+
 ## Installation
 
 To install the required packages for this project, run:

--- a/robits/__init__.py
+++ b/robits/__init__.py
@@ -1,0 +1,1 @@
+"""Robits runtime package."""

--- a/robits/memory/__init__.py
+++ b/robits/memory/__init__.py
@@ -1,0 +1,5 @@
+"""SQLite-backed memory storage for Robits."""
+
+from .sqlite import MemorySearchResult, SQLiteMemoryStore
+
+__all__ = ["MemorySearchResult", "SQLiteMemoryStore"]

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _json_dumps(value):
+    return json.dumps(value or {}, sort_keys=True)
+
+
+@dataclass(frozen=True)
+class MemorySearchResult:
+    kind: str
+    record_id: str
+    content: str
+    agent_id: str | None
+    session_id: str | None
+    source: str | None
+    relationship_type: str | None
+    conversation_type: str | None
+    created_at: str
+
+
+class SQLiteMemoryStore:
+    """Small repository API for durable local Robits memory records."""
+
+    def __init__(self, path):
+        self.path = Path(path)
+        if self.path != Path(":memory:"):
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.connection = sqlite3.connect(str(self.path))
+        self.connection.row_factory = sqlite3.Row
+        self.connection.execute("PRAGMA foreign_keys = ON")
+        self.ensure_schema()
+
+    def close(self):
+        self.connection.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    def ensure_schema(self):
+        self.connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                title TEXT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+
+            CREATE TABLE IF NOT EXISTS agents (
+                agent_id TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                display_name TEXT,
+                lifecycle_state TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+
+            CREATE TABLE IF NOT EXISTS contacts (
+                owner_agent_id TEXT NOT NULL,
+                contact_agent_id TEXT NOT NULL,
+                relationship_type TEXT NOT NULL,
+                notes TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                PRIMARY KEY (owner_agent_id, contact_agent_id),
+                FOREIGN KEY (owner_agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (contact_agent_id) REFERENCES agents(agent_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS messages (
+                message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                sender_agent_id TEXT NOT NULL,
+                receiver_agent_id TEXT,
+                content TEXT NOT NULL,
+                kind TEXT NOT NULL DEFAULT 'message',
+                visibility TEXT NOT NULL DEFAULT 'public',
+                relationship_type TEXT,
+                conversation_type TEXT,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id),
+                FOREIGN KEY (sender_agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (receiver_agent_id) REFERENCES agents(agent_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS thoughts (
+                thought_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT,
+                agent_id TEXT NOT NULL,
+                content TEXT NOT NULL,
+                visibility TEXT NOT NULL DEFAULT 'private',
+                relationship_type TEXT,
+                conversation_type TEXT,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id),
+                FOREIGN KEY (agent_id) REFERENCES agents(agent_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS todos (
+                todo_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT NOT NULL,
+                session_id TEXT,
+                title TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
+                content TEXT,
+                due_at TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                FOREIGN KEY (agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS tool_calls (
+                tool_call_id TEXT PRIMARY KEY,
+                session_id TEXT,
+                agent_id TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                arguments_json TEXT NOT NULL DEFAULT '{}',
+                result_content TEXT,
+                status TEXT NOT NULL DEFAULT 'requested',
+                relationship_type TEXT,
+                conversation_type TEXT,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id),
+                FOREIGN KEY (agent_id) REFERENCES agents(agent_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS memory_entries (
+                memory_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT,
+                session_id TEXT,
+                source_table TEXT,
+                source_id TEXT,
+                kind TEXT NOT NULL,
+                content TEXT NOT NULL,
+                relationship_type TEXT,
+                conversation_type TEXT,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                FOREIGN KEY (agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+            );
+
+            CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+                kind UNINDEXED,
+                record_id UNINDEXED,
+                agent_id UNINDEXED,
+                related_agent_id UNINDEXED,
+                session_id UNINDEXED,
+                source UNINDEXED,
+                relationship_type UNINDEXED,
+                conversation_type UNINDEXED,
+                created_at UNINDEXED,
+                content
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id);
+            CREATE INDEX IF NOT EXISTS idx_messages_sender ON messages(sender_agent_id);
+            CREATE INDEX IF NOT EXISTS idx_messages_receiver ON messages(receiver_agent_id);
+            CREATE INDEX IF NOT EXISTS idx_thoughts_agent ON thoughts(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_tool_calls_agent ON tool_calls(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_memory_entries_agent ON memory_entries(agent_id);
+            """
+        )
+        self.connection.commit()
+
+    def create_session(self, session_id, title=None, started_at=None, metadata=None):
+        created_at = started_at or _utc_now()
+        self.connection.execute(
+            """
+            INSERT OR IGNORE INTO sessions(session_id, title, started_at, metadata_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            (session_id, title, created_at, _json_dumps(metadata)),
+        )
+        self.connection.commit()
+        return session_id
+
+    def upsert_agent(
+        self,
+        agent_id,
+        role,
+        display_name=None,
+        lifecycle_state="active",
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        self.connection.execute(
+            """
+            INSERT INTO agents(
+                agent_id, role, display_name, lifecycle_state, created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                role = excluded.role,
+                display_name = excluded.display_name,
+                lifecycle_state = excluded.lifecycle_state,
+                metadata_json = excluded.metadata_json
+            """,
+            (
+                agent_id,
+                role,
+                display_name,
+                lifecycle_state,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        self.connection.commit()
+        return agent_id
+
+    def add_contact(
+        self,
+        owner_agent_id,
+        contact_agent_id,
+        relationship_type,
+        notes=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        self.connection.execute(
+            """
+            INSERT INTO contacts(
+                owner_agent_id, contact_agent_id, relationship_type, notes,
+                created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(owner_agent_id, contact_agent_id) DO UPDATE SET
+                relationship_type = excluded.relationship_type,
+                notes = excluded.notes,
+                metadata_json = excluded.metadata_json
+            """,
+            (
+                owner_agent_id,
+                contact_agent_id,
+                relationship_type,
+                notes,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        self.connection.commit()
+
+    def append_message(
+        self,
+        session_id,
+        sender_agent_id,
+        receiver_agent_id,
+        content,
+        kind="message",
+        visibility="public",
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO messages(
+                session_id, sender_agent_id, receiver_agent_id, content, kind,
+                visibility, relationship_type, conversation_type, source,
+                created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                sender_agent_id,
+                receiver_agent_id,
+                content,
+                kind,
+                visibility,
+                relationship_type,
+                conversation_type,
+                source,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        record_id = cursor.lastrowid
+        self._index(
+            "message",
+            record_id,
+            sender_agent_id,
+            receiver_agent_id,
+            session_id,
+            source,
+            relationship_type,
+            conversation_type,
+            timestamp,
+            content,
+        )
+        self.connection.commit()
+        return record_id
+
+    def append_thought(
+        self,
+        agent_id,
+        content,
+        session_id=None,
+        visibility="private",
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO thoughts(
+                session_id, agent_id, content, visibility, relationship_type,
+                conversation_type, source, created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                agent_id,
+                content,
+                visibility,
+                relationship_type,
+                conversation_type,
+                source,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        record_id = cursor.lastrowid
+        self._index(
+            "thought",
+            record_id,
+            agent_id,
+            None,
+            session_id,
+            source,
+            relationship_type,
+            conversation_type,
+            timestamp,
+            content,
+        )
+        self.connection.commit()
+        return record_id
+
+    def append_todo(
+        self,
+        agent_id,
+        title,
+        session_id=None,
+        status="open",
+        content=None,
+        due_at=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO todos(
+                agent_id, session_id, title, status, content, due_at,
+                created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                agent_id,
+                session_id,
+                title,
+                status,
+                content,
+                due_at,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        self.connection.commit()
+        return cursor.lastrowid
+
+    def append_tool_call(
+        self,
+        tool_call_id,
+        agent_id,
+        tool_name,
+        arguments=None,
+        result_content=None,
+        status="requested",
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        self.connection.execute(
+            """
+            INSERT INTO tool_calls(
+                tool_call_id, session_id, agent_id, tool_name, arguments_json,
+                result_content, status, relationship_type, conversation_type,
+                source, created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                tool_call_id,
+                session_id,
+                agent_id,
+                tool_name,
+                _json_dumps(arguments),
+                result_content,
+                status,
+                relationship_type,
+                conversation_type,
+                source,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        if result_content:
+            self._index(
+                "tool_call",
+                tool_call_id,
+                agent_id,
+                None,
+                session_id,
+                source,
+                relationship_type,
+                conversation_type,
+                timestamp,
+                result_content,
+            )
+        self.connection.commit()
+        return tool_call_id
+
+    def append_memory_entry(
+        self,
+        kind,
+        content,
+        agent_id=None,
+        session_id=None,
+        source_table=None,
+        source_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO memory_entries(
+                agent_id, session_id, source_table, source_id, kind, content,
+                relationship_type, conversation_type, source, created_at,
+                metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                agent_id,
+                session_id,
+                source_table,
+                None if source_id is None else str(source_id),
+                kind,
+                content,
+                relationship_type,
+                conversation_type,
+                source,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        record_id = cursor.lastrowid
+        self._index(
+            kind,
+            record_id,
+            agent_id,
+            None,
+            session_id,
+            source,
+            relationship_type,
+            conversation_type,
+            timestamp,
+            content,
+        )
+        self.connection.commit()
+        return record_id
+
+    def list_messages(self, session_id=None, agent_id=None, limit=100):
+        clauses = []
+        params: list[Any] = []
+        if session_id is not None:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if agent_id is not None:
+            clauses.append("(sender_agent_id = ? OR receiver_agent_id = ?)")
+            params.extend([agent_id, agent_id])
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return self._rows(
+            f"""
+            SELECT * FROM messages
+            {where}
+            ORDER BY created_at, message_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )
+
+    def list_agent_records(self, agent_id, limit=100):
+        records = []
+        records.extend(
+            self._rows(
+                """
+                SELECT 'message' AS record_type, message_id AS record_id, content,
+                       session_id, sender_agent_id AS agent_id, created_at
+                FROM messages
+                WHERE sender_agent_id = ? OR receiver_agent_id = ?
+                ORDER BY created_at, message_id
+                LIMIT ?
+                """,
+                (agent_id, agent_id, limit),
+            )
+        )
+        records.extend(
+            self._rows(
+                """
+                SELECT 'thought' AS record_type, thought_id AS record_id, content,
+                       session_id, agent_id, created_at
+                FROM thoughts
+                WHERE agent_id = ?
+                ORDER BY created_at, thought_id
+                LIMIT ?
+                """,
+                (agent_id, limit),
+            )
+        )
+        records.extend(
+            self._rows(
+                """
+                SELECT 'tool_call' AS record_type, tool_call_id AS record_id,
+                       result_content AS content, session_id, agent_id, created_at
+                FROM tool_calls
+                WHERE agent_id = ?
+                ORDER BY created_at, tool_call_id
+                LIMIT ?
+                """,
+                (agent_id, limit),
+            )
+        )
+        return sorted(records, key=lambda row: row["created_at"])[:limit]
+
+    def search(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ):
+        clauses = ["memory_fts MATCH ?"]
+        params: list[Any] = [query]
+        for column, value in (
+            ("session_id", session_id),
+            ("relationship_type", relationship_type),
+            ("conversation_type", conversation_type),
+            ("source", source),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        if agent_id is not None:
+            clauses.append("(agent_id = ? OR related_agent_id = ?)")
+            params.extend([agent_id, agent_id])
+        if start_at is not None:
+            clauses.append("created_at >= ?")
+            params.append(start_at)
+        if end_at is not None:
+            clauses.append("created_at <= ?")
+            params.append(end_at)
+        rows = self.connection.execute(
+            f"""
+            SELECT kind, record_id, agent_id, session_id, source,
+                   relationship_type, conversation_type, created_at, content
+            FROM memory_fts
+            WHERE {" AND ".join(clauses)}
+            ORDER BY bm25(memory_fts)
+            LIMIT ?
+            """,
+            params + [limit],
+        ).fetchall()
+        return [MemorySearchResult(**dict(row)) for row in rows]
+
+    def _index(
+        self,
+        kind,
+        record_id,
+        agent_id,
+        related_agent_id,
+        session_id,
+        source,
+        relationship_type,
+        conversation_type,
+        created_at,
+        content,
+    ):
+        self.connection.execute(
+            """
+            INSERT INTO memory_fts(
+                kind, record_id, agent_id, related_agent_id, session_id, source,
+                relationship_type, conversation_type, created_at, content
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                kind,
+                str(record_id),
+                agent_id,
+                related_agent_id,
+                session_id,
+                source,
+                relationship_type,
+                conversation_type,
+                created_at,
+                content,
+            ),
+        )
+
+    def _rows(self, query, params=()):
+        return [dict(row) for row in self.connection.execute(query, params).fetchall()]

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -13,7 +13,7 @@ def _utc_now():
 
 
 def _json_dumps(value):
-    return json.dumps(value or {}, sort_keys=True)
+    return json.dumps({} if value is None else value, sort_keys=True)
 
 
 @dataclass(frozen=True)
@@ -426,6 +426,17 @@ class SQLiteMemoryStore:
                 source, created_at, metadata_json
             )
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(tool_call_id) DO UPDATE SET
+                session_id = excluded.session_id,
+                agent_id = excluded.agent_id,
+                tool_name = excluded.tool_name,
+                arguments_json = excluded.arguments_json,
+                result_content = COALESCE(excluded.result_content, tool_calls.result_content),
+                status = excluded.status,
+                relationship_type = excluded.relationship_type,
+                conversation_type = excluded.conversation_type,
+                source = excluded.source,
+                metadata_json = excluded.metadata_json
             """,
             (
                 tool_call_id,
@@ -443,6 +454,7 @@ class SQLiteMemoryStore:
             ),
         )
         if result_content:
+            self._delete_index("tool_call", tool_call_id)
             self._index(
                 "tool_call",
                 tool_call_id,
@@ -457,6 +469,28 @@ class SQLiteMemoryStore:
             )
         self.connection.commit()
         return tool_call_id
+
+    def list_todos(self, agent_id=None, session_id=None, status=None, limit=100):
+        clauses = []
+        params: list[Any] = []
+        for column, value in (
+            ("agent_id", agent_id),
+            ("session_id", session_id),
+            ("status", status),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return self._rows(
+            f"""
+            SELECT * FROM todos
+            {where}
+            ORDER BY created_at, todo_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )
 
     def append_memory_entry(
         self,
@@ -538,20 +572,22 @@ class SQLiteMemoryStore:
             self._rows(
                 """
                 SELECT 'message' AS record_type, message_id AS record_id, content,
-                       session_id, sender_agent_id AS agent_id, created_at
+                       session_id, ? AS agent_id, sender_agent_id,
+                       receiver_agent_id, created_at
                 FROM messages
                 WHERE sender_agent_id = ? OR receiver_agent_id = ?
                 ORDER BY created_at, message_id
                 LIMIT ?
                 """,
-                (agent_id, agent_id, limit),
+                (agent_id, agent_id, agent_id, limit),
             )
         )
         records.extend(
             self._rows(
                 """
                 SELECT 'thought' AS record_type, thought_id AS record_id, content,
-                       session_id, agent_id, created_at
+                       session_id, agent_id, NULL AS sender_agent_id,
+                       NULL AS receiver_agent_id, created_at
                 FROM thoughts
                 WHERE agent_id = ?
                 ORDER BY created_at, thought_id
@@ -564,7 +600,9 @@ class SQLiteMemoryStore:
             self._rows(
                 """
                 SELECT 'tool_call' AS record_type, tool_call_id AS record_id,
-                       result_content AS content, session_id, agent_id, created_at
+                       result_content AS content, session_id, agent_id,
+                       NULL AS sender_agent_id, NULL AS receiver_agent_id,
+                       created_at
                 FROM tool_calls
                 WHERE agent_id = ?
                 ORDER BY created_at, tool_call_id
@@ -653,6 +691,12 @@ class SQLiteMemoryStore:
                 created_at,
                 content,
             ),
+        )
+
+    def _delete_index(self, kind, record_id):
+        self.connection.execute(
+            "DELETE FROM memory_fts WHERE kind = ? AND record_id = ?",
+            (kind, str(record_id)),
         )
 
     def _rows(self, query, params=()):

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -143,6 +143,74 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].content, "Coworker plan for sqlite search.")
 
+    def test_metadata_preserves_valid_falsy_json_values(self):
+        store = self.seed_store()
+
+        store.append_tool_call(
+            "call-1",
+            "SE",
+            "memory.empty",
+            arguments=[],
+            result_content="Empty args are intentional.",
+            session_id="session-1",
+            metadata=False,
+        )
+
+        row = store.connection.execute(
+            "SELECT arguments_json, metadata_json FROM tool_calls WHERE tool_call_id = ?",
+            ("call-1",),
+        ).fetchone()
+
+        self.assertEqual(row["arguments_json"], "[]")
+        self.assertEqual(row["metadata_json"], "false")
+
+    def test_tool_call_can_be_updated_with_result_and_reindexed(self):
+        store = self.seed_store()
+
+        store.append_tool_call(
+            "call-1",
+            "SE",
+            "memory.search",
+            arguments={"query": "sqlite"},
+            status="requested",
+            session_id="session-1",
+        )
+        store.append_tool_call(
+            "call-1",
+            "SE",
+            "memory.search",
+            arguments={"query": "sqlite"},
+            result_content="Updated sqlite result.",
+            status="completed",
+            session_id="session-1",
+        )
+
+        row = store.connection.execute(
+            "SELECT status, result_content FROM tool_calls WHERE tool_call_id = ?",
+            ("call-1",),
+        ).fetchone()
+        results = store.search("updated", agent_id="SE")
+
+        self.assertEqual(row["status"], "completed")
+        self.assertEqual(row["result_content"], "Updated sqlite result.")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].record_id, "call-1")
+
+    def test_append_and_list_todos(self):
+        store = self.seed_store()
+
+        todo_id = store.append_todo(
+            "SE",
+            "Add prompt assembly retrieval",
+            session_id="session-1",
+            content="Use memory search before growing context.",
+        )
+
+        todos = store.list_todos(agent_id="SE", status="open")
+
+        self.assertEqual(todos[0]["todo_id"], todo_id)
+        self.assertEqual(todos[0]["title"], "Add prompt assembly retrieval")
+
     def test_agent_record_lookup_includes_messages_thoughts_and_tools(self):
         store = self.seed_store()
         store.append_message("session-1", "CEO", "SE", "Message for SE.")
@@ -157,8 +225,12 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
 
         records = store.list_agent_records("SE")
         record_types = {record["record_type"] for record in records}
+        message = next(record for record in records if record["record_type"] == "message")
 
         self.assertEqual(record_types, {"message", "thought", "tool_call"})
+        self.assertEqual(message["agent_id"], "SE")
+        self.assertEqual(message["sender_agent_id"], "CEO")
+        self.assertEqual(message["receiver_agent_id"], "SE")
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,0 +1,165 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from robits.memory import SQLiteMemoryStore
+
+
+class SQLiteMemoryStoreTests(unittest.TestCase):
+    def build_store(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = SQLiteMemoryStore(Path(temp_dir.name) / "memory.sqlite3")
+        self.addCleanup(store.close)
+        return store
+
+    def seed_store(self):
+        store = self.build_store()
+        store.create_session("session-1", title="Planning")
+        store.upsert_agent("CEO", "Human", "CEO")
+        store.upsert_agent("SE", "SoftwareEngineer", "SE")
+        store.upsert_agent("HR", "HR", "HR")
+        store.add_contact("SE", "HR", "coworker")
+        return store
+
+    def test_schema_contains_core_memory_tables(self):
+        store = self.build_store()
+
+        tables = {
+            row["name"]
+            for row in store.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')"
+            )
+        }
+
+        self.assertIn("sessions", tables)
+        self.assertIn("agents", tables)
+        self.assertIn("contacts", tables)
+        self.assertIn("messages", tables)
+        self.assertIn("thoughts", tables)
+        self.assertIn("todos", tables)
+        self.assertIn("tool_calls", tables)
+        self.assertIn("memory_entries", tables)
+        self.assertIn("memory_fts", tables)
+
+    def test_append_and_lookup_messages_by_session_and_agent(self):
+        store = self.seed_store()
+
+        message_id = store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Please design the durable memory substrate.",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="chat",
+        )
+
+        by_session = store.list_messages(session_id="session-1")
+        by_agent = store.list_messages(agent_id="SE")
+
+        self.assertEqual(by_session[0]["message_id"], message_id)
+        self.assertEqual(by_agent[0]["content"], "Please design the durable memory substrate.")
+
+    def test_search_covers_messages_thoughts_tool_results_and_memory_entries(self):
+        store = self.seed_store()
+        store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Use sqlite for coworker recall.",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="chat",
+        )
+        store.append_thought(
+            "SE",
+            "The sqlite schema needs FTS indexes for private recollection.",
+            session_id="session-1",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="thinking",
+        )
+        store.append_tool_call(
+            "call-1",
+            "SE",
+            "memory.search",
+            result_content="Found prior notes about sqlite memory.",
+            session_id="session-1",
+            relationship_type="coworker",
+            conversation_type="tool",
+            source="tool_result",
+        )
+        store.append_memory_entry(
+            "memory_digest",
+            "Digest: sqlite records should preserve source links.",
+            agent_id="SE",
+            session_id="session-1",
+            source_table="messages",
+            source_id=1,
+            relationship_type="coworker",
+            conversation_type="work",
+            source="digest",
+        )
+
+        results = store.search("sqlite", agent_id="SE", session_id="session-1")
+        kinds = {result.kind for result in results}
+
+        self.assertIn("message", kinds)
+        self.assertIn("thought", kinds)
+        self.assertIn("tool_call", kinds)
+        self.assertIn("memory_digest", kinds)
+
+    def test_search_filters_relationship_conversation_source_and_dates(self):
+        store = self.seed_store()
+        store.append_thought(
+            "SE",
+            "Coworker plan for sqlite search.",
+            session_id="session-1",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="thinking",
+            created_at="2026-05-07T10:00:00+00:00",
+        )
+        store.append_thought(
+            "SE",
+            "Family plan for sqlite search.",
+            session_id="session-1",
+            relationship_type="family",
+            conversation_type="home",
+            source="thinking",
+            created_at="2026-05-08T10:00:00+00:00",
+        )
+
+        results = store.search(
+            "sqlite",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="thinking",
+            start_at="2026-05-07T00:00:00+00:00",
+            end_at="2026-05-07T23:59:59+00:00",
+        )
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].content, "Coworker plan for sqlite search.")
+
+    def test_agent_record_lookup_includes_messages_thoughts_and_tools(self):
+        store = self.seed_store()
+        store.append_message("session-1", "CEO", "SE", "Message for SE.")
+        store.append_thought("SE", "Private thought.", session_id="session-1")
+        store.append_tool_call(
+            "call-1",
+            "SE",
+            "memory.search",
+            result_content="Tool result.",
+            session_id="session-1",
+        )
+
+        records = store.list_agent_records("SE")
+        record_types = {record["record_type"] for record in records}
+
+        self.assertEqual(record_types, {"message", "thought", "tool_call"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a local SQLite memory package with tables for sessions, agents, contacts, messages, thoughts, todos, tool calls, and memory entries
- add FTS search over messages, thoughts, tool results, and memory entries with filters for agent, session, relationship type, conversation type, source, and date windows
- add temporary-database tests and repo-local memory skill guidance
- gitignore generated local SQLite database paths

## Validation
- `python -m unittest` (39 tests)
- `python <skill-creator>/scripts/quick_validate.py .github/skills/robits-memory`
- `git diff --check`

Acting as Codex GPT-5.5 on behalf of displague.

Closes #6
