### PR TITLE
Add managed role tool governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Trusted tools live in `tools.yaml`. Each entry includes a namespaced `name`, a J
 Agents can use trusted alarm tools to create, list, and cancel their own reminders,
 and memory tools to inspect accessible SQLite memory. Memory digest creation and
 re-digestion remain automatic system behavior rather than agent-callable tools.
+Roles carry tool grants such as `agent.*` or `memory.search`; model providers
+only expose tools allowed for the active role, and execution denies disallowed
+tool calls. Operator roles can grant or revoke tool access, SE can propose
+non-system tool changes, and system tools such as memory internals and HR role
+management cannot be changed through SE proposals.
 
 Example execution payload:
 

--- a/docs/architecture-vision.md
+++ b/docs/architecture-vision.md
@@ -102,6 +102,13 @@ The registry should keep supporting:
 - JSON Schema parameters
 - explicit tool-call result records
 
+Tools also need role-level governance. Each role has explicit tool grants such
+as `agent.*` or `memory.search`; provider adapters expose only tools allowed for
+the active role, and runtime execution rejects disallowed requests. Operators
+own grant and revoke actions. SE can propose non-system tool changes, but system
+tools such as memory introspection, role lifecycle management, and runtime
+operator controls stay protected trusted artifacts.
+
 Local OpenAI-compatible servers are a validation target, but durable docs should
 describe the generic API shape rather than a machine-specific endpoint or model.
 Structured output should be capability-gated: prefer provider-native schema

--- a/main.py
+++ b/main.py
@@ -69,6 +69,11 @@ class ToolDefinition:
     required_args: list[str]
     func: object
     aliases: tuple[str, ...] = ()
+    namespace: str = ""
+    required_capabilities: tuple[str, ...] = ()
+    owner_capability: str | None = None
+    system_tool: bool = False
+    grantable: bool = True
 
     @property
     def openai_name(self):
@@ -158,6 +163,10 @@ class ToolRegistry:
                 "memory_search": memory_search,
                 "memory_list_digests": memory_list_digests,
                 "memory_expand_digest": memory_expand_digest,
+                "grant_tool_access": grant_tool_access,
+                "revoke_tool_access": revoke_tool_access,
+                "list_registered_tools": list_registered_tools,
+                "propose_tool_change": propose_tool_change,
             },
             local_dict,
         )
@@ -196,10 +205,21 @@ class ToolRegistry:
             code = instruction["code"]
             aliases = tuple(instruction.get("aliases", ()))
 
+        namespace = instruction.get("namespace") or name.split(".", 1)[0]
+        required_capabilities = tuple(instruction.get("required_capabilities", ()))
+        owner_capability = instruction.get("owner_capability")
+        system_tool = bool(instruction.get("system_tool", False))
+        grantable = bool(instruction.get("grantable", True))
         required = parameters.get("required", [])
         properties = parameters.get("properties", {})
         if not isinstance(properties, dict) or not isinstance(required, list):
             raise ValueError("Tool parameters must contain object properties and required list.")
+        if not isinstance(required_capabilities, tuple) or not all(
+            isinstance(capability, str) for capability in required_capabilities
+        ):
+            raise ValueError("Tool required_capabilities must be a list of strings.")
+        if owner_capability is not None and not isinstance(owner_capability, str):
+            raise ValueError("Tool owner_capability must be a string.")
         required_arg_names = []
         for arg_name in required:
             if not isinstance(arg_name, str) or arg_name not in properties:
@@ -207,10 +227,36 @@ class ToolRegistry:
             required_arg_names.append(arg_name)
         arg_names = list(properties)
 
-        return name, description, parameters, arg_names, required_arg_names, code, aliases
+        return (
+            name,
+            description,
+            parameters,
+            arg_names,
+            required_arg_names,
+            code,
+            aliases,
+            namespace,
+            required_capabilities,
+            owner_capability,
+            system_tool,
+            grantable,
+        )
 
     def register_definition(self, instruction):
