### PR TITLE
Address late runtime governance review feedback

### DIFF
--- a/main.py
+++ b/main.py
@@ -293,8 +293,8 @@ class ToolRegistry:
         for tool in sorted(self._tools.values(), key=lambda item: item.name):
             if tool.system_tool and not include_system:
                 continue
-            allowed = role is None or role_can_use_tool(role, tool)
-            if not include_denied and not allowed:
+            allowed = None if role is None else role_can_use_tool(role, tool)
+            if not include_denied and allowed is False:
                 continue
             rows.append(
                 {
@@ -330,7 +330,23 @@ class ToolRegistry:
         unexpected_args = [arg_name for arg_name in args if arg_name not in tool.args]
         if unexpected_args:
             return f"Error: Unexpected args for tool '{name}': {unexpected_args}"
-        result = tool.func(employee_dict=employee_dict, **args)
+        global active_tool_caller, active_tool_caller_name
+        previous_caller = active_tool_caller
+        previous_caller_name = active_tool_caller_name
+        active_tool_caller = caller
+        active_tool_caller_name = None
+        if caller is not None:
+            for employee_name, employee in employee_dict.items():
+                if employee is caller:
+                    active_tool_caller_name = employee_name
+                    break
+            if active_tool_caller_name is None:
+                active_tool_caller_name = getattr(caller, "name", None)
+        try:
+            result = tool.func(employee_dict=employee_dict, **args)
+        finally:
+            active_tool_caller = previous_caller
+            active_tool_caller_name = previous_caller_name
         return f"Executed tool '{resolved_name}' with args {args}. Result: {result}"
 
     def as_responses_tools(self, role=None):
@@ -343,6 +359,8 @@ class ToolRegistry:
 
 
 tool_registry = ToolRegistry()
+active_tool_caller = None
+active_tool_caller_name = None
 
 
 def _response_text(response):
@@ -406,7 +424,7 @@ class ChatCompletionsProvider(ModelProvider):
 
     def generate(self, role, model, sender, messages):
         def request():
-            return self.client.chat.completions.create(
+            stream = self.client.chat.completions.create(
                 model=model,
                 messages=messages,
                 max_tokens=role.max_tokens,
@@ -415,13 +433,13 @@ class ChatCompletionsProvider(ModelProvider):
                 user=f"robits_{role.name}",
                 stream=True,
             )
+            content = ""
+            for chunk in stream:
+                if chunk.choices[0].delta.content is not None:
+                    content += chunk.choices[0].delta.content
+            return content
 
-        stream = _with_model_retries(request)
-        content = ""
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                content += chunk.choices[0].delta.content
-        return content
+        return _with_model_retries(request)
 
 
 class ResponsesProvider(ModelProvider):
@@ -564,8 +582,19 @@ def _normalize_tool_grants(tool_grants=None):
     for grant in raw:
         if not isinstance(grant, str) or not grant.strip():
             raise ValueError("Tool grants must be non-empty strings.")
-        normalized.add(grant.strip())
+        normalized.add(_normalize_tool_grant(grant.strip()))
     return normalized
+
+
+def _normalize_tool_grant(tool_name):
+    if tool_name == "*":
+        return tool_name
+    if tool_name.endswith(".*"):
+        namespace = tool_name[:-2]
+        tool_registry.validate_tool_name(namespace)
+        return f"{namespace}.*"
+    tool_registry.validate_tool_name(tool_name)
+    return tool_registry.resolve_name(tool_name)
 
 
 def _tool_grant_matches(tool_name, grant):
@@ -586,54 +615,60 @@ def role_can_use_tool(role, tool):
     return any(_tool_grant_matches(tool.name, grant) for grant in grants)
 
 
+def _caller_can_act_for_agent(agent_name):
+    caller = active_tool_caller
+    if caller is None:
+        return False
+    if active_tool_caller_name == agent_name or getattr(caller, "name", None) == agent_name:
+        return True
+    capabilities = getattr(caller, "capabilities", set())
+    return bool({"operator", "hr"} & capabilities)
+
+
+def _caller_name_for_error():
+    return active_tool_caller_name or getattr(active_tool_caller, "name", "unknown caller")
+
+
 def grant_tool_access(employee_dict, role_name, tool_name, granted_by=None):
     try:
         normalized_name = validate_role_name(role_name)
+        normalized_tool_name = _normalize_tool_grant(tool_name)
     except ValueError as e:
         return f"Error: {e}"
-    if tool_name == "*":
-        pass
-    elif tool_name.endswith(".*"):
-        try:
-            tool_registry.validate_tool_name(tool_name[:-2])
-        except ValueError as e:
-            return f"Error: {e}"
-    else:
-        try:
-            tool_registry.validate_tool_name(tool_name)
-        except ValueError as e:
-            return f"Error: {e}"
     if normalized_name not in employee_dict:
         return f"Error: Role '{normalized_name}' not found."
-    if tool_name != "*" and not tool_name.endswith(".*") and tool_name not in tool_registry:
+    if normalized_tool_name != "*" and not normalized_tool_name.endswith(".*") and normalized_tool_name not in tool_registry:
         return f"Error: Tool '{tool_name}' not found."
-    if tool_name.endswith(".*"):
-        namespace = tool_name[:-2]
+    if normalized_tool_name.endswith(".*"):
+        namespace = normalized_tool_name[:-2]
         if not any(tool.name.startswith(f"{namespace}.") for tool in tool_registry._tools.values()):
             return f"Error: Tool namespace '{namespace}' not found."
     role = employee_dict[normalized_name]
-    role.allowed_tools.add(tool_name)
+    role.allowed_tools.add(normalized_tool_name)
     actor_text = f" by {granted_by}" if granted_by else ""
-    return f"Granted tool access '{tool_name}' to role '{normalized_name}'{actor_text}."
+    return f"Granted tool access '{normalized_tool_name}' to role '{normalized_name}'{actor_text}."
 
 
 def revoke_tool_access(employee_dict, role_name, tool_name, revoked_by=None):
     try:
         normalized_name = validate_role_name(role_name)
+        normalized_tool_name = _normalize_tool_grant(tool_name)
     except ValueError as e:
         return f"Error: {e}"
     if normalized_name not in employee_dict:
         return f"Error: Role '{normalized_name}' not found."
     role = employee_dict[normalized_name]
-    if tool_name not in role.allowed_tools:
-        return f"Error: Role '{normalized_name}' does not have grant '{tool_name}'."
-    role.allowed_tools.remove(tool_name)
+    if normalized_tool_name not in role.allowed_tools:
+        return f"Error: Role '{normalized_name}' does not have grant '{normalized_tool_name}'."
+    role.allowed_tools.remove(normalized_tool_name)
     actor_text = f" by {revoked_by}" if revoked_by else ""
-    return f"Revoked tool access '{tool_name}' from role '{normalized_name}'{actor_text}."
+    return f"Revoked tool access '{normalized_tool_name}' from role '{normalized_name}'{actor_text}."
 
 
 def list_registered_tools(employee_dict, role_name=None, include_system=True, only_allowed=False):
     role = None
+    if only_allowed and not role_name:
+        return "Error: role_name is required when only_allowed is true."
     if role_name:
         try:
             normalized_name = validate_role_name(role_name)
@@ -909,6 +944,8 @@ def create_alarm(employee_dict, agent_name, reminder, due_at, recurrence="once")
         due = _parse_datetime(due_at)
     except ValueError as e:
         return f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return f"Error: Role '{_caller_name_for_error()}' cannot manage alarms for '{normalized_name}'."
     if normalized_name not in employee_dict:
         return f"Error: Role '{normalized_name}' not found."
     if not isinstance(reminder, str) or not reminder.strip():
@@ -935,6 +972,8 @@ def list_alarms(employee_dict, agent_name, include_inactive=False):
         normalized_name = validate_role_name(agent_name)
     except ValueError as e:
         return f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return f"Error: Role '{_caller_name_for_error()}' cannot inspect alarms for '{normalized_name}'."
     if normalized_name not in employee_dict:
         return f"Error: Role '{normalized_name}' not found."
     alarms = []
@@ -958,6 +997,8 @@ def cancel_alarm(employee_dict, agent_name, alarm_id):
         normalized_name = validate_role_name(agent_name)
     except ValueError as e:
         return f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return f"Error: Role '{_caller_name_for_error()}' cannot manage alarms for '{normalized_name}'."
     if normalized_name not in employee_dict:
         return f"Error: Role '{normalized_name}' not found."
     for alarm in getattr(employee_dict[normalized_name], "alarms", []):
@@ -982,6 +1023,8 @@ def memory_search(employee_dict, agent_name, query, limit=10):
         normalized_name = validate_role_name(agent_name)
     except ValueError as e:
         return f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
     if not isinstance(query, str) or not query.strip():
         return "Error: Memory query must be a non-empty string."
     results = store.search(query, agent_id=normalized_name, limit=int(limit or 10))
@@ -997,6 +1040,8 @@ def memory_list_digests(employee_dict, agent_name, digest_type=None, limit=10):
         normalized_name = validate_role_name(agent_name)
     except ValueError as e:
         return f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
     digests = store.list_memory_digests(
         agent_id=normalized_name,
         digest_type=digest_type,
@@ -1017,6 +1062,8 @@ def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True):
         digest_id = int(digest_id)
     except ValueError as e:
         return f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
     digest = store.get_memory_digest(digest_id)
     if digest is None:
         return f"Error: Memory digest '{digest_id}' not found."
@@ -1171,7 +1218,7 @@ class Ops(Role):
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
         self.capabilities = {"operator"}
-        self.allowed_tools.update({"tools.*", "org.list_roles"})
+        self.allowed_tools.update({"tools.*"})
 
 
 class HR(Role):

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -251,8 +251,6 @@ class SQLiteMemoryStore:
             CREATE INDEX IF NOT EXISTS idx_tool_calls_agent ON tool_calls(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_entries_agent ON memory_entries(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_digests_agent ON memory_digests(agent_id);
-            CREATE INDEX IF NOT EXISTS idx_memory_digests_current
-                ON memory_digests(digest_type, superseded_by_digest_id, accessibility, system_only);
             CREATE INDEX IF NOT EXISTS idx_memory_digest_sources_digest
                 ON memory_digest_sources(digest_id);
             CREATE INDEX IF NOT EXISTS idx_runtime_events_session ON runtime_events(session_id);
@@ -260,6 +258,12 @@ class SQLiteMemoryStore:
             """
         )
         self._ensure_memory_digest_columns()
+        self.connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS idx_memory_digests_current
+                ON memory_digests(digest_type, superseded_by_digest_id, accessibility, system_only)
+            """
+        )
         self.connection.commit()
 
     def _ensure_memory_digest_columns(self):

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -57,6 +57,46 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertIn("system_only", digest_columns)
         self.assertIn("accessibility", digest_columns)
 
+    def test_existing_digest_table_migrates_before_current_index_creation(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        db_path = Path(temp_dir.name) / "legacy.sqlite3"
+        connection = sqlite3.connect(db_path)
+        connection.executescript(
+            """
+            CREATE TABLE memory_digests (
+                digest_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                agent_id TEXT,
+                session_id TEXT,
+                content TEXT NOT NULL,
+                prompt_version TEXT NOT NULL,
+                source_start_at TEXT,
+                source_end_at TEXT,
+                relationship_type TEXT,
+                conversation_type TEXT,
+                source TEXT,
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            """
+        )
+        connection.close()
+
+        store = SQLiteMemoryStore(db_path)
+        self.addCleanup(store.close)
+
+        digest_columns = {
+            row["name"]
+            for row in store.connection.execute("PRAGMA table_info(memory_digests)")
+        }
+        indexes = {
+            row["name"]
+            for row in store.connection.execute("PRAGMA index_list(memory_digests)")
+        }
+
+        self.assertIn("digest_type", digest_columns)
+        self.assertIn("idx_memory_digests_current", indexes)
+
     def test_append_and_lookup_messages_by_session_and_agent(self):
         store = self.seed_store()
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -358,7 +358,7 @@ class RuntimeTests(unittest.TestCase):
                         "args": {
                             "role_name": "Research",
                             "role_description": "Explores memory.",
-                            "tool_grants": ["memory.search"],
+                            "tool_grants": ["tools.list"],
                         },
                     }
                 ),
@@ -366,7 +366,7 @@ class RuntimeTests(unittest.TestCase):
             )
 
         self.assertIn("Created a new role: Research", response)
-        self.assertIn("memory.search", employee_dict["Research"].allowed_tools)
+        self.assertIn("tools.list", employee_dict["Research"].allowed_tools)
 
     def test_lifecycle_rejects_invalid_transitions_without_new_event(self):
         employee_dict = main.build_employee_dict()
@@ -645,7 +645,7 @@ class RuntimeTests(unittest.TestCase):
                         "exec": "tools.grant",
                         "args": {
                             "role_name": "SE",
-                            "tool_name": "memory.search",
+                            "tool_name": "memory__search",
                             "granted_by": "Ops",
                         },
                     }
@@ -655,6 +655,29 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertIn("Granted tool access", grant_response)
         self.assertIn("memory.search", employee_dict["SE"].allowed_tools)
+
+    def test_operator_can_revoke_tool_access_with_openai_alias(self):
+        employee_dict = main.build_employee_dict()
+        employee_dict["SE"].allowed_tools.add("memory.search")
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            revoke_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.revoke",
+                        "args": {
+                            "role_name": "SE",
+                            "tool_name": "memory__search",
+                            "revoked_by": "Ops",
+                        },
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+
+        self.assertIn("Revoked tool access", revoke_response)
+        self.assertNotIn("memory.search", employee_dict["SE"].allowed_tools)
 
     def test_se_cannot_propose_system_tool_update(self):
         employee_dict = main.build_employee_dict()
@@ -699,6 +722,29 @@ class RuntimeTests(unittest.TestCase):
         self.assertIn("tools.propose", names)
         self.assertNotIn("org.create_role", names)
 
+    def test_tools_list_without_role_does_not_report_allowed_true(self):
+        system = main.System(main.build_employee_dict())
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps({"exec": "tools.list", "args": {}})
+            )
+
+        tools = json.loads(response.split("Result: ", 1)[1])
+
+        self.assertIsNone(tools[0]["allowed"])
+
+    def test_tools_list_only_allowed_requires_role(self):
+        system = main.System(main.build_employee_dict())
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps({"exec": "tools.list", "args": {"only_allowed": True}})
+            )
+
+        self.assertIn("role_name is required", response)
+
+
     def test_model_retry_retries_rate_limit_errors(self):
         attempts = []
         original_retries = main.max_api_retries
