### PR TITLE
Formalize HR agent lifecycle

### DIFF
--- a/.github/skills/robits-runtime/SKILL.md
+++ b/.github/skills/robits-runtime/SKILL.md
@@ -11,9 +11,10 @@ description: Work on the Robits Python organization-simulation runtime, includin
 2. Preserve support for OpenAI-compatible endpoints through environment variables; keep machine-specific endpoint and model names out of committed docs unless expressed generically.
 3. Treat tool execution as a high-risk path because model output can request side effects.
 4. Keep trusted tool definition loading separate from untrusted model output.
-5. Prefer focused tests around parsing, tool loading, and execution before relying on a live model smoke test.
-6. For Responses API work, test function-call routing with fake response items before using a live endpoint.
-7. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
+5. Preserve `org.create_role` compatibility while keeping HR lifecycle state transitions explicit.
+6. Prefer focused tests around parsing, tool loading, lifecycle, and execution before relying on a live model smoke test.
+7. For Responses API work, test function-call routing with fake response items before using a live endpoint.
+8. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
 
 ## Validation
 

--- a/.github/skills/robits-runtime/resources/runtime-architecture.md
+++ b/.github/skills/robits-runtime/resources/runtime-architecture.md
@@ -5,10 +5,14 @@
 - `Role` stores role-specific prompt templates and calls chat completions through `interact`.
 - `Human`, `Ops`, `HR`, `SoftwareEngineer`, and `Angel` define the initial organization roles.
 - `System` loads trusted tools and executes them with the current `employee_dict`.
-- `tools.yaml` defines trusted tools such as `org.create_role`.
+- `tools.yaml` defines trusted tools such as `org.create_role`, `org.pause_role`,
+  and `org.retire_role`.
 - `parse_tool_instruction` extracts the first valid JSON object or array from a model response.
 - `Session` owns a run ID, participants, turn count, system tool handling, and transcript entries.
 - `RoundRobinScheduler` provides deterministic time-share recipient selection when a message is not directed.
+- Role lifecycle state is tracked in memory for active, paused, and retired
+  agents, with lifecycle events recording requester and approver context when a
+  trusted lifecycle tool provides it.
 
 ## Current vs Target
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ The simulation runs in a session, where organization members communicate through
 
 The runtime can parse JSON tool instructions, load trusted tools from `tools.yaml`, and execute registered tools by name. Tools use namespaced identifiers such as `org.create_role`, with short aliases only where compatibility is useful.
 
+HR lifecycle tools keep role creation compatible while adding explicit states:
+`active`, `paused`, and `retired` roles record lifecycle events with optional
+requester, approver, and reason fields. `org.create_role` creates an active role;
+`org.pause_role` and `org.retire_role` change an existing role's lifecycle state.
+
 The target runtime direction is OpenAI-compatible tool calling through modern Responses-style loops: approved tools are exposed with JSON Schema metadata, the model may request function calls, the runtime executes those calls, and tool outputs are returned to the model without relying on ad hoc text parsing.
 
 See `docs/architecture-vision.md` for the staged runtime plan covering sessions, tools, SQLite-backed memory, memory digests, lifecycle, observability, TUI inspection, and local-model constraints.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ The simulation runs in a session, where organization members communicate through
 The runtime can parse JSON tool instructions, load trusted tools from `tools.yaml`, and execute registered tools by name. Tools use namespaced identifiers such as `org.create_role`, with short aliases only where compatibility is useful.
 
 HR lifecycle tools keep role creation compatible while adding explicit states:
-`active`, `paused`, and `retired` roles record lifecycle events with optional
-requester, approver, and reason fields. `org.create_role` creates an active role;
-`org.pause_role` and `org.retire_role` change an existing role's lifecycle state.
+`proposed`, `active`, `paused`, and `retired`. Current trusted tools create
+active roles directly, pause active roles, and retire active or paused roles.
+Lifecycle events record optional requester, approver, and reason fields.
 
 The target runtime direction is OpenAI-compatible tool calling through modern Responses-style loops: approved tools are exposed with JSON Schema metadata, the model may request function calls, the runtime executes those calls, and tool outputs are returned to the model without relying on ad hoc text parsing.
 

