### PR TITLE
Add optional agent sandbox runtime

### DIFF
--- a/.github/skills/robits-runtime/SKILL.md
+++ b/.github/skills/robits-runtime/SKILL.md
@@ -13,9 +13,10 @@ description: Work on the Robits Python organization-simulation runtime, includin
 4. Keep trusted tool definition loading separate from untrusted model output.
 5. Preserve `org.create_role` compatibility while keeping HR lifecycle state transitions explicit.
 6. Keep observability headless-first; tests should assert emitted events without requiring a terminal UI.
-7. Prefer focused tests around parsing, tool loading, lifecycle, observability, and execution before relying on a live model smoke test.
-8. For Responses API work, test function-call routing with fake response items before using a live endpoint.
-9. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
+7. Keep sandbox behavior optional and fakeable; unit tests must not require containers or a local cluster.
+8. Prefer focused tests around parsing, tool loading, lifecycle, observability, sandbox metadata, and execution before relying on a live model smoke test.
+9. For Responses API work, test function-call routing with fake response items before using a live endpoint.
+10. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
 
 ## Validation
 

--- a/.github/skills/robits-runtime/resources/runtime-architecture.md
+++ b/.github/skills/robits-runtime/resources/runtime-architecture.md
@@ -15,6 +15,9 @@
 - Role lifecycle state is tracked in memory for active, paused, and retired
   agents, with lifecycle events recording requester and approver context when a
   trusted lifecycle tool provides it.
+- Agents carry optional sandbox metadata. Sandboxing is disabled by default; when
+  enabled, metadata separates a private per-agent workspace from a shared
+  organization workspace and names the backend policy.
 
 ## Current vs Target
 
@@ -28,6 +31,13 @@ Current runtime:
 - Runtime observability is headless-first: an in-memory event stream can be
   subscribed to during active sessions, and event records can be persisted to
   SQLite for replay.
+- Sandbox execution is represented by fakeable runtime abstractions so tests do
+  not require containers. Future container or cluster backends should implement
+  the same request/result boundary.
+- Local runs should treat sandbox metadata as policy metadata until a backend is
+  explicitly configured. Headless automation should use fake or local-process
+  backends, while future container backends should mount private agent workspaces
+  separately from the approved shared organization workspace.
 
 Target runtime:
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ visibility fields separating public transcript events from private thoughts.
 Agents can carry optional sandbox metadata. Default local runs keep sandboxing
 disabled and execute through the current runtime. When enabled, metadata names a
 backend plus a private per-agent workspace and a shared organization workspace.
-The current implementation includes a fakeable runtime abstraction for tests and
-future container or cluster backends; it does not require containers for unit
-tests.
+The runtime validates that an explicit configured backend matches the metadata
+before execution. The current implementation includes a fakeable runtime
+abstraction for tests and future container or cluster backends; it does not
+require containers for unit tests.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ subscribe to the active stream without requiring an interactive terminal.
 Runtime events can also be persisted to SQLite and replayed later, with
 visibility fields separating public transcript events from private thoughts.
 
+## Sandboxes
+
+Agents can carry optional sandbox metadata. Default local runs keep sandboxing
+disabled and execute through the current runtime. When enabled, metadata names a
+backend plus a private per-agent workspace and a shared organization workspace.
+The current implementation includes a fakeable runtime abstraction for tests and
+future container or cluster backends; it does not require containers for unit
+tests.
+
 ## Installation
 
 To install the required packages for this project, run:

--- a/main.py
+++ b/main.py
@@ -14,6 +14,8 @@ import argparse
 from pathlib import Path
 from uuid import uuid4
 
