### PR TITLE
Add retrievable memory digests

### DIFF
--- a/.github/skills/robits-memory/resources/sqlite-memory-schema.md
+++ b/.github/skills/robits-memory/resources/sqlite-memory-schema.md
@@ -12,6 +12,8 @@ Core tables:
 - `todos`: agent-owned commitments and side-project tasks.
 - `tool_calls`: requested or completed tool calls, including result content.
 - `memory_entries`: general memory records and future memory digests with source links.
+- `memory_digests`: compacted memory artifacts with prompt version, time range, and retrieval filters.
+- `memory_digest_sources`: ordered source links from a digest back to raw records.
 - `memory_fts`: FTS5 index over message, thought, tool-result, and memory-entry content.
 
 Repository API:
@@ -24,14 +26,19 @@ Repository API:
 - `append_todo`
 - `append_tool_call`
 - `append_memory_entry`
+- `append_memory_digest`
+- `get_memory_digest`
+- `get_memory_digest_sources`
+- `expand_memory_digest_sources`
 - `list_todos`
 - `list_messages`
 - `list_agent_records`
 - `search`
 
 Search supports filters for agent, session, relationship type, conversation type,
-source, and date windows. Keep these filters available when adding prompt
-assembly or memory-digest retrieval.
+source, and date windows. It searches raw records and memory digests through the
+same FTS table. Use `expand_memory_digest_sources` to drill from a digest back to
+the source records for reanalysis or later re-digestion.
 
 Generated local databases should live under `data/` or `var/` by default, both
 of which are ignored by git.

--- a/.github/skills/robits-memory/resources/sqlite-memory-schema.md
+++ b/.github/skills/robits-memory/resources/sqlite-memory-schema.md
@@ -11,10 +11,10 @@ Core tables:
 - `thoughts`: private inner-monologue records.
 - `todos`: agent-owned commitments and side-project tasks.
 - `tool_calls`: requested or completed tool calls, including result content.
-- `memory_entries`: general memory records and future memory digests with source links.
+- `memory_entries`: general memory records that are not compacted digests.
 - `memory_digests`: compacted memory artifacts with prompt version, time range, and retrieval filters.
 - `memory_digest_sources`: ordered source links from a digest back to raw records.
-- `memory_fts`: FTS5 index over message, thought, tool-result, and memory-entry content.
+- `memory_fts`: FTS5 index over message, thought, tool-result, memory-entry, and memory-digest content.
 
 Repository API:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Generated local database files are ignored by git. Unit tests use temporary
 SQLite databases. Local runs should place generated databases under `data/` or
 `var/` unless the runtime is configured with another gitignored path.
 
+Memory digests are compacted memory artifacts stored with prompt version, source
+time range, retrieval filters, and ordered links back to raw source records so a
+future run can expand or reanalyze the original material.
+
 ## Installation
 
 To install the required packages for this project, run:

--- a/robits/memory/__init__.py
+++ b/robits/memory/__init__.py
@@ -1,5 +1,5 @@
 """SQLite-backed memory storage for Robits."""
 
-from .sqlite import MemorySearchResult, SQLiteMemoryStore
+from .sqlite import MemoryDigestSource, MemorySearchResult, SQLiteMemoryStore
 
-__all__ = ["MemorySearchResult", "SQLiteMemoryStore"]
+__all__ = ["MemoryDigestSource", "MemorySearchResult", "SQLiteMemoryStore"]

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -29,6 +29,15 @@ class MemorySearchResult:
     created_at: str
 
 
+@dataclass(frozen=True)
+class MemoryDigestSource:
+    source_table: str
+    source_id: str
+    source_created_at: str | None
+    position: int
+    metadata: dict[str, Any]
+
+
 class SQLiteMemoryStore:
     """Small repository API for durable local Robits memory records."""
 
@@ -163,6 +172,35 @@ class SQLiteMemoryStore:
                 FOREIGN KEY (session_id) REFERENCES sessions(session_id)
             );
 
