### PR TITLE
Add Responses runtime, cascading memory, and agent tools

### DIFF
--- a/.github/skills/robits-memory/resources/sqlite-memory-schema.md
+++ b/.github/skills/robits-memory/resources/sqlite-memory-schema.md
@@ -12,8 +12,11 @@ Core tables:
 - `todos`: agent-owned commitments and side-project tasks.
 - `tool_calls`: requested or completed tool calls, including result content.
 - `memory_entries`: general memory records that are not compacted digests.
-- `memory_digests`: compacted memory artifacts with prompt version, time range, and retrieval filters.
-- `memory_digest_sources`: ordered source links from a digest back to raw records.
+- `memory_digests`: compacted memory artifacts with digest type, generation,
+  version, supersession state, system-only/accessibility flags, prompt version,
+  time range, and retrieval filters.
+- `memory_digest_sources`: ordered source links from a digest back to raw
+  records or earlier `memory_digests`.
 - `runtime_events`: headless observability events for live-session replay or TUI readers.
 - `memory_fts`: FTS5 index over message, thought, tool-result, memory-entry, and memory-digest content.
 
@@ -28,9 +31,13 @@ Repository API:
 - `append_tool_call`
 - `append_memory_entry`
 - `append_memory_digest`
+- `seed_memory_digest`
+- `seed_identity_and_goal_digests`
 - `get_memory_digest`
 - `get_memory_digest_sources`
 - `expand_memory_digest_sources`
+- `expand_memory_digest_source_tree`
+- `list_memory_digests`
 - `append_runtime_event`
 - `append_runtime_event_object`
 - `list_runtime_events`
@@ -42,7 +49,20 @@ Repository API:
 Search supports filters for agent, session, relationship type, conversation type,
 source, and date windows. It searches raw records and memory digests through the
 same FTS table. Use `expand_memory_digest_sources` to drill from a digest back to
-the source records for reanalysis or later re-digestion.
+the source records for reanalysis or later re-digestion. Pass `recursive=True`
+to include cascading digest sources, or use `expand_memory_digest_source_tree`
+when automatic system reanalysis needs the full nested source tree. Pass
+`include_digest_records=False` during recursive expansion when only raw leaf
+sources are needed.
+
+Digest types are `episodic`, `identity`, `goal_long_term`, and
+`goal_short_term`. Backwards-compatible `append_memory_digest` calls create
+current, agent-accessible episodic digests at generation 1. Digest-of-digest
+inserts automatically advance generation from their source digests unless a
+generation is supplied. New digest records can mark older digests as superseded
+with `supersedes_digest_ids`; superseded records are preserved for future
+reanalysis but can be excluded from agent-facing retrieval with
+`list_memory_digests(current_only=True, accessible_only=True)`.
 
 Generated local databases should live under `data/` or `var/` by default, both
 of which are ignored by git.

--- a/README.md
+++ b/README.md
@@ -99,10 +99,17 @@ Relevant environment variables:
 - `OPENAI_BASE_URL` or `OPENAI_API_BASE`: optional compatible endpoint URL.
 - `ROBITS_MODEL` or `OPENAI_MODEL`: default chat model.
 - `ROBITS_CHEAP_MODEL` and `ROBITS_COSTLY_MODEL`: optional per-role overrides.
+- `ROBITS_MEMORY_DB`: optional SQLite memory database path for memory introspection tools.
+- `ROBITS_PROVIDER_API`: model API path, `responses` by default or `chat_completions` for compatibility.
+- `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
+- `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.
 
 ## Tools
 
 Trusted tools live in `tools.yaml`. Each entry includes a namespaced `name`, a JSON Schema `parameters` object, and trusted repo-owned code. Untrusted model output can request registered tools, but it cannot define new executable tools.
+Agents can use trusted alarm tools to create, list, and cancel their own reminders,
+and memory tools to inspect accessible SQLite memory. Memory digest creation and
+re-digestion remain automatic system behavior rather than agent-callable tools.
 
 Example execution payload:
 

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -19,8 +19,10 @@ for a human CEO to inspect what happened.
   undirected messages; directed messages such as `HR, ...` take precedence.
 - `System` loads trusted tool definitions from `tools.yaml` and executes
   registered tools by namespaced name.
-- `ToolRegistry` normalizes trusted repo-owned tools into metadata that can be
-  exposed to OpenAI-compatible Responses or Chat Completions APIs.
+- `ToolRegistry` normalizes trusted repo-owned tools into metadata exposed to
+  OpenAI-compatible Responses or Chat Completions APIs.
+- Provider adapters route model calls through Responses by default, with Chat
+  Completions available as a compatibility fallback.
 - Tests use fake roles and temporary files so runtime behavior does not require
   a live model service.
 
@@ -74,9 +76,9 @@ translated at the edge, not passed through the whole runtime.
 
 ### Provider Adapters
 
-Model invocation should move behind provider adapters. The first adapter should
-preserve the current Chat Completions behavior. A Responses-compatible adapter
-can then be added without changing session, memory, or lifecycle code.
+Model invocation moves behind provider adapters. Responses is the preferred
+runtime path, while Chat Completions remains available as a compatibility
+fallback during migration.
 
 Provider adapters own:
 

--- a/main.py
+++ b/main.py
@@ -8,12 +8,14 @@ import os
 import json
 import re
 import yaml
-from datetime import datetime, timezone
+import threading
+from datetime import datetime, timedelta, timezone
 from termcolor import colored
 import argparse
 from pathlib import Path
 from uuid import uuid4
 
+from robits.memory.sqlite import SQLiteMemoryStore
 from robits.runtime.sandbox import SandboxMetadata
 
 
@@ -34,6 +36,14 @@ client = make_client()
 default_model = os.environ.get("ROBITS_MODEL") or os.environ.get("OPENAI_MODEL") or "gpt-4o-mini"
 costly_model = os.environ.get("ROBITS_COSTLY_MODEL", default_model)
 cheap_model = os.environ.get("ROBITS_CHEAP_MODEL", default_model)
+provider_api = os.environ.get("ROBITS_PROVIDER_API", "responses").strip().lower()
+max_parallelism = max(1, int(os.environ.get("ROBITS_MAX_PARALLELISM", "1")))
+max_api_retries = max(0, int(os.environ.get("ROBITS_MAX_API_RETRIES", "3")))
+api_retry_base_seconds = max(0.0, float(os.environ.get("ROBITS_API_RETRY_BASE_SECONDS", "0.25")))
+api_retry_max_seconds = max(api_retry_base_seconds, float(os.environ.get("ROBITS_API_RETRY_MAX_SECONDS", "4.0")))
+model_call_gate = threading.BoundedSemaphore(max_parallelism)
+memory_db_path = os.environ.get("ROBITS_MEMORY_DB")
+memory_store = SQLiteMemoryStore(memory_db_path) if memory_db_path else None
 SAFE_TOOL_BUILTINS = {
     "bool": bool,
     "dict": dict,
@@ -140,6 +150,14 @@ class ToolRegistry:
                 "create_lifecycle_role": create_lifecycle_role,
                 "pause_lifecycle_role": pause_lifecycle_role,
                 "retire_lifecycle_role": retire_lifecycle_role,
+                "archive_lifecycle_role": archive_lifecycle_role,
+                "list_lifecycle_roles": list_lifecycle_roles,
+                "create_alarm": create_alarm,
+                "list_alarms": list_alarms,
+                "cancel_alarm": cancel_alarm,
+                "memory_search": memory_search,
+                "memory_list_digests": memory_list_digests,
+                "memory_expand_digest": memory_expand_digest,
             },
             local_dict,
         )