--- a/main.py
+++ b/main.py
@@ -131,7 +131,14 @@ class ToolRegistry:
         local_dict = {}
         exec(
             function_source,
-            {"__builtins__": SAFE_TOOL_BUILTINS, "Role": Role, "HR": HR},
+            {
+                "__builtins__": SAFE_TOOL_BUILTINS,
+                "Role": Role,
+                "HR": HR,
+                "create_lifecycle_role": create_lifecycle_role,
+                "pause_lifecycle_role": pause_lifecycle_role,
+                "retire_lifecycle_role": retire_lifecycle_role,
+            },
             local_dict,
         )
         return local_dict[function_name]
@@ -237,6 +244,166 @@ class ToolRegistry:
 
 tool_registry = ToolRegistry()
 
+LIFECYCLE_STATES = ("proposed", "active", "paused", "retired")
+
+
+@dataclass
+class LifecycleEvent:
+    action: str
+    agent_name: str
+    lifecycle_state: str
+    requested_by: str | None = None
+    approved_by: str | None = None
+    reason: str | None = None
+    created_at: str = field(default_factory=lambda: datetime.now().isoformat(timespec="seconds"))
+
+
+def validate_role_name(role_name):
+    if not isinstance(role_name, str) or not role_name.strip():
+        raise ValueError("Role name must be a non-empty string.")
+    normalized = role_name.strip()
+    if "," in normalized:
+        raise ValueError("Role name cannot contain commas.")
+    if len(normalized) > 64:
+        raise ValueError("Role name cannot exceed 64 characters.")
+    return normalized
+
+
+def validate_role_description(role_description):
+    if not isinstance(role_description, str) or not role_description.strip():
+        raise ValueError("Role description must be a non-empty string.")
+    return role_description.strip()
+
+
+def record_lifecycle_event(
+    role,
+    action,
+    lifecycle_state,
+    requested_by=None,
+    approved_by=None,
+    reason=None,
+):
+    event = LifecycleEvent(
+        action=action,
+        agent_name=role.name,
+        lifecycle_state=lifecycle_state,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+    if not hasattr(role, "lifecycle_events"):
+        role.lifecycle_events = []
+    role.lifecycle_events.append(event)
+    role.lifecycle_state = lifecycle_state
+    return event
+
+
+def format_lifecycle_actor_text(requested_by=None, approved_by=None):
+    actor_parts = []
+    if requested_by:
+        actor_parts.append(f"requested by {requested_by}")
+    if approved_by:
+        actor_parts.append(f"approved by {approved_by}")
+    return f" ({', '.join(actor_parts)})" if actor_parts else ""
+
+
+def create_lifecycle_role(
+    employee_dict,
+    role_name,
+    role_description,
+    requested_by=None,
+    approved_by=None,
+):
+    try:
+        normalized_name = validate_role_name(role_name)
+        normalized_description = validate_role_description(role_description)
+    except ValueError as e:
+        return f"Error: {e}"
+    if normalized_name in employee_dict:
+        return f"Error: Role '{normalized_name}' already exists."
+    if len(employee_dict) >= HR.max_organization_members:
+        return f"Error: The organization has reached its maximum size of {HR.max_organization_members} members."
+
+    new_role = Role(normalized_name, normalized_description, employee_dict)
+    record_lifecycle_event(
+        new_role,
+        action="create",
+        lifecycle_state="active",
+        requested_by=requested_by,
+        approved_by=approved_by,
+    )
+    employee_dict[normalized_name] = new_role
+    actor_text = format_lifecycle_actor_text(requested_by, approved_by)
+    return f"Created a new role: {normalized_name} (state: active){actor_text}"
+
+
+def change_lifecycle_state(
+    employee_dict,
+    role_name,
+    lifecycle_state,
+    action,
+    requested_by=None,
+    approved_by=None,
+    reason=None,
+):
+    try:
+        normalized_name = validate_role_name(role_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if lifecycle_state not in LIFECYCLE_STATES:
+        return f"Error: Invalid lifecycle state '{lifecycle_state}'."
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+
+    role = employee_dict[normalized_name]
+    record_lifecycle_event(
+        role,
+        action=action,
+        lifecycle_state=lifecycle_state,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+    actor_text = format_lifecycle_actor_text(requested_by, approved_by)
+    reason_text = f" Reason: {reason}" if reason else ""
+    return f"Updated role '{normalized_name}' to lifecycle state '{lifecycle_state}'{actor_text}.{reason_text}"
+
+
+def pause_lifecycle_role(
+    employee_dict,
+    role_name,
+    requested_by=None,
+    approved_by=None,
+    reason=None,
+):
+    return change_lifecycle_state(
+        employee_dict,
+        role_name,
+        "paused",
+        "pause",
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+
+
+def retire_lifecycle_role(
+    employee_dict,
+    role_name,
+    requested_by=None,
+    approved_by=None,
+    reason=None,
+):
+    return change_lifecycle_state(
+        employee_dict,
+        role_name,
+        "retired",
+        "retire",
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+
 
 def interact(self, model, sender, message):
     if self.template != "" and self.name not in self.conversation_history:
@@ -285,6 +452,8 @@ class Role:
         self.global_conversation_history = []
         self.temperature = 0.7 # 0.1 * random.randint(1, 9)
         self.max_tokens = random.randint(250, 400) # -1
+        self.lifecycle_state = "active"
+        self.lifecycle_events = []
 
     def interact(self, sender, prompt):
         return interact_cheap(self, sender, prompt)

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ import os
 import json
 import re
 import yaml
-from datetime import datetime
+from datetime import datetime, timezone
 from termcolor import colored
 import argparse
 from pathlib import Path
@@ -255,7 +255,9 @@ class LifecycleEvent:
     requested_by: str | None = None
     approved_by: str | None = None
     reason: str | None = None
-    created_at: str = field(default_factory=lambda: datetime.now().isoformat(timespec="seconds"))
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
 
 
 def validate_role_name(role_name):
@@ -345,6 +347,7 @@ def change_lifecycle_state(
     requested_by=None,
     approved_by=None,
     reason=None,
+    allowed_from=None,
 ):
     try:
         normalized_name = validate_role_name(role_name)
@@ -356,6 +359,13 @@ def change_lifecycle_state(
         return f"Error: Role '{normalized_name}' not found."
 
     role = employee_dict[normalized_name]
+    current_state = getattr(role, "lifecycle_state", "active")
+    if allowed_from is not None and current_state not in allowed_from:
+        allowed_text = ", ".join(allowed_from)
+        return (
+            f"Error: Cannot {action} role '{normalized_name}' from lifecycle "
+            f"state '{current_state}'. Expected one of: {allowed_text}."
+        )
     record_lifecycle_event(
         role,
         action=action,
@@ -384,6 +394,7 @@ def pause_lifecycle_role(
         requested_by=requested_by,
         approved_by=approved_by,
         reason=reason,
+        allowed_from=("active",),
     )
 
 
@@ -402,6 +413,7 @@ def retire_lifecycle_role(
         requested_by=requested_by,
         approved_by=approved_by,
         reason=reason,
+        allowed_from=("active", "paused"),
     )
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -91,6 +91,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("Created a new role: QA", response)
         self.assertIn("QA", employee_dict)
         self.assertIsInstance(employee_dict["QA"], main.Role)
+        self.assertEqual(employee_dict["QA"].lifecycle_state, "active")
 
     def test_system_accepts_json_instruction_arrays(self):
         employee_dict = main.build_employee_dict()
@@ -136,6 +137,168 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertIn("Missing args", response)
         self.assertNotIn("QA", employee_dict)
+
+    def test_create_role_records_lifecycle_request_and_approval(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                            "requested_by": "CEO",
+                            "approved_by": "HR",
+                        },
+                    }
+                )
+            )
+
+        event = employee_dict["QA"].lifecycle_events[0]
+
+        self.assertIn("Created a new role: QA", response)
+        self.assertEqual(event.action, "create")
+        self.assertEqual(event.lifecycle_state, "active")
+        self.assertEqual(event.requested_by, "CEO")
+        self.assertEqual(event.approved_by, "HR")
+
+    def test_create_role_rejects_duplicate_role(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            first = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+            )
+            duplicate = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Duplicate role",
+                        },
+                    }
+                )
+            )
+
+        self.assertIn("Created a new role: QA", first)
+        self.assertIn("already exists", duplicate)
+
+    def test_create_role_rejects_capacity_limit(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        original_limit = main.HR.max_organization_members
+        main.HR.max_organization_members = len(employee_dict)
+        try:
+            with redirect_stdout(StringIO()):
+                main.load_tools(system)
+                response = system.interact(
+                    json.dumps(
+                        {
+                            "exec": "org.create_role",
+                            "args": {
+                                "role_name": "QA",
+                                "role_description": "Tests the organization",
+                            },
+                        }
+                    )
+                )
+        finally:
+            main.HR.max_organization_members = original_limit
+
+        self.assertIn("maximum size", response)
+        self.assertNotIn("QA", employee_dict)
+
+    def test_pause_and_retire_role_update_lifecycle_state(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                            "requested_by": "CEO",
+                            "approved_by": "HR",
+                        },
+                    }
+                )
+            )
+            pause_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.pause_role",
+                        "args": {
+                            "role_name": "QA",
+                            "requested_by": "HR",
+                            "approved_by": "HR",
+                            "reason": "Rest period",
+                        },
+                    }
+                )
+            )
+            retire_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.retire_role",
+                        "args": {
+                            "role_name": "QA",
+                            "requested_by": "HR",
+                            "approved_by": "CEO",
+                            "reason": "Assignment complete",
+                        },
+                    }
+                )
+            )
+
+        qa = employee_dict["QA"]
+
+        self.assertIn("paused", pause_response)
+        self.assertIn("retired", retire_response)
+        self.assertEqual(qa.lifecycle_state, "retired")
+        self.assertEqual([event.action for event in qa.lifecycle_events], ["create", "pause", "retire"])
+        self.assertEqual(qa.lifecycle_events[-1].approved_by, "CEO")
+
+    def test_tool_lifecycle_event_is_recorded_in_session_transcript(self):
+        participants = build_fake_participants()
+        participants["Ops"] = FakeRole("Ops", ["done"])
+        system = main.System(participants)
+        session = main.Session(participants=participants, system=system, run_id="session-1")
+        payload = json.dumps(
+            {
+                "exec": "org.create_role",
+                "args": {
+                    "role_name": "QA",
+                    "role_description": "Tests the organization",
+                    "requested_by": "CEO",
+                    "approved_by": "HR",
+                },
+            }
+        )
+
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            session.run(initial_message=payload, max_turns=1)
+
+        event_text = session.transcript[0].system_events[0]
+
+        self.assertIn("requested by CEO", event_text)
+        self.assertIn("approved by HR", event_text)
 
     def test_tool_definition_validates_args_shape(self):
         system = main.System(main.build_employee_dict())

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -164,6 +164,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(event.lifecycle_state, "active")
         self.assertEqual(event.requested_by, "CEO")
         self.assertEqual(event.approved_by, "HR")