+            CREATE TABLE IF NOT EXISTS memory_digests (
+                digest_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT,
+                session_id TEXT,
+                content TEXT NOT NULL,
+                prompt_version TEXT NOT NULL,
+                source_start_at TEXT,
+                source_end_at TEXT,
+                relationship_type TEXT,
+                conversation_type TEXT,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                FOREIGN KEY (agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS memory_digest_sources (
+                digest_id INTEGER NOT NULL,
+                source_table TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                source_created_at TEXT,
+                position INTEGER NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                PRIMARY KEY (digest_id, source_table, source_id),
+                FOREIGN KEY (digest_id) REFERENCES memory_digests(digest_id)
+                    ON DELETE CASCADE
+            );
+
             CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
                 kind UNINDEXED,
                 record_id UNINDEXED,
@@ -182,6 +220,9 @@ class SQLiteMemoryStore:
             CREATE INDEX IF NOT EXISTS idx_thoughts_agent ON thoughts(agent_id);
             CREATE INDEX IF NOT EXISTS idx_tool_calls_agent ON tool_calls(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_entries_agent ON memory_entries(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_memory_digests_agent ON memory_digests(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_memory_digest_sources_digest
+                ON memory_digest_sources(digest_id);
             """
         )
         self.connection.commit()
@@ -546,6 +587,123 @@ class SQLiteMemoryStore:
         self.connection.commit()
         return record_id
 
+    def append_memory_digest(
+        self,
+        content,
+        source_refs,
+        agent_id=None,
+        session_id=None,
+        prompt_version="memory-digest-v1",
+        source_start_at=None,
+        source_end_at=None,
+        relationship_type=None,
+        conversation_type=None,
+        source="digest",
+        created_at=None,
+        metadata=None,
+    ):
+        if not source_refs:
+            raise ValueError("Memory digest requires at least one source reference.")
+        timestamp = created_at or _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO memory_digests(
+                agent_id, session_id, content, prompt_version, source_start_at,
+                source_end_at, relationship_type, conversation_type, source,
+                created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                agent_id,
+                session_id,
+                content,
+                prompt_version,
+                source_start_at,
+                source_end_at,
+                relationship_type,
+                conversation_type,
+                source,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        digest_id = cursor.lastrowid
+        for position, source_ref in enumerate(source_refs):
+            source_table = source_ref["source_table"]
+            source_id = str(source_ref["source_id"])
+            self._validate_source_table(source_table)
+            self.connection.execute(
+                """
+                INSERT INTO memory_digest_sources(
+                    digest_id, source_table, source_id, source_created_at,
+                    position, metadata_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    digest_id,
+                    source_table,
+                    source_id,
+                    source_ref.get("source_created_at"),
+                    position,
+                    _json_dumps(source_ref.get("metadata")),
+                ),
+            )
+        self._index(
+            "memory_digest",
+            digest_id,
+            agent_id,
+            None,
+            session_id,
+            source,
+            relationship_type,
+            conversation_type,
+            timestamp,
+            content,
+        )
+        self.connection.commit()
+        return digest_id
+
+    def get_memory_digest(self, digest_id):
+        row = self.connection.execute(
+            "SELECT * FROM memory_digests WHERE digest_id = ?",
+            (digest_id,),
+        ).fetchone()
+        return dict(row) if row else None
+
+    def get_memory_digest_sources(self, digest_id):
+        rows = self.connection.execute(
+            """
+            SELECT source_table, source_id, source_created_at, position, metadata_json
+            FROM memory_digest_sources
+            WHERE digest_id = ?
+            ORDER BY position
+            """,
+            (digest_id,),
+        ).fetchall()
+        return [
+            MemoryDigestSource(
+                source_table=row["source_table"],
+                source_id=row["source_id"],
+                source_created_at=row["source_created_at"],
+                position=row["position"],
+                metadata=json.loads(row["metadata_json"]),
+            )
+            for row in rows
+        ]
+
+    def expand_memory_digest_sources(self, digest_id):
+        expanded = []
+        for source_ref in self.get_memory_digest_sources(digest_id):
+            row = self._fetch_source_record(source_ref.source_table, source_ref.source_id)
+            if row is not None:
+                row["source_table"] = source_ref.source_table
+                row["source_id"] = source_ref.source_id
+                row["digest_position"] = source_ref.position
+                expanded.append(row)
+        return expanded
+
     def list_messages(self, session_id=None, agent_id=None, limit=100):
         clauses = []
         params: list[Any] = []
@@ -698,6 +856,31 @@ class SQLiteMemoryStore:
             "DELETE FROM memory_fts WHERE kind = ? AND record_id = ?",
             (kind, str(record_id)),
         )
+
+    def _validate_source_table(self, source_table):
+        if source_table not in {
+            "messages",
+            "thoughts",
+            "tool_calls",
+            "memory_entries",
+            "memory_digests",
+        }:
+            raise ValueError(f"Unsupported memory digest source table: {source_table}")
+
+    def _fetch_source_record(self, source_table, source_id):
+        self._validate_source_table(source_table)
+        id_column = {
+            "messages": "message_id",
+            "thoughts": "thought_id",
+            "tool_calls": "tool_call_id",
+            "memory_entries": "memory_id",
+            "memory_digests": "digest_id",
+        }[source_table]
+        row = self.connection.execute(
+            f"SELECT * FROM {source_table} WHERE {id_column} = ?",
+            (source_id,),
+        ).fetchone()
+        return dict(row) if row else None
 
     def _rows(self, query, params=()):
         return [dict(row) for row in self.connection.execute(query, params).fetchall()]

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -547,6 +547,8 @@ class SQLiteMemoryStore:
         created_at=None,
         metadata=None,
     ):
+        if kind == "memory_digest":
+            raise ValueError("Use append_memory_digest for compacted memory artifacts.")
         timestamp = created_at or _utc_now()
         cursor = self.connection.execute(
             """
@@ -604,65 +606,63 @@ class SQLiteMemoryStore:
     ):
         if not source_refs:
             raise ValueError("Memory digest requires at least one source reference.")
+        normalized_sources = self._normalize_digest_source_refs(source_refs)
         timestamp = created_at or _utc_now()
-        cursor = self.connection.execute(
-            """
-            INSERT INTO memory_digests(
-                agent_id, session_id, content, prompt_version, source_start_at,
-                source_end_at, relationship_type, conversation_type, source,
-                created_at, metadata_json
-            )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                agent_id,
-                session_id,
-                content,
-                prompt_version,
-                source_start_at,
-                source_end_at,
-                relationship_type,
-                conversation_type,
-                source,
-                timestamp,
-                _json_dumps(metadata),
-            ),
-        )
-        digest_id = cursor.lastrowid
-        for position, source_ref in enumerate(source_refs):
-            source_table = source_ref["source_table"]
-            source_id = str(source_ref["source_id"])
-            self._validate_source_table(source_table)
-            self.connection.execute(
+        with self.connection:
+            cursor = self.connection.execute(
                 """
-                INSERT INTO memory_digest_sources(
-                    digest_id, source_table, source_id, source_created_at,
-                    position, metadata_json
+                INSERT INTO memory_digests(
+                    agent_id, session_id, content, prompt_version, source_start_at,
+                    source_end_at, relationship_type, conversation_type, source,
+                    created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
-                    digest_id,
-                    source_table,
-                    source_id,
-                    source_ref.get("source_created_at"),
-                    position,
-                    _json_dumps(source_ref.get("metadata")),
+                    agent_id,
+                    session_id,
+                    content,
+                    prompt_version,
+                    source_start_at,
+                    source_end_at,
+                    relationship_type,
+                    conversation_type,
+                    source,
+                    timestamp,
+                    _json_dumps(metadata),
                 ),
             )
-        self._index(
-            "memory_digest",
-            digest_id,
-            agent_id,
-            None,
-            session_id,
-            source,
-            relationship_type,
-            conversation_type,
-            timestamp,
-            content,
-        )
-        self.connection.commit()
+            digest_id = cursor.lastrowid
+            for position, source_ref in enumerate(normalized_sources):
+                self.connection.execute(
+                    """
+                    INSERT INTO memory_digest_sources(
+                        digest_id, source_table, source_id, source_created_at,
+                        position, metadata_json
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        digest_id,
+                        source_ref["source_table"],
+                        source_ref["source_id"],
+                        source_ref.get("source_created_at"),
+                        position,
+                        _json_dumps(source_ref.get("metadata")),
+                    ),
+                )
+            self._index(
+                "memory_digest",
+                digest_id,
+                agent_id,
+                None,
+                session_id,
+                source,
+                relationship_type,
+                conversation_type,
+                timestamp,
+                content,
+            )
         return digest_id
 
     def get_memory_digest(self, digest_id):
@@ -866,6 +866,26 @@ class SQLiteMemoryStore:
             "memory_digests",
         }:
             raise ValueError(f"Unsupported memory digest source table: {source_table}")
+
+    def _normalize_digest_source_refs(self, source_refs):
+        normalized = []
+        for source_ref in source_refs:
+            if "source_table" not in source_ref or "source_id" not in source_ref:
+                raise ValueError("Memory digest sources require source_table and source_id.")
+            source_table = source_ref["source_table"]
+            self._validate_source_table(source_table)
+            metadata = source_ref.get("metadata")
+            if metadata is not None and not isinstance(metadata, dict):
+                raise ValueError("Memory digest source metadata must be an object.")
+            normalized.append(
+                {
+                    "source_table": source_table,
+                    "source_id": str(source_ref["source_id"]),
+                    "source_created_at": source_ref.get("source_created_at"),
+                    "metadata": metadata,
+                }
+            )
+        return normalized
 
     def _fetch_source_record(self, source_table, source_id):
         self._validate_source_table(source_table)

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -40,6 +40,8 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertIn("todos", tables)
         self.assertIn("tool_calls", tables)
         self.assertIn("memory_entries", tables)
+        self.assertIn("memory_digests", tables)
+        self.assertIn("memory_digest_sources", tables)
         self.assertIn("memory_fts", tables)
 
     def test_append_and_lookup_messages_by_session_and_agent(self):
@@ -231,6 +233,98 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(message["agent_id"], "SE")
         self.assertEqual(message["sender_agent_id"], "CEO")
         self.assertEqual(message["receiver_agent_id"], "SE")
+
+    def test_memory_digest_records_provenance_and_is_searchable(self):
+        store = self.seed_store()
+        message_id = store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Use sqlite to recall architecture decisions.",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="chat",
+            created_at="2026-05-07T10:00:00+00:00",
+        )
+        thought_id = store.append_thought(
+            "SE",
+            "The digest should link back to raw records.",
+            session_id="session-1",
+            relationship_type="coworker",
+            conversation_type="work",
+            source="thinking",
+            created_at="2026-05-07T10:01:00+00:00",
+        )
+
+        digest_id = store.append_memory_digest(
+            "Digest: sqlite recall needs reversible source links.",
+            [
+                {
+                    "source_table": "messages",
+                    "source_id": message_id,
+                    "source_created_at": "2026-05-07T10:00:00+00:00",
+                },
+                {
+                    "source_table": "thoughts",
+                    "source_id": thought_id,
+                    "source_created_at": "2026-05-07T10:01:00+00:00",
+                },
+            ],
+            agent_id="SE",
+            session_id="session-1",
+            prompt_version="memory-digest-test-v1",
+            source_start_at="2026-05-07T10:00:00+00:00",
+            source_end_at="2026-05-07T10:01:00+00:00",
+            relationship_type="coworker",
+            conversation_type="work",
+        )
+
+        digest = store.get_memory_digest(digest_id)
+        sources = store.get_memory_digest_sources(digest_id)
+        results = store.search("reversible", agent_id="SE")
+
+        self.assertEqual(digest["prompt_version"], "memory-digest-test-v1")
+        self.assertEqual(digest["source_start_at"], "2026-05-07T10:00:00+00:00")
+        self.assertEqual([source.source_table for source in sources], ["messages", "thoughts"])
+        self.assertEqual(results[0].kind, "memory_digest")
+        self.assertEqual(results[0].record_id, str(digest_id))
+
+    def test_memory_digest_sources_can_expand_to_raw_records(self):
+        store = self.seed_store()
+        message_id = store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Raw source message.",
+        )
+        tool_call_id = store.append_tool_call(
+            "call-1",
+            "SE",
+            "memory.search",
+            result_content="Raw tool result.",
+            session_id="session-1",
+        )
+        digest_id = store.append_memory_digest(
+            "Digest with two source kinds.",
+            [
+                {"source_table": "messages", "source_id": message_id},
+                {"source_table": "tool_calls", "source_id": tool_call_id},
+            ],
+            agent_id="SE",
+            session_id="session-1",
+        )
+
+        expanded = store.expand_memory_digest_sources(digest_id)
+
+        self.assertEqual([row["source_table"] for row in expanded], ["messages", "tool_calls"])
+        self.assertEqual(expanded[0]["content"], "Raw source message.")
+        self.assertEqual(expanded[1]["result_content"], "Raw tool result.")
+
+    def test_memory_digest_requires_sources(self):
+        store = self.seed_store()
+
+        with self.assertRaisesRegex(ValueError, "requires at least one source"):
+            store.append_memory_digest("No source links.", [], agent_id="SE")
 
 
 if __name__ == "__main__":

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -1,3 +1,4 @@
+import sqlite3
 import tempfile
 import unittest
 from pathlib import Path