@@ -246,7 +264,153 @@ class ToolRegistry:
 
 tool_registry = ToolRegistry()
 
-LIFECYCLE_STATES = ("proposed", "active", "paused", "retired")
+
+def _response_text(response):
+    output_text = getattr(response, "output_text", None)
+    if output_text:
+        return output_text
+    chunks = []
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) == "message":
+            for content in getattr(item, "content", []) or []:
+                text = getattr(content, "text", None)
+                if text:
+                    chunks.append(text)
+        elif getattr(item, "type", None) in {"output_text", "text"}:
+            text = getattr(item, "text", None)
+            if text:
+                chunks.append(text)
+    return "".join(chunks)
+
+
+def _response_function_calls(response):
+    calls = []
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) != "function_call":
+            continue
+        calls.append(item)
+    return calls
+
+
+def _is_retryable_api_error(error):
+    status_code = getattr(error, "status_code", None)
+    if status_code in {408, 409, 429, 500, 502, 503, 504}:
+        return True
+    name = error.__class__.__name__.lower()
+    return any(token in name for token in ("ratelimit", "timeout", "connection"))
+
+
+def _with_model_retries(operation):
+    attempt = 0
+    while True:
+        try:
+            with model_call_gate:
+                return operation()
+        except Exception as error:
+            if attempt >= max_api_retries or not _is_retryable_api_error(error):
+                raise
+            delay = min(api_retry_max_seconds, api_retry_base_seconds * (2**attempt))
+            if delay:
+                time.sleep(delay + random.uniform(0, delay / 4))
+            attempt += 1
+
+
+class ModelProvider:
+    def generate(self, role, model, sender, messages):
+        raise NotImplementedError
+
+
+class ChatCompletionsProvider(ModelProvider):
+    def __init__(self, api_client):
+        self.client = api_client
+
+    def generate(self, role, model, sender, messages):
+        def request():
+            return self.client.chat.completions.create(
+                model=model,
+                messages=messages,
+                max_tokens=role.max_tokens,
+                n=1,
+                temperature=role.temperature,
+                user=f"robits_{role.name}",
+                stream=True,
+            )
+
+        stream = _with_model_retries(request)
+        content = ""
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                content += chunk.choices[0].delta.content
+        return content
+
+
+class ResponsesProvider(ModelProvider):
+    def __init__(self, api_client, registry=None):
+        self.client = api_client
+        self.registry = registry if registry is not None else tool_registry
+
+    def generate(self, role, model, sender, messages):
+        employee_dict = getattr(role, "employee_dict", None)
+        tools = self.registry.as_responses_tools()
+        kwargs = {
+            "model": model,
+            "input": messages,
+            "max_output_tokens": role.max_tokens,
+            "temperature": role.temperature,
+            "user": f"robits_{role.name}",
+        }
+        if tools:
+            kwargs["tools"] = tools
+            kwargs["tool_choice"] = "auto"
+
+        response = _with_model_retries(lambda: self.client.responses.create(**kwargs))
+        for _ in range(8):
+            function_calls = _response_function_calls(response)
+            if not function_calls:
+                return _response_text(response)
+            if employee_dict is None:
+                return "Error: Tool call requested but no employee dictionary is available."
+            outputs = []
+            for call in function_calls:
+                try:
+                    args = json.loads(getattr(call, "arguments", "") or "{}")
+                except json.JSONDecodeError as error:
+                    result = f"Error: Invalid tool arguments JSON: {error}"
+                else:
+                    result = self.registry.execute(getattr(call, "name", ""), args, employee_dict)
+                outputs.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": getattr(call, "call_id", getattr(call, "id", "")),
+                        "output": result,
+                    }
+                )
+            previous_response_id = getattr(response, "id", None)
+            if previous_response_id:
+                response = _with_model_retries(
+                    lambda: self.client.responses.create(
+                        model=model,
+                        input=outputs,
+                        previous_response_id=previous_response_id,
+                    )
+                )
+            else:
+                kwargs["input"] = messages + outputs
+                response = _with_model_retries(lambda: self.client.responses.create(**kwargs))
+        return "Error: Too many consecutive tool-call rounds."
+
+
+def make_model_provider():
+    if provider_api in {"chat", "chat_completions", "chat-completions"}:
+        return ChatCompletionsProvider(client)
+    return ResponsesProvider(client)
+
+
+model_provider = make_model_provider()
+
+LIFECYCLE_STATES = ("proposed", "active", "paused", "retired", "exited")
+PROTECTED_ROLE_NAMES = {"CEO", "HR"}
+ALARM_RECURRENCES = {"once", "hourly", "daily", "weekly"}
 
 
 @dataclass
@@ -260,6 +424,48 @@ class LifecycleEvent:
     created_at: str = field(
         default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
     )
+
+
+@dataclass
+class Alarm:
+    alarm_id: str
+    agent_name: str
+    reminder: str
+    due_at: str
+    recurrence: str = "once"
+    status: str = "active"
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+
+
+def _parse_datetime(value):
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("Timestamp must be a non-empty ISO datetime string.")
+    normalized = value.strip().replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _format_datetime(value):
+    return value.astimezone(timezone.utc).isoformat(timespec="seconds")
+
+
+def _normalize_capabilities(capabilities=None):
+    if capabilities is None:
+        return set()
+    if isinstance(capabilities, str):
+        raw = [capabilities]
+    else:
+        raw = list(capabilities)
+    normalized = set()
+    for capability in raw:
+        if not isinstance(capability, str) or not capability.strip():
+            raise ValueError("Capabilities must be non-empty strings.")
+        normalized.add(capability.strip())
+    return normalized
 
 
 def validate_role_name(role_name):
@@ -315,12 +521,14 @@ def create_lifecycle_role(
     employee_dict,
     role_name,
     role_description,
+    capabilities=None,
     requested_by=None,
     approved_by=None,
 ):
     try:
         normalized_name = validate_role_name(role_name)
         normalized_description = validate_role_description(role_description)
+        normalized_capabilities = _normalize_capabilities(capabilities)
     except ValueError as e:
         return f"Error: {e}"
     if normalized_name in employee_dict:
@@ -329,6 +537,7 @@ def create_lifecycle_role(
         return f"Error: The organization has reached its maximum size of {HR.max_organization_members} members."
 
     new_role = Role(normalized_name, normalized_description, employee_dict)
+    new_role.capabilities = normalized_capabilities
     record_lifecycle_event(
         new_role,
         action="create",
@@ -338,7 +547,10 @@ def create_lifecycle_role(
     )
     employee_dict[normalized_name] = new_role
     actor_text = format_lifecycle_actor_text(requested_by, approved_by)
-    return f"Created a new role: {normalized_name} (state: active){actor_text}"
+    capabilities_text = (
+        f" capabilities={sorted(normalized_capabilities)}" if normalized_capabilities else ""
+    )
+    return f"Created a new role: {normalized_name} (state: active{capabilities_text}){actor_text}"
 
 
 def change_lifecycle_state(
@@ -419,6 +631,220 @@ def retire_lifecycle_role(
     )
 
 
+def _is_role_protected(role_name, role):
+    capabilities = getattr(role, "capabilities", set())
+    return (
+        role_name in PROTECTED_ROLE_NAMES
+        or "protected" in capabilities
+        or "essential" in capabilities
+    )
+
+
+def archive_lifecycle_role(
+    employee_dict,
+    role_name,
+    requested_by=None,
+    approved_by=None,
+    reason=None,
+):
+    try:
+        normalized_name = validate_role_name(role_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+    role = employee_dict[normalized_name]
+    if _is_role_protected(normalized_name, role):
+        return f"Error: Role '{normalized_name}' is protected and cannot be removed from the organization."
+    return change_lifecycle_state(
+        employee_dict,
+        normalized_name,
+        "exited",
+        "archive",
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+        allowed_from=("active", "paused", "retired"),
+    )
+
+
+def list_lifecycle_roles(employee_dict, include_exited=True):
+    rows = []
+    for name, role in sorted(employee_dict.items()):
+        state = getattr(role, "lifecycle_state", "active")
+        if not include_exited and state == "exited":
+            continue
+        capabilities = sorted(getattr(role, "capabilities", set()))
+        rows.append(
+            {
+                "role_name": name,
+                "lifecycle_state": state,
+                "capabilities": capabilities,
+            }
+        )
+    return json.dumps(rows, sort_keys=True)
+
+
+def _active_alarms(role):
+    return [alarm for alarm in getattr(role, "alarms", []) if alarm.status == "active"]
+
+
+def create_alarm(employee_dict, agent_name, reminder, due_at, recurrence="once"):
+    try:
+        normalized_name = validate_role_name(agent_name)
+        due = _parse_datetime(due_at)
+    except ValueError as e:
+        return f"Error: {e}"
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+    if not isinstance(reminder, str) or not reminder.strip():
+        return "Error: Reminder must be a non-empty string."
+    recurrence = (recurrence or "once").strip().lower()
+    if recurrence not in ALARM_RECURRENCES:
+        return f"Error: Invalid recurrence '{recurrence}'."
+    role = employee_dict[normalized_name]
+    if len(_active_alarms(role)) >= 5:
+        return f"Error: Role '{normalized_name}' already has the maximum of 5 active alarms."
+    alarm = Alarm(
+        alarm_id=f"alarm-{uuid4()}",
+        agent_name=normalized_name,
+        reminder=reminder.strip(),
+        due_at=_format_datetime(due),
+        recurrence=recurrence,
+    )
+    role.alarms.append(alarm)
+    return f"Created alarm '{alarm.alarm_id}' for {normalized_name} at {alarm.due_at}."
+
+
+def list_alarms(employee_dict, agent_name, include_inactive=False):
+    try:
+        normalized_name = validate_role_name(agent_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+    alarms = []
+    for alarm in getattr(employee_dict[normalized_name], "alarms", []):
+        if alarm.status != "active" and not include_inactive:
+            continue
+        alarms.append(
+            {
+                "alarm_id": alarm.alarm_id,
+                "reminder": alarm.reminder,
+                "due_at": alarm.due_at,
+                "recurrence": alarm.recurrence,
+                "status": alarm.status,
+            }
+        )
+    return json.dumps(alarms, sort_keys=True)
+
+
+def cancel_alarm(employee_dict, agent_name, alarm_id):
+    try:
+        normalized_name = validate_role_name(agent_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+    for alarm in getattr(employee_dict[normalized_name], "alarms", []):
+        if alarm.alarm_id == alarm_id:
+            alarm.status = "canceled"
+            return f"Canceled alarm '{alarm_id}' for {normalized_name}."
+    return f"Error: Alarm '{alarm_id}' not found for {normalized_name}."
+
+
+def _require_memory_store():
+    if memory_store is None:
+        return None, "Error: No SQLite memory store is configured."
+    return memory_store, None
+
+
+def memory_search(employee_dict, agent_name, query, limit=10):
+    del employee_dict
+    store, error = _require_memory_store()
+    if error:
+        return error
+    try:
+        normalized_name = validate_role_name(agent_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if not isinstance(query, str) or not query.strip():
+        return "Error: Memory query must be a non-empty string."
+    results = store.search(query, agent_id=normalized_name, limit=int(limit or 10))
+    return json.dumps([result.__dict__ for result in results], sort_keys=True)
+
+
+def memory_list_digests(employee_dict, agent_name, digest_type=None, limit=10):
+    del employee_dict
+    store, error = _require_memory_store()
+    if error:
+        return error
+    try:
+        normalized_name = validate_role_name(agent_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    digests = store.list_memory_digests(
+        agent_id=normalized_name,
+        digest_type=digest_type,
+        current_only=True,
+        accessible_only=True,
+        limit=int(limit or 10),
+    )
+    return json.dumps(digests, sort_keys=True)
+
+
+def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True):
+    del employee_dict
+    store, error = _require_memory_store()
+    if error:
+        return error
+    try:
+        normalized_name = validate_role_name(agent_name)
+        digest_id = int(digest_id)
+    except ValueError as e:
+        return f"Error: {e}"
+    digest = store.get_memory_digest(digest_id)
+    if digest is None:
+        return f"Error: Memory digest '{digest_id}' not found."
+    if digest.get("agent_id") not in {None, normalized_name}:
+        return f"Error: Memory digest '{digest_id}' is not accessible to {normalized_name}."
+    if digest.get("system_only") or digest.get("accessibility") != "agent":
+        return f"Error: Memory digest '{digest_id}' is system-only."
+    rows = store.expand_memory_digest_sources(digest_id, recursive=recursive)
+    rows = [
+        {
+            **row.__dict__,
+            "source_path": list(row.source_path),
+        }
+        if hasattr(row, "__dict__")
+        else row
+        for row in rows
+    ]
+    return json.dumps(rows, sort_keys=True)
+
+
+def due_alarm_reminders(role, now=None):
+    now = now or datetime.now(timezone.utc)
+    reminders = []
+    for alarm in _active_alarms(role):
+        due = _parse_datetime(alarm.due_at)
+        if due > now:
+            continue
+        reminders.append(f"Reminder due at {alarm.due_at}: {alarm.reminder}")
+        if alarm.recurrence == "once":
+            alarm.status = "completed"
+        else:
+            delta = {
+                "hourly": timedelta(hours=1),
+                "daily": timedelta(days=1),
+                "weekly": timedelta(weeks=1),
+            }[alarm.recurrence]
+            while due <= now:
+                due += delta
+            alarm.due_at = _format_datetime(due)
+    return reminders
+
+
 def interact(self, model, sender, message):
     if self.template != "" and self.name not in self.conversation_history:
         self.conversation_history[self.name] = [
@@ -429,20 +855,8 @@ def interact(self, model, sender, message):
         messages.append({"role": "user", "content": message, "name": sender})
     print(colored(f"\n---\n// {self.name}\n{json.dumps(messages)}\n---\n", "grey"))
 
-    # Start a streaming session
-    stream = client.chat.completions.create(
-        model=model,
-        messages=messages,
-        max_tokens=self.max_tokens,
-        n=1,
-        temperature=self.temperature,
-        user=f"robits_{self.name}",
-        stream=True,
-    )
-    message = {"role": "assistant", "content": "", "name": self.name}
-    for chunk in stream:
-        if chunk.choices[0].delta.content is not None:
-            message["content"] += chunk.choices[0].delta.content
+    content = model_provider.generate(self, model, sender, messages)
+    message = {"role": "assistant", "content": content or "", "name": self.name}
 
     # Remove any additional whitespace and control characters
     message["content"] = message["content"].strip()
@@ -461,6 +875,7 @@ class Role:
     def __init__(self, name, template, employee_dict, group_template_additions=""):
         self.name = name
         self.template = template + group_template_additions
+        self.employee_dict = employee_dict
         self.conversation_history = {name: [] for name in employee_dict}
         self.group_conversation_history = {}
         self.global_conversation_history = []
@@ -468,6 +883,8 @@ class Role:
         self.max_tokens = random.randint(250, 400) # -1
         self.lifecycle_state = "active"
         self.lifecycle_events = []
+        self.capabilities = set()
+        self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
 
     def interact(self, sender, prompt):
@@ -538,6 +955,7 @@ class Ops(Role):
         super().__init__(
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
+        self.capabilities = {"operator"}
 
 
 class HR(Role):
@@ -551,6 +969,7 @@ You are part of the Human Resources group. To create a new role, send a message 
         super().__init__(
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
+        self.capabilities = {"hr", "protected", "essential"}
 
 
 class Angel(Role):
@@ -564,6 +983,7 @@ class SoftwareEngineer(Role):
         template = """As a Software Engineer (SE), you are responsible for designing, developing, and maintaining software applications. You primarily propose trusted tools when requested by others in your organization."""
         group_template_additions = """You are part of the Engineering group. Tools are trusted, repo-loaded functions described by namespaced OpenAI-compatible metadata. Propose tool behavior in plain language; do not assume untrusted chat output can define executable tools directly."""
         super().__init__(self.__class__.__name__, template, employee_dict, group_template_additions)
+        self.capabilities = {"engineer"}
 
     def interact(self, sender, prompt):
         return interact_costly(self, sender, prompt)
@@ -573,6 +993,10 @@ class Human(Role):
     def __init__(self):
         self.name = "CEO"
         self.template = "As CEO, you are responsible for making high-level decisions and setting the overall direction of the organization."
+        self.lifecycle_state = "active"
+        self.lifecycle_events = []
+        self.capabilities = {"protected", "essential"}
+        self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
 
     def interact(self, *_):
@@ -697,6 +1121,11 @@ class RoundRobinScheduler:
         if participant_name not in self.participant_names:
             self.participant_names.append(participant_name)
 
+    def remove_participant(self, participant_name):
+        if participant_name in self.participant_names and len(self.participant_names) > 1:
+            self.participant_names.remove(participant_name)
+            self.index %= len(self.participant_names)
+
 
 class Session:
     def __init__(
@@ -815,22 +1244,30 @@ class Session:
         )
 
     def sync_scheduler_participants(self):
-        for name in self.participants:
-            self.scheduler.add_participant(name)
+        for name, participant in self.participants.items():
+            if getattr(participant, "lifecycle_state", "active") == "active":
+                self.scheduler.add_participant(name)
+            else:
+                self.scheduler.remove_participant(name)
 
     def step(self, message):
         sender = self.last_receiver
+        self.sync_scheduler_participants()
         routed = self.route_message(message, sender.name)
         system_events = self.process_tool_instruction(message)
         self.sync_scheduler_participants()
-        response = routed.receiver.interact(sender.name, routed.prompt)
+        prompt = routed.prompt
+        reminders = due_alarm_reminders(routed.receiver)
+        if reminders:
+            prompt = "\n".join(reminders + [prompt])
+        response = routed.receiver.interact(sender.name, prompt)
         response = "" if response is None else response
         if routed.receiver.name != "CEO" and response != "":
             print(colored(f"{routed.receiver.name} responds: {response}", "cyan"))
         self.record_turn(
             sender=sender.name,
             receiver=routed.receiver.name,
-            prompt=routed.prompt,
+            prompt=prompt,
             response=response,
             directed=routed.directed,
             system_events=system_events,

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -38,6 +38,19 @@ class MemoryDigestSource:
     metadata: dict[str, Any]
 
 
+@dataclass(frozen=True)
+class ExpandedMemoryDigestSource:
+    source_table: str
+    source_id: str
+    source_created_at: str | None
+    position: int
+    depth: int
+    parent_digest_id: int
+    source_path: tuple[int, ...]
+    metadata: dict[str, Any]
+    record: dict[str, Any]
+
+
 class SQLiteMemoryStore:
     """Small repository API for durable local Robits memory records."""
 
@@ -177,6 +190,12 @@ class SQLiteMemoryStore:
                 agent_id TEXT,
                 session_id TEXT,
                 content TEXT NOT NULL,
+                digest_type TEXT NOT NULL DEFAULT 'episodic',
+                generation INTEGER NOT NULL DEFAULT 1,
+                version INTEGER NOT NULL DEFAULT 1,
+                superseded_by_digest_id INTEGER,
+                system_only INTEGER NOT NULL DEFAULT 0,
+                accessibility TEXT NOT NULL DEFAULT 'agent',
                 prompt_version TEXT NOT NULL,
                 source_start_at TEXT,
                 source_end_at TEXT,
@@ -232,13 +251,33 @@ class SQLiteMemoryStore:
             CREATE INDEX IF NOT EXISTS idx_tool_calls_agent ON tool_calls(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_entries_agent ON memory_entries(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_digests_agent ON memory_digests(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_memory_digests_current
+                ON memory_digests(digest_type, superseded_by_digest_id, accessibility, system_only);
             CREATE INDEX IF NOT EXISTS idx_memory_digest_sources_digest
                 ON memory_digest_sources(digest_id);
             CREATE INDEX IF NOT EXISTS idx_runtime_events_session ON runtime_events(session_id);
             CREATE INDEX IF NOT EXISTS idx_runtime_events_type ON runtime_events(event_type);
             """
         )
+        self._ensure_memory_digest_columns()
         self.connection.commit()
+
+    def _ensure_memory_digest_columns(self):
+        columns = {
+            row["name"]
+            for row in self.connection.execute("PRAGMA table_info(memory_digests)").fetchall()
+        }
+        migrations = {
+            "digest_type": "ALTER TABLE memory_digests ADD COLUMN digest_type TEXT NOT NULL DEFAULT 'episodic'",
+            "generation": "ALTER TABLE memory_digests ADD COLUMN generation INTEGER NOT NULL DEFAULT 1",
+            "version": "ALTER TABLE memory_digests ADD COLUMN version INTEGER NOT NULL DEFAULT 1",
+            "superseded_by_digest_id": "ALTER TABLE memory_digests ADD COLUMN superseded_by_digest_id INTEGER",
+            "system_only": "ALTER TABLE memory_digests ADD COLUMN system_only INTEGER NOT NULL DEFAULT 0",
+            "accessibility": "ALTER TABLE memory_digests ADD COLUMN accessibility TEXT NOT NULL DEFAULT 'agent'",
+        }
+        for column, statement in migrations.items():
+            if column not in columns:
+                self.connection.execute(statement)
 
     def create_session(self, session_id, title=None, started_at=None, metadata=None):
         created_at = started_at or _utc_now()
@@ -608,6 +647,12 @@ class SQLiteMemoryStore:
         source_refs,
         agent_id=None,
         session_id=None,
+        digest_type="episodic",
+        generation=None,
+        version=1,
+        supersedes_digest_ids=None,
+        system_only=False,
+        accessibility=None,
         prompt_version="memory-digest-v1",
         source_start_at=None,
         source_end_at=None,
@@ -619,22 +664,41 @@ class SQLiteMemoryStore:
     ):
         if not source_refs:
             raise ValueError("Memory digest requires at least one source reference.")
+        self._validate_digest_type(digest_type)
+        if version < 1:
+            raise ValueError("Memory digest version must be at least 1.")
+        if accessibility is None:
+            accessibility = "system" if system_only else "agent"
+        self._validate_digest_accessibility(accessibility)
         normalized_sources = self._normalize_digest_source_refs(source_refs)
+        if generation is None:
+            generation = self._next_digest_generation(normalized_sources)
+        if generation < 0:
+            raise ValueError("Memory digest generation must be non-negative.")
+        supersedes_digest_ids = [
+            int(digest_id) for digest_id in (supersedes_digest_ids or [])
+        ]
         timestamp = created_at or _utc_now()
         with self.connection:
             cursor = self.connection.execute(
                 """
                 INSERT INTO memory_digests(
-                    agent_id, session_id, content, prompt_version, source_start_at,
+                    agent_id, session_id, content, digest_type, generation, version,
+                    system_only, accessibility, prompt_version, source_start_at,
                     source_end_at, relationship_type, conversation_type, source,
                     created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     agent_id,
                     session_id,
                     content,
+                    digest_type,
+                    generation,
+                    version,
+                    1 if system_only else 0,
+                    accessibility,
                     prompt_version,
                     source_start_at,
                     source_end_at,
@@ -674,9 +738,96 @@ class SQLiteMemoryStore:
                 relationship_type,
                 conversation_type,
                 timestamp,
-                content,
-            )
+                    content,
+                )
+            for superseded_digest_id in supersedes_digest_ids:
+                self.connection.execute(
+                    """
+                    UPDATE memory_digests
+                    SET superseded_by_digest_id = ?
+                    WHERE digest_id = ?
+                    """,
+                    (digest_id, superseded_digest_id),
+                )
         return digest_id
+
+    def seed_memory_digest(
+        self,
+        digest_type,
+        content,
+        agent_id=None,
+        session_id=None,
+        prompt_version="memory-digest-seed-v1",
+        source="system_seed",
+        created_at=None,
+        metadata=None,
+        system_only=False,
+        accessibility=None,
+    ):
+        self._validate_digest_type(digest_type)
+        seed_id = self.append_memory_entry(
+            f"{digest_type}_digest_seed",
+            content,
+            agent_id=agent_id,
+            session_id=session_id,
+            source=source,
+            created_at=created_at,
+            metadata=metadata,
+        )
+        return self.append_memory_digest(
+            content,
+            [{"source_table": "memory_entries", "source_id": seed_id}],
+            agent_id=agent_id,
+            session_id=session_id,
+            digest_type=digest_type,
+            generation=0,
+            version=1,
+            system_only=system_only,
+            accessibility=accessibility,
+            prompt_version=prompt_version,
+            source=source,
+            created_at=created_at,
+            metadata=metadata,
+        )
+
+    def seed_identity_and_goal_digests(
+        self,
+        agent_id,
+        identity_content,
+        long_term_goal_content,
+        short_term_goal_content=None,
+        session_id=None,
+        created_at=None,
+        metadata=None,
+    ):
+        if short_term_goal_content is None:
+            short_term_goal_content = long_term_goal_content
+        return {
+            "identity": self.seed_memory_digest(
+                "identity",
+                identity_content,
+                agent_id=agent_id,
+                session_id=session_id,
+                created_at=created_at,
+                metadata=metadata,
+            ),
+            "goal_long_term": self.seed_memory_digest(
+                "goal_long_term",
+                long_term_goal_content,
+                agent_id=agent_id,
+                session_id=session_id,
+                created_at=created_at,
+                metadata=metadata,
+            ),
+            "goal_short_term": self.seed_memory_digest(
+                "goal_short_term",
+                short_term_goal_content,
+                agent_id=agent_id,
+                session_id=session_id,
+                created_at=created_at,
+                metadata=metadata,
+            ),
+        }
 
     def append_runtime_event(
         self,
@@ -773,7 +924,17 @@ class SQLiteMemoryStore:
             for row in rows
         ]
 
-    def expand_memory_digest_sources(self, digest_id):
+    def expand_memory_digest_sources(
+        self,
+        digest_id,
+        recursive=False,
+        include_digest_records=True,
+    ):
+        if recursive:
+            return self._expand_memory_digest_sources_recursive(
+                int(digest_id),
+                include_digest_records=include_digest_records,
+            )
         expanded = []
         for source_ref in self.get_memory_digest_sources(digest_id):
             row = self._fetch_source_record(source_ref.source_table, source_ref.source_id)
@@ -783,6 +944,54 @@ class SQLiteMemoryStore:
                 row["digest_position"] = source_ref.position
                 expanded.append(row)
         return expanded
+
+    def expand_memory_digest_source_tree(self, digest_id):
+        digest_id = int(digest_id)
+        digest = self.get_memory_digest(digest_id)
+        if digest is None:
+            return None
+        return {
+            "digest": digest,
+            "sources": self._build_memory_digest_source_tree(digest_id, visited=set()),
+        }
+
+    def list_memory_digests(
+        self,
+        agent_id=None,
+        session_id=None,
+        digest_type=None,
+        current_only=False,
+        accessible_only=False,
+        include_system_only=True,
+        limit=100,
+    ):
+        clauses = []
+        params: list[Any] = []
+        for column, value in (
+            ("agent_id", agent_id),
+            ("session_id", session_id),
+            ("digest_type", digest_type),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        if current_only:
+            clauses.append("superseded_by_digest_id IS NULL")
+        if accessible_only:
+            clauses.append("accessibility = 'agent'")
+            clauses.append("system_only = 0")
+        elif not include_system_only:
+            clauses.append("system_only = 0")
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return self._rows(
+            f"""
+            SELECT * FROM memory_digests
+            {where}
+            ORDER BY created_at, digest_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )
 
     def list_messages(self, session_id=None, agent_id=None, limit=100):
         clauses = []
@@ -947,6 +1156,16 @@ class SQLiteMemoryStore:
         }:
             raise ValueError(f"Unsupported memory digest source table: {source_table}")
 
+    def _validate_digest_type(self, digest_type):
+        if digest_type not in {"episodic", "identity", "goal_long_term", "goal_short_term"}:
+            raise ValueError(
+                "Memory digest type must be episodic, identity, goal_long_term, or goal_short_term."
+            )
+
+    def _validate_digest_accessibility(self, accessibility):
+        if accessibility not in {"agent", "system"}:
+            raise ValueError("Memory digest accessibility must be agent or system.")
+
     def _normalize_digest_source_refs(self, source_refs):
         normalized = []
         for source_ref in source_refs:
@@ -966,6 +1185,93 @@ class SQLiteMemoryStore:
                 }
             )
         return normalized
+
+    def _next_digest_generation(self, normalized_sources):
+        source_digest_ids = [
+            source_ref["source_id"]
+            for source_ref in normalized_sources
+            if source_ref["source_table"] == "memory_digests"
+        ]
+        if not source_digest_ids:
+            return 1
+        placeholders = ", ".join("?" for _ in source_digest_ids)
+        row = self.connection.execute(
+            f"""
+            SELECT MAX(generation) AS max_generation
+            FROM memory_digests
+            WHERE digest_id IN ({placeholders})
+            """,
+            source_digest_ids,
+        ).fetchone()
+        max_generation = row["max_generation"] if row else None
+        return (max_generation or 0) + 1
+
+    def _expand_memory_digest_sources_recursive(
+        self,
+        digest_id,
+        include_digest_records=True,
+    ):
+        expanded: list[ExpandedMemoryDigestSource] = []
+
+        def visit(current_digest_id, depth, path, visited):
+            if current_digest_id in visited:
+                return
+            next_visited = visited | {current_digest_id}
+            for source_ref in self.get_memory_digest_sources(current_digest_id):
+                row = self._fetch_source_record(source_ref.source_table, source_ref.source_id)
+                if row is None:
+                    continue
+                source_digest_id = (
+                    int(source_ref.source_id)
+                    if source_ref.source_table == "memory_digests"
+                    else None
+                )
+                next_path = path + ((source_digest_id,) if source_digest_id else ())
+                if source_ref.source_table != "memory_digests" or include_digest_records:
+                    expanded.append(
+                        ExpandedMemoryDigestSource(
+                            source_table=source_ref.source_table,
+                            source_id=source_ref.source_id,
+                            source_created_at=source_ref.source_created_at,
+                            position=source_ref.position,
+                            depth=depth,
+                            parent_digest_id=current_digest_id,
+                            source_path=next_path,
+                            metadata=source_ref.metadata,
+                            record=row,
+                        )
+                    )
+                if source_digest_id is not None:
+                    visit(source_digest_id, depth + 1, next_path, next_visited)
+
+        visit(digest_id, 0, (digest_id,), set())
+        return expanded
+
+    def _build_memory_digest_source_tree(self, digest_id, visited):
+        if digest_id in visited:
+            return []
+        next_visited = visited | {digest_id}
+        tree = []
+        for source_ref in self.get_memory_digest_sources(digest_id):
+            row = self._fetch_source_record(source_ref.source_table, source_ref.source_id)
+            if row is None:
+                continue
+            node = {
+                "source_table": source_ref.source_table,
+                "source_id": source_ref.source_id,
+                "source_created_at": source_ref.source_created_at,
+                "position": source_ref.position,
+                "metadata": source_ref.metadata,
+                "record": row,
+                "sources": [],
+            }
+            if source_ref.source_table == "memory_digests":
+                node["sources"] = self._build_memory_digest_source_tree(
+                    int(source_ref.source_id),
+                    next_visited,
+                )
+            tree.append(node)
+        return tree
 
     def _fetch_source_record(self, source_table, source_id):
         self._validate_source_table(source_table)

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -46,6 +46,17 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertIn("runtime_events", tables)
         self.assertIn("memory_fts", tables)
 
+        digest_columns = {
+            row["name"]
+            for row in store.connection.execute("PRAGMA table_info(memory_digests)")
+        }
+        self.assertIn("digest_type", digest_columns)
+        self.assertIn("generation", digest_columns)
+        self.assertIn("version", digest_columns)
+        self.assertIn("superseded_by_digest_id", digest_columns)
+        self.assertIn("system_only", digest_columns)
+        self.assertIn("accessibility", digest_columns)
+
     def test_append_and_lookup_messages_by_session_and_agent(self):
         store = self.seed_store()
 
@@ -321,6 +332,139 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual([row["source_table"] for row in expanded], ["messages", "tool_calls"])
         self.assertEqual(expanded[0]["content"], "Raw source message.")
         self.assertEqual(expanded[1]["result_content"], "Raw tool result.")
+
+    def test_memory_digest_can_use_digest_sources_and_expand_recursively(self):
+        store = self.seed_store()
+        message_id = store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Raw cascade source message.",
+        )
+        first_digest_id = store.append_memory_digest(
+            "First generation digest.",
+            [{"source_table": "messages", "source_id": message_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+        second_digest_id = store.append_memory_digest(
+            "Second generation digest.",
+            [{"source_table": "memory_digests", "source_id": first_digest_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+
+        second_digest = store.get_memory_digest(second_digest_id)
+        direct_sources = store.expand_memory_digest_sources(second_digest_id)
+        recursive_sources = store.expand_memory_digest_sources(second_digest_id, recursive=True)
+        tree = store.expand_memory_digest_source_tree(second_digest_id)
+
+        self.assertEqual(second_digest["generation"], 2)
+        self.assertEqual(direct_sources[0]["source_table"], "memory_digests")
+        self.assertEqual(recursive_sources[0].source_table, "memory_digests")
+        self.assertEqual(recursive_sources[1].source_table, "messages")
+        self.assertEqual(recursive_sources[1].record["content"], "Raw cascade source message.")
+        self.assertEqual(tree["sources"][0]["sources"][0]["record"]["content"], "Raw cascade source message.")
+
+    def test_memory_digest_current_accessibility_excludes_superseded_and_system_only(self):
+        store = self.seed_store()
+        message_id = store.append_message("session-1", "CEO", "SE", "Source.")
+        original_digest_id = store.append_memory_digest(
+            "Original accessible digest.",
+            [{"source_table": "messages", "source_id": message_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+        replacement_digest_id = store.append_memory_digest(
+            "Replacement accessible digest.",
+            [{"source_table": "memory_digests", "source_id": original_digest_id}],
+            agent_id="SE",
+            session_id="session-1",
+            supersedes_digest_ids=[original_digest_id],
+        )
+        system_digest_id = store.append_memory_digest(
+            "System-only reanalysis digest.",
+            [{"source_table": "memory_digests", "source_id": replacement_digest_id}],
+            agent_id="SE",
+            session_id="session-1",
+            system_only=True,
+        )
+
+        all_digests = store.list_memory_digests(agent_id="SE")
+        current_accessible = store.list_memory_digests(
+            agent_id="SE",
+            current_only=True,
+            accessible_only=True,
+        )
+        original_digest = store.get_memory_digest(original_digest_id)
+        system_digest = store.get_memory_digest(system_digest_id)
+
+        self.assertEqual(
+            {digest["digest_id"] for digest in all_digests},
+            {original_digest_id, replacement_digest_id, system_digest_id},
+        )
+        self.assertEqual([digest["digest_id"] for digest in current_accessible], [replacement_digest_id])
+        self.assertEqual(original_digest["superseded_by_digest_id"], replacement_digest_id)
+        self.assertEqual(system_digest["system_only"], 1)
+        self.assertEqual(system_digest["accessibility"], "system")
+
+    def test_seed_identity_and_goal_digest_records(self):
+        store = self.seed_store()
+
+        seeded = store.seed_identity_and_goal_digests(
+            "SE",
+            "Identity: SE owns reliable runtime changes.",
+            "Long-term goal: preserve agent lives.",
+            "Short-term goal: keep memory compact and reanalyzable.",
+            session_id="session-1",
+        )
+
+        identity_digest = store.get_memory_digest(seeded["identity"])
+        long_goal_digest = store.get_memory_digest(seeded["goal_long_term"])
+        short_goal_digest = store.get_memory_digest(seeded["goal_short_term"])
+        identity_sources = store.expand_memory_digest_sources(seeded["identity"])
+        short_goal_sources = store.expand_memory_digest_sources(seeded["goal_short_term"])
+
+        self.assertEqual(identity_digest["digest_type"], "identity")
+        self.assertEqual(long_goal_digest["digest_type"], "goal_long_term")
+        self.assertEqual(short_goal_digest["digest_type"], "goal_short_term")
+        self.assertEqual(identity_digest["generation"], 0)
+        self.assertEqual(short_goal_digest["generation"], 0)
+        self.assertEqual(identity_sources[0]["kind"], "identity_digest_seed")
+        self.assertEqual(short_goal_sources[0]["kind"], "goal_short_term_digest_seed")
+
+    def test_recursive_digest_expansion_can_return_raw_sources_without_digest_nodes(self):
+        store = self.seed_store()
+        thought_id = store.append_thought(
+            "SE",
+            "Raw thought remains available for automatic reanalysis.",
+            session_id="session-1",
+        )
+        first_digest_id = store.append_memory_digest(
+            "Digest of raw thought.",
+            [{"source_table": "thoughts", "source_id": thought_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+        second_digest_id = store.append_memory_digest(
+            "Digest of digest.",
+            [{"source_table": "memory_digests", "source_id": first_digest_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+
+        raw_sources = store.expand_memory_digest_sources(
+            second_digest_id,
+            recursive=True,
+            include_digest_records=False,
+        )
+
+        self.assertEqual(len(raw_sources), 1)
+        self.assertEqual(raw_sources[0].source_table, "thoughts")
+        self.assertEqual(
+            raw_sources[0].record["content"],
+            "Raw thought remains available for automatic reanalysis.",
+        )
 
     def test_memory_digest_requires_sources(self):
         store = self.seed_store()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,8 +4,11 @@ import tempfile
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import main
+from robits.memory.sqlite import SQLiteMemoryStore
 
 
 class FakeRole:
@@ -23,6 +26,16 @@ class FakeRole:
 
     def update_group_conversations(self, message):
         self.group_conversation_history.setdefault(self.name, []).append(message)
+
+
+class FakeCreate:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
 
 
 def build_fake_participants():
@@ -275,6 +288,60 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual([event.action for event in qa.lifecycle_events], ["create", "pause", "retire"])
         self.assertEqual(qa.lifecycle_events[-1].approved_by, "CEO")
 
+    def test_create_and_list_roles_include_capabilities(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            create_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "SRE",
+                            "role_description": "Operates runtime infrastructure.",
+                            "capabilities": ["operator", "kubeapi"],
+                        },
+                    }
+                )
+            )
+            list_response = system.interact(
+                json.dumps({"exec": "org.list_roles", "args": {}})
+            )
+
+        role_list = json.loads(list_response.split("Result: ", 1)[1])
+        sre = next(role for role in role_list if role["role_name"] == "SRE")
+
+        self.assertIn("Created a new role: SRE", create_response)
+        self.assertEqual(sre["capabilities"], ["kubeapi", "operator"])
+
+    def test_archive_role_rejects_protected_roles_and_exits_eligible_role(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            protected_response = system.interact(
+                json.dumps({"exec": "org.archive_role", "args": {"role_name": "CEO"}})
+            )
+            system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+            )
+            archived_response = system.interact(
+                json.dumps({"exec": "org.archive_role", "args": {"role_name": "QA"}})
+            )
+
+        self.assertIn("protected", protected_response)
+        self.assertIn("exited", archived_response)
+        self.assertEqual(employee_dict["QA"].lifecycle_state, "exited")
+
     def test_lifecycle_rejects_invalid_transitions_without_new_event(self):
         employee_dict = main.build_employee_dict()
         system = main.System(employee_dict)
@@ -456,6 +523,81 @@ class RuntimeTests(unittest.TestCase):
             tool["function"]["parameters"]["required"],
             ["role_name", "role_description"],
         )
+
+    def test_responses_provider_executes_registered_function_call(self):
+        employee_dict = main.build_employee_dict()
+        role = employee_dict["Ops"]
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+
+        first_response = SimpleNamespace(
+            id="response-1",
+            output=[
+                SimpleNamespace(
+                    type="function_call",
+                    call_id="call-1",
+                    name="org__create_role",
+                    arguments=json.dumps(
+                        {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        }
+                    ),
+                )
+            ],
+        )
+        final_response = SimpleNamespace(id="response-2", output_text="Created QA.")
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                create=FakeCreate([first_response, final_response])
+            )
+        )
+        provider = main.ResponsesProvider(fake_client)
+
+        response = provider.generate(
+            role,
+            "test-model",
+            "CEO",
+            [{"role": "user", "content": "create QA", "name": "CEO"}],
+        )
+
+        self.assertEqual(response, "Created QA.")
+        self.assertIn("QA", employee_dict)
+        second_call = fake_client.responses.create.calls[1]
+        self.assertEqual(second_call["previous_response_id"], "response-1")
+        self.assertEqual(second_call["input"][0]["type"], "function_call_output")
+        self.assertIn("Created a new role: QA", second_call["input"][0]["output"])
+
+    def test_model_retry_retries_rate_limit_errors(self):
+        attempts = []
+        original_retries = main.max_api_retries
+        original_base = main.api_retry_base_seconds
+        original_max = main.api_retry_max_seconds
+        try:
+            main.max_api_retries = 2
+            main.api_retry_base_seconds = 0
+            main.api_retry_max_seconds = 0
+
+            class FakeRateLimit(Exception):
+                status_code = 429
+
+            def operation():
+                attempts.append("attempt")
+                if len(attempts) == 1:
+                    raise FakeRateLimit("too many requests")
+                return "ok"
+
+            with patch("main.time.sleep") as sleep:
+                result = main._with_model_retries(operation)
+        finally:
+            main.max_api_retries = original_retries
+            main.api_retry_base_seconds = original_base
+            main.api_retry_max_seconds = original_max
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(len(attempts), 2)
+        sleep.assert_not_called()
 
     def test_namespaced_exec_resolves_tool(self):
         employee_dict = main.build_employee_dict()
@@ -745,6 +887,137 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("QA", session.scheduler.participant_names)
         self.assertEqual(len(session.transcript[0].system_events), 1)
         self.assertIn("Created a new role: QA", session.transcript[0].system_events[0])
+
+    def test_exited_role_is_removed_from_scheduler(self):
+        participants = build_fake_participants()
+        participants["QA"] = FakeRole("QA", ["done"])
+        participants["QA"].lifecycle_state = "exited"
+        session = main.Session(participants=participants, run_id="session-1")
+
+        session.sync_scheduler_participants()
+
+        self.assertNotIn("QA", session.scheduler.participant_names)
+
+    def test_alarm_tools_create_list_and_cancel_alarm(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            create_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.create_alarm",
+                        "args": {
+                            "agent_name": "SE",
+                            "reminder": "Check build health.",
+                            "due_at": "2026-05-08T10:00:00+00:00",
+                        },
+                    }
+                )
+            )
+            alarm_id = employee_dict["SE"].alarms[0].alarm_id
+            list_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.list_alarms",
+                        "args": {"agent_name": "SE"},
+                    }
+                )
+            )
+            cancel_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.cancel_alarm",
+                        "args": {"agent_name": "SE", "alarm_id": alarm_id},
+                    }
+                )
+            )
+
+        alarms = json.loads(list_response.split("Result: ", 1)[1])
+
+        self.assertIn("Created alarm", create_response)
+        self.assertEqual(alarms[0]["reminder"], "Check build health.")
+        self.assertIn("Canceled alarm", cancel_response)
+        self.assertEqual(employee_dict["SE"].alarms[0].status, "canceled")
+
+    def test_memory_tools_search_list_and_expand_accessible_digests(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        original_store = main.memory_store
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = SQLiteMemoryStore(os.path.join(temp_dir, "memory.sqlite3"))
+            try:
+                store.create_session("session-1")
+                store.upsert_agent("SE", "SoftwareEngineer", "SE")
+                message_id = store.append_message(
+                    "session-1",
+                    "SE",
+                    "SE",
+                    "Robits should preserve source memory.",
+                )
+                digest_id = store.append_memory_digest(
+                    "Digest: preserve source memory.",
+                    [{"source_table": "messages", "source_id": message_id}],
+                    agent_id="SE",
+                    session_id="session-1",
+                    digest_type="identity",
+                )
+                main.memory_store = store
+                with redirect_stdout(StringIO()):
+                    main.load_tools(system)
+                    search_response = system.interact(
+                        json.dumps(
+                            {
+                                "exec": "memory.search",
+                                "args": {"agent_name": "SE", "query": "preserve"},
+                            }
+                        )
+                    )
+                    list_response = system.interact(
+                        json.dumps(
+                            {
+                                "exec": "memory.list_digests",
+                                "args": {"agent_name": "SE", "digest_type": "identity"},
+                            }
+                        )
+                    )
+                    expand_response = system.interact(
+                        json.dumps(
+                            {
+                                "exec": "memory.expand_digest",
+                                "args": {"agent_name": "SE", "digest_id": digest_id},
+                            }
+                        )
+                    )
+            finally:
+                main.memory_store = original_store
+                store.close()
+
+        search_results = json.loads(search_response.split("Result: ", 1)[1])
+        digest_results = json.loads(list_response.split("Result: ", 1)[1])
+        expanded = json.loads(expand_response.split("Result: ", 1)[1])
+
+        self.assertTrue(search_results)
+        self.assertEqual(digest_results[0]["digest_id"], digest_id)
+        self.assertEqual(expanded[0]["record"]["content"], "Robits should preserve source memory.")
+
+    def test_due_alarm_is_injected_into_agent_prompt(self):
+        participants = build_fake_participants()
+        participants["Ops"].alarms = [
+            main.Alarm(
+                alarm_id="alarm-1",
+                agent_name="Ops",
+                reminder="Review runtime load.",
+                due_at="2026-05-08T10:00:00+00:00",
+            )
+        ]
+        session = main.Session(participants=participants, run_id="session-1")
+
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="hello", max_turns=1)
+
+        self.assertIn("Reminder due at", participants["Ops"].received[0][1])
+        self.assertEqual(participants["Ops"].alarms[0].status, "completed")
 
     def test_session_emits_headless_runtime_events(self):
         participants = build_fake_participants()

--- a/tools.yaml
+++ b/tools.yaml
@@ -11,6 +11,11 @@
       role_description:
         type: string
         description: The responsibilities and purpose of the new role.
+      capabilities:
+        type: array
+        items:
+          type: string
+        description: Optional role capability flags such as operator, hr, kubeapi, protected, or essential.
       requested_by:
         type: string
         description: The agent or human requesting the lifecycle change.
@@ -25,9 +30,21 @@
         employee_dict,
         role_name,
         role_description,
+        capabilities=capabilities,
         requested_by=requested_by,
         approved_by=approved_by,
     )
+- name: org.list_roles
+  description: List roles in the organization with lifecycle state and capability flags.
+  parameters:
+    type: object
+    properties:
+      include_exited:
+        type: boolean
+        description: Include roles archived out of organization scheduling.
+    required: []
+  code: |
+    return list_lifecycle_roles(employee_dict, include_exited=include_exited if include_exited is not None else True)
 - name: org.pause_role
   description: Pause an active role in the organization.
   parameters:
@@ -81,4 +98,180 @@
         requested_by=requested_by,
         approved_by=approved_by,
         reason=reason,
+    )
+- name: org.archive_role
+  aliases:
+    - org.remove_role
+  description: Archive an eligible role out of active organization scheduling without deleting its data.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: The name of the role to archive.
+      requested_by:
+        type: string
+        description: The agent or human requesting the lifecycle change.
+      approved_by:
+        type: string
+        description: The agent or human approving the lifecycle change.
+      reason:
+        type: string
+        description: The reason for archiving the role.
+    required:
+      - role_name
+  code: |
+    return archive_lifecycle_role(
+        employee_dict,
+        role_name,
+        requested_by=requested_by,
+        approved_by=approved_by,
+        reason=reason,
+    )
+- name: agent.create_alarm
+  description: Create a one-shot or recurring reminder alarm for an agent.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: The agent that owns the alarm.
+      reminder:
+        type: string
+        description: Reminder text shown to the agent when the alarm is due.
+      due_at:
+        type: string
+        description: ISO datetime when the alarm is next due.
+      recurrence:
+        type: string
+        enum:
+          - once
+          - hourly
+          - daily
+          - weekly
+        description: Optional recurrence interval.
+    required:
+      - agent_name
+      - reminder
+      - due_at
+  code: |
+    return create_alarm(
+        employee_dict,
+        agent_name,
+        reminder,
+        due_at,
+        recurrence=recurrence if recurrence is not None else "once",
+    )
+- name: agent.list_alarms
+  description: List an agent's alarms.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: The agent that owns the alarms.
+      include_inactive:
+        type: boolean
+        description: Include canceled and completed alarms.
+    required:
+      - agent_name
+  code: |
+    return list_alarms(
+        employee_dict,
+        agent_name,
+        include_inactive=include_inactive if include_inactive is not None else False,
+    )
+- name: agent.cancel_alarm
+  aliases:
+    - agent.delete_alarm
+  description: Cancel an agent alarm by ID.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: The agent that owns the alarm.
+      alarm_id:
+        type: string
+        description: Alarm ID to cancel.
+    required:
+      - agent_name
+      - alarm_id
+  code: |
+    return cancel_alarm(employee_dict, agent_name, alarm_id)
+- name: memory.search
+  description: Search an agent's accessible SQLite memory records.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: The agent performing memory introspection.
+      query:
+        type: string
+        description: Full-text memory search query.
+      limit:
+        type: integer
+        description: Maximum number of records to return.
+    required:
+      - agent_name
+      - query
+  code: |
+    return memory_search(
+        employee_dict,
+        agent_name,
+        query,
+        limit=limit if limit is not None else 10,
+    )
+- name: memory.list_digests
+  description: List an agent's current accessible memory digests.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: The agent performing memory introspection.
+      digest_type:
+        type: string
+        enum:
+          - episodic
+          - identity
+          - goal_long_term
+          - goal_short_term
+        description: Optional digest type filter.
+      limit:
+        type: integer
+        description: Maximum number of digests to return.
+    required:
+      - agent_name
+  code: |
+    return memory_list_digests(
+        employee_dict,
+        agent_name,
+        digest_type=digest_type,
+        limit=limit if limit is not None else 10,
+    )
+- name: memory.expand_digest
+  description: Expand an accessible memory digest into its source records.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: The agent performing memory introspection.
+      digest_id:
+        type: integer
+        description: The digest ID to expand.
+      recursive:
+        type: boolean
+        description: Include cascading digest sources recursively.
+    required:
+      - agent_name
+      - digest_id
+  code: |
+    return memory_expand_digest(
+        employee_dict,
+        agent_name,
+        digest_id,
+        recursive=recursive if recursive is not None else True,
     )


### PR DESCRIPTION
## Summary
- add Responses-first provider support with native trusted tool-call execution, Chat Completions fallback, retry/backoff handling, and local max parallelism control
- extend SQLite memory digests with cascading metadata, supersession, system-only accessibility, seed identity/goal digests, and recursive expansion
- add role capability flags, protected archive/exited lifecycle behavior, agent alarm tools, and memory introspection tools

## Validation
- `py -3 -m unittest tests.test_memory_store`
- `py -3 -m unittest` with a temporary 
 
OpenAI import stub because the local OpenAI dependency is blocked by application control in this shell
- `git diff --check`

Closes #28
Closes #29
Closes #30 
Closes #31 

Created by Codex GPT-5.5 on behalf of the user.