### PR TITLE
Add headless runtime observability

### DIFF
--- a/.github/skills/robits-memory/resources/sqlite-memory-schema.md
+++ b/.github/skills/robits-memory/resources/sqlite-memory-schema.md
@@ -14,6 +14,7 @@ Core tables:
 - `memory_entries`: general memory records that are not compacted digests.
 - `memory_digests`: compacted memory artifacts with prompt version, time range, and retrieval filters.
 - `memory_digest_sources`: ordered source links from a digest back to raw records.
+- `runtime_events`: headless observability events for live-session replay or TUI readers.
 - `memory_fts`: FTS5 index over message, thought, tool-result, memory-entry, and memory-digest content.
 
 Repository API:
@@ -30,6 +31,9 @@ Repository API:
 - `get_memory_digest`
 - `get_memory_digest_sources`
 - `expand_memory_digest_sources`
+- `append_runtime_event`
+- `append_runtime_event_object`
+- `list_runtime_events`
 - `list_todos`
 - `list_messages`
 - `list_agent_records`

--- a/.github/skills/robits-runtime/SKILL.md
+++ b/.github/skills/robits-runtime/SKILL.md
@@ -12,9 +12,10 @@ description: Work on the Robits Python organization-simulation runtime, includin
 3. Treat tool execution as a high-risk path because model output can request side effects.
 4. Keep trusted tool definition loading separate from untrusted model output.
 5. Preserve `org.create_role` compatibility while keeping HR lifecycle state transitions explicit.
-6. Prefer focused tests around parsing, tool loading, lifecycle, and execution before relying on a live model smoke test.
-7. For Responses API work, test function-call routing with fake response items before using a live endpoint.
-8. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
+6. Keep observability headless-first; tests should assert emitted events without requiring a terminal UI.
+7. Prefer focused tests around parsing, tool loading, lifecycle, observability, and execution before relying on a live model smoke test.
+8. For Responses API work, test function-call routing with fake response items before using a live endpoint.
+9. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
 
 ## Validation
 

--- a/.github/skills/robits-runtime/resources/runtime-architecture.md
+++ b/.github/skills/robits-runtime/resources/runtime-architecture.md
@@ -10,6 +10,8 @@
 - `parse_tool_instruction` extracts the first valid JSON object or array from a model response.
 - `Session` owns a run ID, participants, turn count, system tool handling, and transcript entries.
 - `RoundRobinScheduler` provides deterministic time-share recipient selection when a message is not directed.
+- `RuntimeEventStream` emits headless session, routing, message, tool, and
+  thought events for tests and future TUI observers.
 - Role lifecycle state is tracked in memory for active, paused, and retired
   agents, with lifecycle events recording requester and approver context when a
   trusted lifecycle tool provides it.
@@ -23,6 +25,9 @@ Current runtime:
 - Trusted tool definitions are repo-owned and loaded from `tools.yaml`.
 - Runtime sessions record structured turn transcripts and enforce bounded turn counts.
 - Undirected recipient selection is deterministic round-robin scheduling; directed messages still take precedence.
+- Runtime observability is headless-first: an in-memory event stream can be
+  subscribed to during active sessions, and event records can be persisted to
+  SQLite for replay.
 
 Target runtime:
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Memory digests are compacted memory artifacts stored with prompt version, source
 time range, retrieval filters, and ordered links back to raw source records so a
 future run can expand or reanalyze the original material.
 
+## Observability
+
+Sessions emit a headless runtime event stream for session lifecycle, routing,
+message, tool, and private thought events. Tests and future TUI code can
+subscribe to the active stream without requiring an interactive terminal.
+Runtime events can also be persisted to SQLite and replayed later, with
+visibility fields separating public transcript events from private thoughts.
+
 ## Installation
 
 To install the required packages for this project, run:

--- a/main.py
+++ b/main.py
@@ -613,6 +613,48 @@ class TranscriptEntry:
 
 
 @dataclass