+        self.assertIn("+00:00", event.created_at)
 
     def test_create_role_rejects_duplicate_role(self):
         employee_dict = main.build_employee_dict()
@@ -273,6 +274,43 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(qa.lifecycle_state, "retired")
         self.assertEqual([event.action for event in qa.lifecycle_events], ["create", "pause", "retire"])
         self.assertEqual(qa.lifecycle_events[-1].approved_by, "CEO")
+
+    def test_lifecycle_rejects_invalid_transitions_without_new_event(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+            )
+            first_pause = system.interact(
+                json.dumps({"exec": "org.pause_role", "args": {"role_name": "QA"}})
+            )
+            second_pause = system.interact(
+                json.dumps({"exec": "org.pause_role", "args": {"role_name": "QA"}})
+            )
+            retire = system.interact(
+                json.dumps({"exec": "org.retire_role", "args": {"role_name": "QA"}})
+            )
+            retire_again = system.interact(
+                json.dumps({"exec": "org.retire_role", "args": {"role_name": "QA"}})
+            )
+
+        qa = employee_dict["QA"]
+
+        self.assertIn("paused", first_pause)
+        self.assertIn("Cannot pause", second_pause)
+        self.assertIn("retired", retire)
+        self.assertIn("Cannot retire", retire_again)
+        self.assertEqual([event.action for event in qa.lifecycle_events], ["create", "pause", "retire"])
 
     def test_tool_lifecycle_event_is_recorded_in_session_transcript(self):
         participants = build_fake_participants()