@@ -729,6 +775,34 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(len(attempts), 2)
         sleep.assert_not_called()
 
+    def test_chat_completion_parallelism_gate_covers_stream_consumption(self):
+        gate_was_held = []
+
+        def stream():
+            gate_was_held.append(not main.model_call_gate.acquire(blocking=False))
+            if not gate_was_held[-1]:
+                main.model_call_gate.release()
+            yield SimpleNamespace(
+                choices=[
+                    SimpleNamespace(delta=SimpleNamespace(content="hello"))
+                ]
+            )
+
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **_kwargs: stream()
+                ),
+            )
+        )
+        provider = main.ChatCompletionsProvider(fake_client)
+        role = SimpleNamespace(name="SE", max_tokens=10, temperature=0)
+
+        response = provider.generate(role, "test-model", "CEO", [])
+
+        self.assertEqual(response, "hello")
+        self.assertEqual(gate_was_held, [True])
+
     def test_namespaced_exec_resolves_tool(self):
         employee_dict = main.build_employee_dict()
         system = main.System(employee_dict)
@@ -745,7 +819,7 @@ class RuntimeTests(unittest.TestCase):
                             "role_description": "Tests the organization",
                         },
                     }
-                )
+                ),
             )
 
         self.assertIn("Created a new role: QA", response)