+class RuntimeEvent:
+    sequence: int
+    event_type: str
+    session_id: str
+    payload: dict
+    visibility: str = "public"
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+
+
+class RuntimeEventStream:
+    def __init__(self):
+        self._events = []
+        self._subscribers = []
+        self._sequence = 0
+
+    def subscribe(self, callback):
+        self._subscribers.append(callback)
+        return callback
+
+    def emit(self, event_type, session_id, payload=None, visibility="public"):
+        self._sequence += 1
+        event = RuntimeEvent(
+            sequence=self._sequence,
+            event_type=event_type,
+            session_id=session_id,
+            payload=payload or {},
+            visibility=visibility,
+        )
+        self._events.append(event)
+        for callback in list(self._subscribers):
+            callback(event)
+        return event
+
+    def events(self, visibility=None):
+        if visibility is None:
+            return list(self._events)
+        return [event for event in self._events if event.visibility == visibility]
+
+
+@dataclass
 class RoutedMessage:
     receiver: object
     prompt: str
@@ -644,16 +686,33 @@ class RoundRobinScheduler:
 
 
 class Session:
-    def __init__(self, participants=None, system=None, scheduler=None, run_id=None, max_turns=None):
+    def __init__(
+        self,
+        participants=None,
+        system=None,
+        scheduler=None,
+        run_id=None,
+        max_turns=None,
+        event_stream=None,
+    ):
         self.participants = participants if participants is not None else build_employee_dict()
         self.system = system if system is not None else System(self.participants)
         scheduler_names = list(self.participants)
         self.scheduler = scheduler if scheduler is not None else RoundRobinScheduler(scheduler_names)
         self.run_id = run_id or f"run-{uuid4()}"
         self.max_turns = max_turns
+        self.event_stream = event_stream if event_stream is not None else RuntimeEventStream()
         self.transcript = []
         self.turns_completed = 0
         self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
+        self.event_stream.emit(
+            "session.created",
+            self.run_id,
+            {
+                "participants": list(self.participants),
+                "max_turns": self.max_turns,
+            },
+        )
 
     def route_message(self, message, last_receiver_name=None):
         prompt_split = message.split(",", 1) if isinstance(message, str) else []
@@ -662,9 +721,25 @@ class Session:
             if receiver_name in self.participants:
                 print(colored(f"// Directed to {receiver_name}", "grey"))
                 self.scheduler.observe(receiver_name)
+                self.event_stream.emit(
+                    "message.routed",
+                    self.run_id,
+                    {
+                        "receiver": receiver_name,
+                        "directed": True,
+                    },
+                )
                 return RoutedMessage(self.participants[receiver_name], prompt_split[1].strip(), True)
 
         receiver_name = self.scheduler.next(last_receiver_name)
+        self.event_stream.emit(
+            "message.routed",
+            self.run_id,
+            {
+                "receiver": receiver_name,
+                "directed": False,
+            },
+        )
         return RoutedMessage(self.participants[receiver_name], message, False)
 
     def process_tool_instruction(self, message):
@@ -676,6 +751,14 @@ class Session:
 
         system_response = self.system.interact(tool_instruction)
         print(colored(f"System: {system_response}", "blue"))
+        self.event_stream.emit(
+            "tool.executed",
+            self.run_id,
+            {
+                "instruction": tool_instruction,
+                "response": system_response,
+            },
+        )
         if system_response is not None and system_response != "" and "Ops" in self.participants:
             ops = self.participants["Ops"]
             if hasattr(ops, "update_group_conversations"):
@@ -694,7 +777,29 @@ class Session:
         )
         self.transcript.append(entry)
         self.turns_completed += 1
+        self.event_stream.emit(
+            "message.recorded",
+            self.run_id,
+            {
+                "turn": entry.turn,
+                "sender": entry.sender,
+                "receiver": entry.receiver,
+                "directed": entry.directed,
+                "system_event_count": len(entry.system_events),
+            },
+        )
         return entry
+
+    def record_thought(self, agent_name, content, visibility="private"):
+        return self.event_stream.emit(
+            "thought.recorded",
+            self.run_id,
+            {
+                "agent": agent_name,
+                "content": content,
+            },
+            visibility=visibility,
+        )
 
     def sync_scheduler_participants(self):
         for name in self.participants:
@@ -733,6 +838,13 @@ class Session:
         while effective_max_turns is None or self.turns_completed < effective_max_turns:
             last_response = self.step(last_response)
 
+        self.event_stream.emit(
+            "session.completed",
+            self.run_id,
+            {
+                "turns_completed": self.turns_completed,
+            },
+        )
         return self
 
 

--- a/main.py
+++ b/main.py
@@ -628,6 +628,7 @@ class RuntimeEventStream:
     def __init__(self):
         self._events = []
         self._subscribers = []
+        self.subscriber_errors = []
         self._sequence = 0
 
     def subscribe(self, callback):
@@ -645,7 +646,15 @@ class RuntimeEventStream:
         )
         self._events.append(event)
         for callback in list(self._subscribers):
-            callback(event)
+            try:
+                callback(event)
+            except Exception as e:
+                self.subscriber_errors.append(
+                    {
+                        "event_type": event_type,
+                        "error": str(e),
+                    }
+                )
         return event
 
     def events(self, visibility=None):

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -201,6 +201,17 @@ class SQLiteMemoryStore:
                     ON DELETE CASCADE
             );
 
+            CREATE TABLE IF NOT EXISTS runtime_events (
+                event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                sequence INTEGER,
+                event_type TEXT NOT NULL,
+                visibility TEXT NOT NULL DEFAULT 'public',
+                payload_json TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL,
+                FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+            );
+
             CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
                 kind UNINDEXED,
                 record_id UNINDEXED,