--- a/tools.yaml
+++ b/tools.yaml
@@ -11,20 +11,74 @@
       role_description:
         type: string
         description: The responsibilities and purpose of the new role.
+      requested_by:
+        type: string
+        description: The agent or human requesting the lifecycle change.
+      approved_by:
+        type: string
+        description: The agent or human approving the lifecycle change.
     required:
       - role_name
       - role_description
   code: |
-    if role_name not in employee_dict:
-        if len(employee_dict) < HR.max_organization_members:
-            new_role = Role(
-                role_name,
-                role_description,
-                employee_dict
-            )
-            employee_dict[role_name] = new_role
-            return f"Created a new role: {role_name}"
-        else:
-            return f"Error: The organization has reached its maximum size of {HR.max_organization_members} members."
-    else:
-        return f"Error: Role '{role_name}' already exists."
+    return create_lifecycle_role(
+        employee_dict,
+        role_name,
+        role_description,
+        requested_by=requested_by,
+        approved_by=approved_by,
+    )
+- name: org.pause_role
+  description: Pause an active role in the organization.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: The name of the role to pause.
+      requested_by:
+        type: string
+        description: The agent or human requesting the lifecycle change.
+      approved_by:
+        type: string
+        description: The agent or human approving the lifecycle change.
+      reason:
+        type: string
+        description: The reason for pausing the role.
+    required:
+      - role_name
+  code: |
+    return pause_lifecycle_role(
+        employee_dict,
+        role_name,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+- name: org.retire_role
+  description: Retire a role in the organization.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: The name of the role to retire.
+      requested_by:
+        type: string
+        description: The agent or human requesting the lifecycle change.
+      approved_by:
+        type: string
+        description: The agent or human approving the lifecycle change.
+      reason:
+        type: string
+        description: The reason for retiring the role.
+    required:
+      - role_name
+  code: |
+    return retire_lifecycle_role(
+        employee_dict,
+        role_name,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )


### PR DESCRIPTION
## Summary
- add explicit in-memory lifecycle state and lifecycle events for roles
- preserve `org.create_role` compatibility while adding validation, requester, and approver tracking
- add trusted `org.pause_role` and `org.retire_role` lifecycle tools with transition validation
- record lifecycle tool output in session system events and document the runtime behavior

## Validation
- `python -m unittest` (52 tests)
- `python <skill-creator>/scripts/quick_validate.py .github/skills/robits-runtime`
- `git diff --check`

Acting as Codex GPT-5.5 on behalf of displague.

Closes #9