@@ -1043,7 +1117,8 @@ class RuntimeTests(unittest.TestCase):
                             "due_at": "2026-05-08T10:00:00+00:00",
                         },
                     }
-                )
+                ),
+                caller=employee_dict["SE"],
             )
             alarm_id = employee_dict["SE"].alarms[0].alarm_id
             list_response = system.interact(
@@ -1052,7 +1127,8 @@ class RuntimeTests(unittest.TestCase):
                         "exec": "agent.list_alarms",
                         "args": {"agent_name": "SE"},
                     }
-                )
+                ),
+                caller=employee_dict["SE"],
             )
             cancel_response = system.interact(
                 json.dumps(
@@ -1060,7 +1136,8 @@ class RuntimeTests(unittest.TestCase):
                         "exec": "agent.cancel_alarm",
                         "args": {"agent_name": "SE", "alarm_id": alarm_id},
                     }
-                )
+                ),
+                caller=employee_dict["SE"],
             )
 
         alarms = json.loads(list_response.split("Result: ", 1)[1])
@@ -1069,6 +1146,49 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(alarms[0]["reminder"], "Check build health.")
         self.assertIn("Canceled alarm", cancel_response)
         self.assertEqual(employee_dict["SE"].alarms[0].status, "canceled")
+
+    def test_agent_alarm_tools_reject_missing_caller(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.create_alarm",
+                        "args": {
+                            "agent_name": "SE",
+                            "reminder": "Check build health.",
+                            "due_at": "2026-05-08T10:00:00+00:00",
+                        },
+                    }
+                )
+            )
+
+        self.assertIn("unknown caller", response)
+        self.assertEqual(employee_dict["SE"].alarms, [])
+
+    def test_agent_alarm_tools_reject_cross_agent_access(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.create_alarm",
+                        "args": {
+                            "agent_name": "HR",
+                            "reminder": "Check people.",
+                            "due_at": "2026-05-08T10:00:00+00:00",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+
+        self.assertIn("cannot manage alarms", response)
+        self.assertEqual(employee_dict["HR"].alarms, [])
 
     def test_memory_tools_search_list_and_expand_accessible_digests(self):
         employee_dict = main.build_employee_dict()
@@ -1101,7 +1221,8 @@ class RuntimeTests(unittest.TestCase):
                                 "exec": "memory.search",
                                 "args": {"agent_name": "SE", "query": "preserve"},
                             }
-                        )
+                        ),
+                        caller=employee_dict["SE"],
                     )
                     list_response = system.interact(
                         json.dumps(
@@ -1109,7 +1230,8 @@ class RuntimeTests(unittest.TestCase):
                                 "exec": "memory.list_digests",
                                 "args": {"agent_name": "SE", "digest_type": "identity"},
                             }
-                        )
+                        ),
+                        caller=employee_dict["SE"],
                     )
                     expand_response = system.interact(
                         json.dumps(
@@ -1117,7 +1239,8 @@ class RuntimeTests(unittest.TestCase):
                                 "exec": "memory.expand_digest",
                                 "args": {"agent_name": "SE", "digest_id": digest_id},
                             }
-                        )
+                        ),
+                        caller=employee_dict["SE"],
                     )
             finally:
                 main.memory_store = original_store