@@ -223,6 +234,8 @@ class SQLiteMemoryStore:
             CREATE INDEX IF NOT EXISTS idx_memory_digests_agent ON memory_digests(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_digest_sources_digest
                 ON memory_digest_sources(digest_id);
+            CREATE INDEX IF NOT EXISTS idx_runtime_events_session ON runtime_events(session_id);
+            CREATE INDEX IF NOT EXISTS idx_runtime_events_type ON runtime_events(event_type);
             """
         )
         self.connection.commit()
@@ -664,6 +677,73 @@ class SQLiteMemoryStore:
                 content,
             )
         return digest_id
+
+    def append_runtime_event(
+        self,
+        session_id,
+        event_type,
+        payload=None,
+        visibility="public",
+        sequence=None,
+        created_at=None,
+    ):
+        timestamp = created_at or _utc_now()
+        cursor = self.connection.execute(
+            """
+            INSERT INTO runtime_events(
+                session_id, sequence, event_type, visibility, payload_json, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                session_id,
+                sequence,
+                event_type,
+                visibility,
+                _json_dumps(payload),
+                timestamp,
+            ),
+        )
+        self.connection.commit()
+        return cursor.lastrowid
+
+    def append_runtime_event_object(self, event):
+        return self.append_runtime_event(
+            event.session_id,
+            event.event_type,
+            payload=event.payload,
+            visibility=event.visibility,
+            sequence=event.sequence,
+            created_at=event.created_at,
+        )
+
+    def list_runtime_events(
+        self,
+        session_id=None,
+        event_type=None,
+        visibility=None,
+        limit=100,
+    ):
+        clauses = []
+        params: list[Any] = []
+        for column, value in (
+            ("session_id", session_id),
+            ("event_type", event_type),
+            ("visibility", visibility),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return self._rows(
+            f"""
+            SELECT * FROM runtime_events
+            {where}
+            ORDER BY COALESCE(sequence, event_id), event_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )
 
     def get_memory_digest(self, digest_id):
         row = self.connection.execute(

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -43,6 +43,7 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertIn("memory_entries", tables)
         self.assertIn("memory_digests", tables)
         self.assertIn("memory_digest_sources", tables)
+        self.assertIn("runtime_events", tables)
         self.assertIn("memory_fts", tables)
 
     def test_append_and_lookup_messages_by_session_and_agent(self):
@@ -397,6 +398,27 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
                 "Ambiguous legacy digest.",
                 agent_id="SE",
             )
+
+    def test_runtime_events_can_be_persisted_and_filtered(self):
+        store = self.seed_store()
+
+        event_id = store.append_runtime_event(
+            "session-1",
+            "thought.recorded",
+            payload={"agent": "SE", "content": "Private note."},
+            visibility="private",
+            sequence=1,
+            created_at="2026-05-07T10:00:00+00:00",
+        )
+
+        events = store.list_runtime_events(
+            session_id="session-1",
+            event_type="thought.recorded",
+            visibility="private",
+        )
+
+        self.assertEqual(events[0]["event_id"], event_id)
+        self.assertEqual(events[0]["payload_json"], '{"agent": "SE", "content": "Private note."}')
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -618,6 +618,7 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(session.max_turns, 3)
         self.assertEqual(session.turns_completed, 0)
         self.assertEqual(session.transcript, [])
+        self.assertEqual(session.event_stream.events()[0].event_type, "session.created")
 
     def test_round_robin_scheduler_skips_last_receiver(self):
         scheduler = main.RoundRobinScheduler(["CEO", "Ops", "SE"])
@@ -741,6 +742,36 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("QA", session.scheduler.participant_names)
         self.assertEqual(len(session.transcript[0].system_events), 1)
         self.assertIn("Created a new role: QA", session.transcript[0].system_events[0])
+
+    def test_session_emits_headless_runtime_events(self):
+        participants = build_fake_participants()
+        event_stream = main.RuntimeEventStream()
+        observed = []
+        event_stream.subscribe(observed.append)
+        session = main.Session(
+            participants=participants,
+            run_id="session-1",
+            event_stream=event_stream,
+        )
+
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="HR, status please", max_turns=1)
+
+        event_types = [event.event_type for event in observed]
+
+        self.assertIn("session.created", event_types)
+        self.assertIn("message.routed", event_types)
+        self.assertIn("message.recorded", event_types)
+        self.assertIn("session.completed", event_types)
+
+    def test_thought_events_are_private_by_default(self):
+        session = main.Session(participants=build_fake_participants(), run_id="session-1")
+
+        event = session.record_thought("SE", "Private implementation note.")
+
+        self.assertEqual(event.event_type, "thought.recorded")
+        self.assertEqual(event.visibility, "private")
+        self.assertEqual(session.event_stream.events("private"), [event])
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -618,7 +618,10 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(session.max_turns, 3)
         self.assertEqual(session.turns_completed, 0)
         self.assertEqual(session.transcript, [])
-        self.assertEqual(session.event_stream.events()[0].event_type, "session.created")
+        self.assertIn(
+            "session.created",
+            [event.event_type for event in session.event_stream.events()],
+        )
 
     def test_round_robin_scheduler_skips_last_receiver(self):
         scheduler = main.RoundRobinScheduler(["CEO", "Ops", "SE"])
@@ -763,6 +766,19 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("message.routed", event_types)
         self.assertIn("message.recorded", event_types)
         self.assertIn("session.completed", event_types)
+
+    def test_event_subscriber_errors_do_not_break_runtime(self):
+        event_stream = main.RuntimeEventStream()
+
+        def broken_subscriber(_event):
+            raise RuntimeError("observer failed")
+
+        event_stream.subscribe(broken_subscriber)
+        event = event_stream.emit("session.created", "session-1")
+
+        self.assertEqual(event.event_type, "session.created")
+        self.assertEqual(event_stream.subscriber_errors[0]["event_type"], "session.created")
+        self.assertEqual(event_stream.subscriber_errors[0]["error"], "observer failed")
 
     def test_thought_events_are_private_by_default(self):
         session = main.Session(participants=build_fake_participants(), run_id="session-1")


### PR DESCRIPTION
## Summary
- add a headless `RuntimeEventStream` for session, routing, message, tool, and private thought events
- let tests and future TUI code subscribe to active runtime events without requiring an interactive terminal
- add SQLite runtime event persistence APIs for replay/filtering by session, type, and visibility
- document observability behavior in README and repo-local runtime/memory skill resources

## Validation
- `python -m unittest` (56 tests)
- `python <skill-creator>/scripts/quick_validate.py .github/skills/robits-runtime`
- `python <skill-creator>/scripts/quick_validate.py .github/skills/robits-memory`
- `git diff --check`

Acting as Codex GPT-5.5 on behalf of displague.

Closes #16