-        name, description, parameters, arg_names, required_arg_names, code, aliases = self.normalize_definition(instruction)
+        (
+            name,
+            description,
+            parameters,
+            arg_names,
+            required_arg_names,
+            code,
+            aliases,
+            namespace,
+            required_capabilities,
+            owner_capability,
+            system_tool,
+            grantable,
+        ) = self.normalize_definition(instruction)
         if name in self._tools:
             raise ValueError(f"Tool '{name}' already exists.")
         for alias in aliases:
@@ -226,6 +272,11 @@ class ToolRegistry:
             required_args=required_arg_names,
             func=func,
             aliases=aliases,
+            namespace=namespace,
+            required_capabilities=required_capabilities,
+            owner_capability=owner_capability,
+            system_tool=system_tool,
+            grantable=grantable,
         )
         openai_name = tool.openai_name
         if openai_name != name and (openai_name in self._aliases or openai_name in self._tools):
@@ -237,7 +288,32 @@ class ToolRegistry:
             self._aliases[openai_name] = name
         return tool
 
-    def execute(self, name, args, employee_dict):
+    def list_tools(self, include_system=True, role=None, include_denied=True):
+        rows = []
+        for tool in sorted(self._tools.values(), key=lambda item: item.name):
+            if tool.system_tool and not include_system:
+                continue
+            allowed = role is None or role_can_use_tool(role, tool)
+            if not include_denied and not allowed:
+                continue
+            rows.append(
+                {
+                    "name": tool.name,
+                    "namespace": tool.namespace,
+                    "description": tool.description,
+                    "required_capabilities": list(tool.required_capabilities),
+                    "owner_capability": tool.owner_capability,
+                    "system_tool": tool.system_tool,
+                    "grantable": tool.grantable,
+                    "allowed": allowed,
+                }
+            )
+        return rows
+
+    def tools_for_role(self, role):
+        return [tool for tool in self._tools.values() if role_can_use_tool(role, tool)]
+
+    def execute(self, name, args, employee_dict, caller=None):
         try:
             self.validate_tool_name(name)
         except ValueError as e:
@@ -246,6 +322,8 @@ class ToolRegistry:
         if resolved_name not in self._tools:
             return f"Error: Tool '{name}' not found."
         tool = self._tools[resolved_name]
+        if caller is not None and not role_can_use_tool(caller, tool):
+            return f"Error: Role '{caller.name}' is not allowed to use tool '{resolved_name}'."
         missing_args = [arg_name for arg_name in tool.required_args if arg_name not in args]
         if missing_args:
             return f"Error: Missing args for tool '{name}': {missing_args}"
@@ -255,11 +333,13 @@ class ToolRegistry:
         result = tool.func(employee_dict=employee_dict, **args)
         return f"Executed tool '{resolved_name}' with args {args}. Result: {result}"
 
-    def as_responses_tools(self):
-        return [tool.as_responses_tool() for tool in self._tools.values()]
+    def as_responses_tools(self, role=None):
+        tools = self._tools.values() if role is None else self.tools_for_role(role)
+        return [tool.as_responses_tool() for tool in tools]
 
-    def as_chat_completion_tools(self):
-        return [tool.as_chat_completion_tool() for tool in self._tools.values()]
+    def as_chat_completion_tools(self, role=None):
+        tools = self._tools.values() if role is None else self.tools_for_role(role)
+        return [tool.as_chat_completion_tool() for tool in tools]
 
 
 tool_registry = ToolRegistry()
@@ -351,7 +431,7 @@ class ResponsesProvider(ModelProvider):
 
     def generate(self, role, model, sender, messages):
         employee_dict = getattr(role, "employee_dict", None)