@@ -1130,6 +1253,71 @@ class RuntimeTests(unittest.TestCase):
         self.assertTrue(search_results)
         self.assertEqual(digest_results[0]["digest_id"], digest_id)
         self.assertEqual(expanded[0]["record"]["content"], "Robits should preserve source memory.")
+
+    def test_memory_tools_reject_cross_agent_access(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        original_store = main.memory_store
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = SQLiteMemoryStore(os.path.join(temp_dir, "memory.sqlite3"))
+            try:
+                store.create_session("session-1")
+                store.upsert_agent("HR", "HR", "HR")
+                store.append_message(
+                    "session-1",
+                    "HR",
+                    "HR",
+                    "Private HR memory.",
+                )
+                main.memory_store = store
+                with redirect_stdout(StringIO()):
+                    main.load_tools(system)
+                    response = system.interact(
+                        json.dumps(
+                            {
+                                "exec": "memory.search",
+                                "args": {"agent_name": "HR", "query": "private"},
+                            }
+                        ),
+                        caller=employee_dict["SE"],
+                    )
+            finally:
+                main.memory_store = original_store
+                store.close()
+
+        self.assertIn("cannot inspect memory", response)
+
+    def test_memory_tools_reject_missing_caller(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        original_store = main.memory_store
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = SQLiteMemoryStore(os.path.join(temp_dir, "memory.sqlite3"))
+            try:
+                store.create_session("session-1")
+                store.upsert_agent("SE", "SoftwareEngineer", "SE")
+                store.append_message(
+                    "session-1",
+                    "SE",
+                    "SE",
+                    "Private SE memory.",
+                )
+                main.memory_store = store
+                with redirect_stdout(StringIO()):
+                    main.load_tools(system)
+                    response = system.interact(
+                        json.dumps(
+                            {
+                                "exec": "memory.search",
+                                "args": {"agent_name": "SE", "query": "private"},
+                            }
+                        )
+                    )
+            finally:
+                main.memory_store = original_store
+                store.close()
+
+        self.assertIn("unknown caller", response)
 
     def test_due_alarm_is_injected_into_agent_prompt(self):
         participants = build_fake_participants()


### PR DESCRIPTION
## Summary\n- fix SQLite digest migration ordering before creating indexes on new columns\n- keep local model parallelism gate held while streaming responses are consumed\n- enforce self-access for alarm and memory tools, with HR/operator override\n- normalize grant/revoke tool aliases to canonical names\n- make tools.list access output explicit when no role is provided and remove ineffective Ops role grant\n- strengthen regression coverage for late review comments\n\n## Validation\n- py -3 -m unittest with a temporary OpenAI import stub because the local OpenAI dependency is blocked by application control in this shell\n- git diff --check\n\nCloses #35\n\nCreated by Codex GPT-5.5 on behalf of the user.