+from robits.runtime.sandbox import SandboxMetadata
+
 
 def make_client():
     client_kwargs = {
@@ -466,6 +468,7 @@ class Role:
         self.max_tokens = random.randint(250, 400) # -1
         self.lifecycle_state = "active"
         self.lifecycle_events = []
+        self.sandbox_metadata = SandboxMetadata.disabled(self.name)
 
     def interact(self, sender, prompt):
         return interact_cheap(self, sender, prompt)
@@ -570,6 +573,7 @@ class Human(Role):
     def __init__(self):
         self.name = "CEO"
         self.template = "As CEO, you are responsible for making high-level decisions and setting the overall direction of the organization."
+        self.sandbox_metadata = SandboxMetadata.disabled(self.name)
 
     def interact(self, *_):
         return input(f"{self.name}: ")

--- a/robits/runtime/__init__.py
+++ b/robits/runtime/__init__.py
@@ -1,0 +1,17 @@
+"""Runtime support boundaries for Robits."""
+
+from .sandbox import (
+    FakeSandboxBackend,
+    SandboxExecutionRequest,
+    SandboxExecutionResult,
+    SandboxMetadata,
+    SandboxRuntime,
+)
+
+__all__ = [
+    "FakeSandboxBackend",
+    "SandboxExecutionRequest",
+    "SandboxExecutionResult",
+    "SandboxMetadata",
+    "SandboxRuntime",
+]

--- a/robits/runtime/sandbox.py
+++ b/robits/runtime/sandbox.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SandboxMetadata:
+    agent_name: str
+    enabled: bool = False
+    backend: str = "none"
+    private_workspace: str | None = None
+    shared_organization_workspace: str | None = None
+    policy: str = "disabled"
+
+    @classmethod
+    def disabled(cls, agent_name):
+        return cls(agent_name=agent_name)
+
+    @classmethod
+    def local_process(
+        cls,
+        agent_name,
+        private_workspace,
+        shared_organization_workspace,
+        policy="agent",
+    ):
+        return cls(
+            agent_name=agent_name,
+            enabled=True,
+            backend="local_process",
+            private_workspace=str(PurePosixPath(private_workspace)),
+            shared_organization_workspace=str(PurePosixPath(shared_organization_workspace)),
+            policy=policy,
+        )
+
+
+@dataclass(frozen=True)
+class SandboxExecutionRequest:
+    agent_name: str
+    tool_name: str
+    arguments: dict[str, Any] = field(default_factory=dict)
+    private_workspace: str | None = None
+    shared_organization_workspace: str | None = None
+    policy: str = "agent"
+
+
+@dataclass(frozen=True)
+class SandboxExecutionResult:
+    status: str
+    output: str
+    backend: str
+    agent_name: str
+    tool_name: str
+
+
+class FakeSandboxBackend:
+    """Deterministic backend for tests and future container adapters."""
+
+    name = "fake"
+
+    def __init__(self, output="ok"):
+        self.output = output
+        self.requests = []
+
+    def execute(self, request):
+        self.requests.append(request)
+        return SandboxExecutionResult(
+            status="completed",
+            output=self.output,
+            backend=self.name,
+            agent_name=request.agent_name,
+            tool_name=request.tool_name,
+        )
+
+
+class SandboxRuntime:
+    def __init__(self, backend=None):
+        self.backend = backend if backend is not None else FakeSandboxBackend()
+
+    def execute_tool(self, sandbox_metadata, tool_name, arguments=None):
+        if sandbox_metadata is None or not sandbox_metadata.enabled:
+            return SandboxExecutionResult(
+                status="skipped",
+                output="Sandbox disabled; execute in current runtime.",
+                backend="none",
+                agent_name=getattr(sandbox_metadata, "agent_name", ""),
+                tool_name=tool_name,
+            )
+        request = SandboxExecutionRequest(
+            agent_name=sandbox_metadata.agent_name,
+            tool_name=tool_name,
+            arguments=arguments or {},
+            private_workspace=sandbox_metadata.private_workspace,
+            shared_organization_workspace=sandbox_metadata.shared_organization_workspace,
+            policy=sandbox_metadata.policy,
+        )
+        return self.backend.execute(request)

--- a/robits/runtime/sandbox.py
+++ b/robits/runtime/sandbox.py
@@ -58,10 +58,9 @@ class SandboxExecutionResult:
 class FakeSandboxBackend:
     """Deterministic backend for tests and future container adapters."""
 
-    name = "fake"
-
-    def __init__(self, output="ok"):
+    def __init__(self, output="ok", name="fake"):
         self.output = output
+        self.name = name
         self.requests = []
 
     def execute(self, request):
@@ -77,7 +76,7 @@ class FakeSandboxBackend:
 
 class SandboxRuntime:
     def __init__(self, backend=None):
-        self.backend = backend if backend is not None else FakeSandboxBackend()
+        self.backend = backend
 
     def execute_tool(self, sandbox_metadata, tool_name, arguments=None):
         if sandbox_metadata is None or not sandbox_metadata.enabled:
@@ -86,6 +85,25 @@ class SandboxRuntime:
                 output="Sandbox disabled; execute in current runtime.",
                 backend="none",
                 agent_name=getattr(sandbox_metadata, "agent_name", ""),
+                tool_name=tool_name,
+            )
+        if self.backend is None:
+            return SandboxExecutionResult(
+                status="error",
+                output="Sandbox enabled but no backend is configured.",
+                backend="none",
+                agent_name=sandbox_metadata.agent_name,
+                tool_name=tool_name,
+            )
+        if sandbox_metadata.backend != self.backend.name:
+            return SandboxExecutionResult(
+                status="error",
+                output=(
+                    f"Sandbox backend mismatch: requested '{sandbox_metadata.backend}' "
+                    f"but configured '{self.backend.name}'."
+                ),
+                backend=self.backend.name,
+                agent_name=sandbox_metadata.agent_name,
                 tool_name=tool_name,
             )
         request = SandboxExecutionRequest(

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -22,7 +22,7 @@ class SandboxRuntimeTests(unittest.TestCase):
         self.assertEqual(result.backend, "none")
 
     def test_fake_backend_receives_private_and_shared_workspace_metadata(self):
-        backend = FakeSandboxBackend(output="done")
+        backend = FakeSandboxBackend(output="done", name="local_process")
         runtime = SandboxRuntime(backend=backend)
         metadata = SandboxMetadata.local_process(
             "SE",
@@ -38,6 +38,32 @@ class SandboxRuntimeTests(unittest.TestCase):
         self.assertEqual(backend.requests[0].private_workspace, "/agents/SE")
         self.assertEqual(backend.requests[0].shared_organization_workspace, "/organization")
         self.assertEqual(backend.requests[0].arguments, {"target": "runtime"})
+
+    def test_enabled_sandbox_without_backend_fails_explicitly(self):
+        runtime = SandboxRuntime()
+        metadata = SandboxMetadata.local_process(
+            "SE",
+            private_workspace="/agents/SE",
+            shared_organization_workspace="/organization",
+        )
+
+        result = runtime.execute_tool(metadata, "project.build")
+
+        self.assertEqual(result.status, "error")
+        self.assertIn("no backend", result.output)
+
+    def test_enabled_sandbox_requires_matching_backend(self):
+        runtime = SandboxRuntime(backend=FakeSandboxBackend(name="container"))
+        metadata = SandboxMetadata.local_process(
+            "SE",
+            private_workspace="/agents/SE",
+            shared_organization_workspace="/organization",
+        )
+
+        result = runtime.execute_tool(metadata, "project.build")
+
+        self.assertEqual(result.status, "error")
+        self.assertIn("backend mismatch", result.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_sandbox_runtime.py
+++ b/tests/test_sandbox_runtime.py
@@ -1,0 +1,44 @@
+import unittest
+
+import main
+from robits.runtime.sandbox import FakeSandboxBackend, SandboxMetadata, SandboxRuntime
+
+
+class SandboxRuntimeTests(unittest.TestCase):
+    def test_default_agents_have_disabled_sandbox_metadata(self):
+        employees = main.build_employee_dict()
+
+        self.assertFalse(employees["SE"].sandbox_metadata.enabled)
+        self.assertEqual(employees["SE"].sandbox_metadata.backend, "none")
+        self.assertFalse(employees["CEO"].sandbox_metadata.enabled)
+
+    def test_disabled_sandbox_runtime_skips_execution(self):
+        runtime = SandboxRuntime()
+        metadata = SandboxMetadata.disabled("SE")
+
+        result = runtime.execute_tool(metadata, "org.create_role", {"role_name": "QA"})
+
+        self.assertEqual(result.status, "skipped")
+        self.assertEqual(result.backend, "none")
+
+    def test_fake_backend_receives_private_and_shared_workspace_metadata(self):
+        backend = FakeSandboxBackend(output="done")
+        runtime = SandboxRuntime(backend=backend)
+        metadata = SandboxMetadata.local_process(
+            "SE",
+            private_workspace="/agents/SE",
+            shared_organization_workspace="/organization",
+        )
+
+        result = runtime.execute_tool(metadata, "project.build", {"target": "runtime"})
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.output, "done")
+        self.assertEqual(backend.requests[0].agent_name, "SE")
+        self.assertEqual(backend.requests[0].private_workspace, "/agents/SE")
+        self.assertEqual(backend.requests[0].shared_organization_workspace, "/organization")
+        self.assertEqual(backend.requests[0].arguments, {"target": "runtime"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional sandbox metadata to agents while keeping default local behavior disabled
- add a fakeable sandbox runtime boundary with request/result objects and private/shared workspace metadata
- validate that enabled sandbox metadata has an explicit matching backend before execution
- document private agent workspace versus shared organization workspace semantics and safety notes for local/headless/future backends
- add unit tests for disabled defaults, missing backend, backend mismatch, and fake backend execution metadata

## Validation
- `python -m unittest` (61 tests)
- `python <skill-creator>/scripts/quick_validate.py .github/skills/robits-runtime`
- `git diff --check`

Acting as Codex GPT-5.5 on behalf of displague.

Closes #18