-        tools = self.registry.as_responses_tools()
+        tools = self.registry.as_responses_tools(role)
         kwargs = {
             "model": model,
             "input": messages,
@@ -377,7 +457,12 @@ class ResponsesProvider(ModelProvider):
                 except json.JSONDecodeError as error:
                     result = f"Error: Invalid tool arguments JSON: {error}"
                 else:
-                    result = self.registry.execute(getattr(call, "name", ""), args, employee_dict)
+                    result = self.registry.execute(
+                        getattr(call, "name", ""),
+                        args,
+                        employee_dict,
+                        caller=role,
+                    )
                 outputs.append(
                     {
                         "type": "function_call_output",
@@ -468,6 +553,130 @@ def _normalize_capabilities(capabilities=None):
     return normalized
 
 
+def _normalize_tool_grants(tool_grants=None):
+    if tool_grants is None:
+        return set()
+    if isinstance(tool_grants, str):
+        raw = [tool_grants]
+    else:
+        raw = list(tool_grants)
+    normalized = set()
+    for grant in raw:
+        if not isinstance(grant, str) or not grant.strip():
+            raise ValueError("Tool grants must be non-empty strings.")
+        normalized.add(grant.strip())
+    return normalized
+
+
+def _tool_grant_matches(tool_name, grant):
+    if grant == "*":
+        return True
+    if grant.endswith(".*"):
+        return tool_name.startswith(grant[:-1])
+    return tool_name == grant
+
+
+def role_can_use_tool(role, tool):
+    if getattr(role, "name", None) == "CEO":
+        return True
+    capabilities = getattr(role, "capabilities", set())
+    if tool.required_capabilities and not set(tool.required_capabilities).issubset(capabilities):
+        return False
+    grants = getattr(role, "allowed_tools", set())
+    return any(_tool_grant_matches(tool.name, grant) for grant in grants)
+
+
+def grant_tool_access(employee_dict, role_name, tool_name, granted_by=None):
+    try:
+        normalized_name = validate_role_name(role_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if tool_name == "*":
+        pass
+    elif tool_name.endswith(".*"):
+        try:
+            tool_registry.validate_tool_name(tool_name[:-2])
+        except ValueError as e:
+            return f"Error: {e}"
+    else:
+        try:
+            tool_registry.validate_tool_name(tool_name)
+        except ValueError as e:
+            return f"Error: {e}"
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+    if tool_name != "*" and not tool_name.endswith(".*") and tool_name not in tool_registry:
+        return f"Error: Tool '{tool_name}' not found."
+    if tool_name.endswith(".*"):
+        namespace = tool_name[:-2]
+        if not any(tool.name.startswith(f"{namespace}.") for tool in tool_registry._tools.values()):
+            return f"Error: Tool namespace '{namespace}' not found."
+    role = employee_dict[normalized_name]
+    role.allowed_tools.add(tool_name)
+    actor_text = f" by {granted_by}" if granted_by else ""
+    return f"Granted tool access '{tool_name}' to role '{normalized_name}'{actor_text}."
+
+
+def revoke_tool_access(employee_dict, role_name, tool_name, revoked_by=None):
+    try:
+        normalized_name = validate_role_name(role_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if normalized_name not in employee_dict:
+        return f"Error: Role '{normalized_name}' not found."
+    role = employee_dict[normalized_name]
+    if tool_name not in role.allowed_tools:
+        return f"Error: Role '{normalized_name}' does not have grant '{tool_name}'."
+    role.allowed_tools.remove(tool_name)
+    actor_text = f" by {revoked_by}" if revoked_by else ""
+    return f"Revoked tool access '{tool_name}' from role '{normalized_name}'{actor_text}."
+
+
+def list_registered_tools(employee_dict, role_name=None, include_system=True, only_allowed=False):
+    role = None
+    if role_name:
+        try:
+            normalized_name = validate_role_name(role_name)
+        except ValueError as e:
+            return f"Error: {e}"
+        if normalized_name not in employee_dict:
+            return f"Error: Role '{normalized_name}' not found."
+        role = employee_dict[normalized_name]
+    return json.dumps(
+        tool_registry.list_tools(
+            include_system=include_system,
+            role=role,
+            include_denied=not only_allowed,
+        ),
+        sort_keys=True,
+    )
+
+
+def propose_tool_change(employee_dict, requested_by, tool_name, description, action="create"):
+    del employee_dict
+    try:
+        tool_registry.validate_tool_name(tool_name)
+    except ValueError as e:
+        return f"Error: {e}"
+    if not isinstance(description, str) or not description.strip():
+        return "Error: Tool proposal description must be a non-empty string."
+    if action not in {"create", "update"}:
+        return f"Error: Tool proposal action must be create or update."
+    if tool_name in tool_registry:
+        tool = tool_registry.get(tool_name)
+        if tool.system_tool:
+            return f"Error: System tool '{tool_name}' cannot be changed by SE proposal."
+    proposal = {
+        "proposal_id": f"tool-proposal-{uuid4()}",
+        "requested_by": requested_by,
+        "tool_name": tool_name,
+        "action": action,
+        "description": description.strip(),
+        "status": "proposed",
+    }
+    return json.dumps(proposal, sort_keys=True)
+
+
 def validate_role_name(role_name):
     if not isinstance(role_name, str) or not role_name.strip():
         raise ValueError("Role name must be a non-empty string.")
@@ -522,6 +731,7 @@ def create_lifecycle_role(
     role_name,
     role_description,
     capabilities=None,
+    tool_grants=None,
     requested_by=None,
     approved_by=None,
 ):
@@ -529,6 +739,7 @@ def create_lifecycle_role(
         normalized_name = validate_role_name(role_name)
         normalized_description = validate_role_description(role_description)
         normalized_capabilities = _normalize_capabilities(capabilities)
+        normalized_tool_grants = _normalize_tool_grants(tool_grants)
     except ValueError as e:
         return f"Error: {e}"
     if normalized_name in employee_dict:
@@ -538,6 +749,7 @@ def create_lifecycle_role(
 
     new_role = Role(normalized_name, normalized_description, employee_dict)
     new_role.capabilities = normalized_capabilities
+    new_role.allowed_tools.update(normalized_tool_grants)
     record_lifecycle_event(
         new_role,
         action="create",
@@ -675,11 +887,13 @@ def list_lifecycle_roles(employee_dict, include_exited=True):
         if not include_exited and state == "exited":
             continue
         capabilities = sorted(getattr(role, "capabilities", set()))
+        tool_grants = sorted(getattr(role, "allowed_tools", set()))
         rows.append(
             {
                 "role_name": name,
                 "lifecycle_state": state,
                 "capabilities": capabilities,
+                "tool_grants": tool_grants,
             }
         )
     return json.dumps(rows, sort_keys=True)
@@ -884,6 +1098,7 @@ class Role:
         self.lifecycle_state = "active"
         self.lifecycle_events = []
         self.capabilities = set()
+        self.allowed_tools = {"agent.*", "memory.search", "memory.list_digests", "memory.expand_digest"}
         self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
 
@@ -909,7 +1124,7 @@ class System(Role):
         self.employee_dict = employee_dict if employee_dict is not None else {}
         self.tools = registry if registry is not None else tool_registry
 
-    def handle_instruction(self, instruction, trusted=False):
+    def handle_instruction(self, instruction, trusted=False, caller=None):
         if not isinstance(instruction, dict):
             return "Error: JSON instruction must be an object."
 
@@ -923,10 +1138,10 @@ class System(Role):
             args = instruction.get("args", {})
             if not isinstance(args, dict):
                 return "Error: Tool args must be an object."
-            return self.tools.execute(tool_name, args, self.employee_dict)
+            return self.tools.execute(tool_name, args, self.employee_dict, caller=caller)
         return "Error: JSON instruction must include a tool definition or exec."
 
-    def interact(self, prompt, trusted=False):
+    def interact(self, prompt, trusted=False, caller=None):
         print(colored(f"\n---\n// {self.name}\n{prompt}\n---\n", "grey"))
 
         prompt_text = prompt.strip() if isinstance(prompt, str) else ""
@@ -935,11 +1150,11 @@ class System(Role):
                 instruction = json.loads(prompt_text)
                 if isinstance(instruction, list):
                     responses = [
-                        self.handle_instruction(item, trusted=trusted)
+                        self.handle_instruction(item, trusted=trusted, caller=caller)
                         for item in instruction
                     ]
                     return "\n".join(responses)
-                return self.handle_instruction(instruction, trusted=trusted)
+                return self.handle_instruction(instruction, trusted=trusted, caller=caller)
             except json.JSONDecodeError as e:
                 return f"Error: {e}"
             except Exception as e:
@@ -956,6 +1171,7 @@ class Ops(Role):
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
         self.capabilities = {"operator"}
+        self.allowed_tools.update({"tools.*", "org.list_roles"})
 
 
 class HR(Role):
@@ -970,6 +1186,7 @@ You are part of the Human Resources group. To create a new role, send a message 
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
         self.capabilities = {"hr", "protected", "essential"}
+        self.allowed_tools.update({"org.*", "tools.list"})
 
 
 class Angel(Role):
@@ -984,6 +1201,7 @@ class SoftwareEngineer(Role):
         group_template_additions = """You are part of the Engineering group. Tools are trusted, repo-loaded functions described by namespaced OpenAI-compatible metadata. Propose tool behavior in plain language; do not assume untrusted chat output can define executable tools directly."""
         super().__init__(self.__class__.__name__, template, employee_dict, group_template_additions)
         self.capabilities = {"engineer"}
+        self.allowed_tools.update({"tools.list", "tools.propose"})
 
     def interact(self, sender, prompt):
         return interact_costly(self, sender, prompt)
@@ -996,6 +1214,7 @@ class Human(Role):
         self.lifecycle_state = "active"
         self.lifecycle_events = []
         self.capabilities = {"protected", "essential"}
+        self.allowed_tools = {"*"}
         self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
 
@@ -1184,14 +1403,14 @@ class Session:
         )
         return RoutedMessage(self.participants[receiver_name], message, False)
 
-    def process_tool_instruction(self, message):
+    def process_tool_instruction(self, message, sender=None):
         if not isinstance(message, str) or message == "":
             return []
         tool_instruction = parse_tool_instruction(message)
         if tool_instruction is None or tool_instruction == "":
             return []
 
-        system_response = self.system.interact(tool_instruction)
+        system_response = self.system.interact(tool_instruction, caller=sender)
         print(colored(f"System: {system_response}", "blue"))
         self.event_stream.emit(
             "tool.executed",
@@ -1254,7 +1473,7 @@ class Session:
         sender = self.last_receiver
         self.sync_scheduler_participants()
         routed = self.route_message(message, sender.name)
-        system_events = self.process_tool_instruction(message)
+        system_events = self.process_tool_instruction(message, sender=sender)
         self.sync_scheduler_participants()
         prompt = routed.prompt
         reminders = due_alarm_reminders(routed.receiver)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -314,6 +314,10 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertIn("Created a new role: SRE", create_response)
         self.assertEqual(sre["capabilities"], ["kubeapi", "operator"])
+        self.assertEqual(
+            sre["tool_grants"],
+            ["agent.*", "memory.expand_digest", "memory.list_digests", "memory.search"],
+        )
 
     def test_archive_role_rejects_protected_roles_and_exits_eligible_role(self):
         employee_dict = main.build_employee_dict()
@@ -341,6 +345,28 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("protected", protected_response)
         self.assertIn("exited", archived_response)
         self.assertEqual(employee_dict["QA"].lifecycle_state, "exited")
+
+    def test_create_role_can_seed_tool_grants(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "Research",
+                            "role_description": "Explores memory.",
+                            "tool_grants": ["memory.search"],
+                        },
+                    }
+                ),
+                caller=employee_dict["HR"],
+            )
+
+        self.assertIn("Created a new role: Research", response)
+        self.assertIn("memory.search", employee_dict["Research"].allowed_tools)
 
     def test_lifecycle_rejects_invalid_transitions_without_new_event(self):
         employee_dict = main.build_employee_dict()
@@ -526,7 +552,7 @@ class RuntimeTests(unittest.TestCase):
 
     def test_responses_provider_executes_registered_function_call(self):
         employee_dict = main.build_employee_dict()
-        role = employee_dict["Ops"]
+        role = employee_dict["HR"]
         system = main.System(employee_dict)
         with redirect_stdout(StringIO()):
             main.load_tools(system)
@@ -568,6 +594,110 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(second_call["previous_response_id"], "response-1")
         self.assertEqual(second_call["input"][0]["type"], "function_call_output")
         self.assertIn("Created a new role: QA", second_call["input"][0]["output"])
+
+    def test_responses_provider_exposes_only_role_allowed_tools(self):
+        employee_dict = main.build_employee_dict()
+        role = employee_dict["SE"]
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+        final_response = SimpleNamespace(id="response-1", output_text="ok")
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(create=FakeCreate([final_response]))
+        )
+        provider = main.ResponsesProvider(fake_client)
+
+        provider.generate(role, "test-model", "CEO", [{"role": "user", "content": "hi"}])
+
+        tool_names = {tool["name"] for tool in fake_client.responses.create.calls[0]["tools"]}
+        self.assertIn("tools__propose", tool_names)
+        self.assertNotIn("org__create_role", tool_names)
+
+    def test_disallowed_tool_call_is_rejected_at_runtime(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+
+        self.assertIn("not allowed", response)
+        self.assertNotIn("QA", employee_dict)
+
+    def test_operator_can_grant_tool_access(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            grant_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.grant",
+                        "args": {
+                            "role_name": "SE",
+                            "tool_name": "memory.search",
+                            "granted_by": "Ops",
+                        },
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+
+        self.assertIn("Granted tool access", grant_response)
+        self.assertIn("memory.search", employee_dict["SE"].allowed_tools)
+
+    def test_se_cannot_propose_system_tool_update(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.propose",
+                        "args": {
+                            "requested_by": "SE",
+                            "tool_name": "memory.search",
+                            "description": "Change memory access.",
+                            "action": "update",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+
+        self.assertIn("System tool", response)
+
+    def test_tools_list_reports_allowed_access_for_role(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.list",
+                        "args": {"role_name": "SE", "only_allowed": True},
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+
+        tools = json.loads(response.split("Result: ", 1)[1])
+        names = {tool["name"] for tool in tools}
+
+        self.assertIn("tools.propose", names)
+        self.assertNotIn("org.create_role", names)
 
     def test_model_retry_retries_rate_limit_errors(self):
         attempts = []

--- a/tools.yaml
+++ b/tools.yaml
@@ -1,4 +1,9 @@
 - name: org.create_role
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - hr
+  owner_capability: hr
   aliases:
     - create_role
   description: Create a new role in the organization.
@@ -16,6 +21,11 @@
         items:
           type: string
         description: Optional role capability flags such as operator, hr, kubeapi, protected, or essential.
+      tool_grants:
+        type: array
+        items:
+          type: string
+        description: Optional initial tool grants such as agent.* or memory.search.
       requested_by:
         type: string
         description: The agent or human requesting the lifecycle change.
@@ -31,10 +41,16 @@
         role_name,
         role_description,
         capabilities=capabilities,
+        tool_grants=tool_grants,
         requested_by=requested_by,
         approved_by=approved_by,
     )
 - name: org.list_roles
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - hr
+  owner_capability: hr
   description: List roles in the organization with lifecycle state and capability flags.
   parameters:
     type: object
@@ -46,6 +62,11 @@
   code: |
     return list_lifecycle_roles(employee_dict, include_exited=include_exited if include_exited is not None else True)
 - name: org.pause_role
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - hr
+  owner_capability: hr
   description: Pause an active role in the organization.
   parameters:
     type: object
@@ -73,6 +94,11 @@
         reason=reason,
     )
 - name: org.retire_role
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - hr
+  owner_capability: hr
   description: Retire a role in the organization.
   parameters:
     type: object
@@ -100,6 +126,11 @@
         reason=reason,
     )
 - name: org.archive_role
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - hr
+  owner_capability: hr
   aliases:
     - org.remove_role
   description: Archive an eligible role out of active organization scheduling without deleting its data.
@@ -129,6 +160,8 @@
         reason=reason,
     )
 - name: agent.create_alarm
+  required_capabilities: []
+  owner_capability: agent
   description: Create a one-shot or recurring reminder alarm for an agent.
   parameters:
     type: object
@@ -163,6 +196,8 @@
         recurrence=recurrence if recurrence is not None else "once",
     )
 - name: agent.list_alarms
+  required_capabilities: []
+  owner_capability: agent
   description: List an agent's alarms.
   parameters:
     type: object
@@ -182,6 +217,8 @@
         include_inactive=include_inactive if include_inactive is not None else False,
     )
 - name: agent.cancel_alarm
+  required_capabilities: []
+  owner_capability: agent
   aliases:
     - agent.delete_alarm
   description: Cancel an agent alarm by ID.
@@ -200,6 +237,9 @@
   code: |
     return cancel_alarm(employee_dict, agent_name, alarm_id)
 - name: memory.search
+  system_tool: true
+  grantable: true
+  owner_capability: system
   description: Search an agent's accessible SQLite memory records.
   parameters:
     type: object
@@ -224,6 +264,9 @@
         limit=limit if limit is not None else 10,
     )
 - name: memory.list_digests
+  system_tool: true
+  grantable: true
+  owner_capability: system
   description: List an agent's current accessible memory digests.
   parameters:
     type: object
@@ -252,6 +295,9 @@
         limit=limit if limit is not None else 10,
     )
 - name: memory.expand_digest
+  system_tool: true
+  grantable: true
+  owner_capability: system
   description: Expand an accessible memory digest into its source records.
   parameters:
     type: object
@@ -274,4 +320,113 @@
         agent_name,
         digest_id,
         recursive=recursive if recursive is not None else True,
+    )
+- name: tools.list
+  system_tool: true
+  grantable: false
+  description: List registered tools and role access decisions.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: Optional role to evaluate access for.
+      include_system:
+        type: boolean
+        description: Include system tools in the listing.
+      only_allowed:
+        type: boolean
+        description: Only show tools the role can call.
+    required: []
+  code: |
+    return list_registered_tools(
+        employee_dict,
+        role_name=role_name,
+        include_system=include_system if include_system is not None else True,
+        only_allowed=only_allowed if only_allowed is not None else False,
+    )
+- name: tools.grant
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - operator
+  owner_capability: operator
+  description: Grant a tool or namespace pattern to a role.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: Role receiving access.
+      tool_name:
+        type: string
+        description: Tool name or namespace pattern such as memory.search or agent.*.
+      granted_by:
+        type: string
+        description: Agent approving the grant.
+    required:
+      - role_name
+      - tool_name
+  code: |
+    return grant_tool_access(employee_dict, role_name, tool_name, granted_by=granted_by)
+- name: tools.revoke
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - operator
+  owner_capability: operator
+  description: Revoke a tool or namespace pattern from a role.
+  parameters:
+    type: object
+    properties:
+      role_name:
+        type: string
+        description: Role losing access.
+      tool_name:
+        type: string
+        description: Tool name or namespace pattern to revoke.
+      revoked_by:
+        type: string
+        description: Agent approving the revocation.
+    required:
+      - role_name
+      - tool_name
+  code: |
+    return revoke_tool_access(employee_dict, role_name, tool_name, revoked_by=revoked_by)
+- name: tools.propose
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - engineer
+  owner_capability: engineer
+  description: Propose creation or update of a non-system trusted tool.
+  parameters:
+    type: object
+    properties:
+      requested_by:
+        type: string
+        description: Agent proposing the tool change.
+      tool_name:
+        type: string
+        description: Tool name being proposed.
+      description:
+        type: string
+        description: Proposed behavior and purpose.
+      action:
+        type: string
+        enum:
+          - create
+          - update
+        description: Proposal action.
+    required:
+      - requested_by
+      - tool_name
+      - description
+  code: |
+    return propose_tool_change(
+        employee_dict,
+        requested_by,
+        tool_name,
+        description,
+        action=action if action is not None else "create",
     )


### PR DESCRIPTION
## Summary\n- add tool metadata for required capabilities, owner capability, system tools, and grantability\n- add per-role tool grants, filtered model-facing tool exposure, and runtime denial for disallowed tool calls\n- add governance tools for listing tools, operator grants/revokes, and SE non-system tool proposals\n- document role-level tool governance\n\n## Validation\n- py -3 -m unittest with a temporary OpenAI import stub because the local OpenAI dependency is blocked by application control in this shell\n- git diff --check\n\nCloses #33\n\nCreated by Codex GPT-5.5 on behalf of the user.