@@ -93,8 +94,8 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             source="tool_result",
         )
         store.append_memory_entry(
-            "memory_digest",
-            "Digest: sqlite records should preserve source links.",
+            "memory_note",
+            "Note: sqlite records should preserve source links.",
             agent_id="SE",
             session_id="session-1",
             source_table="messages",
@@ -110,7 +111,7 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertIn("message", kinds)
         self.assertIn("thought", kinds)
         self.assertIn("tool_call", kinds)
-        self.assertIn("memory_digest", kinds)
+        self.assertIn("memory_note", kinds)
 
     def test_search_filters_relationship_conversation_source_and_dates(self):
         store = self.seed_store()
@@ -325,6 +326,77 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "requires at least one source"):
             store.append_memory_digest("No source links.", [], agent_id="SE")
+
+    def test_memory_digest_validates_sources_before_insert(self):
+        store = self.seed_store()
+
+        with self.assertRaisesRegex(ValueError, "source_table and source_id"):
+            store.append_memory_digest(
+                "Bad source link.",
+                [{"source_table": "messages"}],
+                agent_id="SE",
+            )
+
+        count = store.connection.execute(
+            "SELECT COUNT(*) AS count FROM memory_digests"
+        ).fetchone()["count"]
+
+        self.assertEqual(count, 0)
+
+    def test_memory_digest_source_metadata_must_be_object(self):
+        store = self.seed_store()
+        message_id = store.append_message("session-1", "CEO", "SE", "Source.")
+
+        with self.assertRaisesRegex(ValueError, "metadata must be an object"):
+            store.append_memory_digest(
+                "Bad source metadata.",
+                [
+                    {
+                        "source_table": "messages",
+                        "source_id": message_id,
+                        "metadata": False,
+                    }
+                ],
+                agent_id="SE",
+            )
+
+    def test_memory_digest_rolls_back_partial_insert_on_source_error(self):
+        store = self.seed_store()
+        message_id = store.append_message("session-1", "CEO", "SE", "Source.")
+
+        with self.assertRaises(sqlite3.IntegrityError):
+            store.append_memory_digest(
+                "Duplicate source links should roll back.",
+                [
+                    {"source_table": "messages", "source_id": message_id},
+                    {"source_table": "messages", "source_id": message_id},
+                ],
+                agent_id="SE",
+            )
+
+        digest_count = store.connection.execute(
+            "SELECT COUNT(*) AS count FROM memory_digests"
+        ).fetchone()["count"]
+        source_count = store.connection.execute(
+            "SELECT COUNT(*) AS count FROM memory_digest_sources"
+        ).fetchone()["count"]
+        fts_count = store.connection.execute(
+            "SELECT COUNT(*) AS count FROM memory_fts WHERE kind = 'memory_digest'"
+        ).fetchone()["count"]
+
+        self.assertEqual(digest_count, 0)
+        self.assertEqual(source_count, 0)
+        self.assertEqual(fts_count, 0)
+
+    def test_legacy_memory_entry_digest_kind_is_rejected(self):
+        store = self.seed_store()
+
+        with self.assertRaisesRegex(ValueError, "Use append_memory_digest"):
+            store.append_memory_entry(
+                "memory_digest",
+                "Ambiguous legacy digest.",
+                agent_id="SE",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add first-class memory digest tables for compacted artifacts and ordered source links
- add repository APIs to append, fetch, search, and expand memory digests back to raw source records
- document digest schema/API behavior in README and the repo-local memory skill resource
- add temporary-database tests for digest provenance, search, expansion, validation, and rollback behavior

## Validation
- `python -m unittest` (46 tests)
- `python <skill-creator>/scripts/quick_validate.py .github/skills/robits-memory`
- `git diff --check`

Acting as Codex GPT-5.5 on behalf of displague.

Closes #15
