### PR TITLE
Allow non-reply agent turn actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -1135,7 +1135,12 @@ def interact_costly(self, sender, message):
 class Role:
     def __init__(self, name, template, employee_dict, group_template_additions=""):
         self.name = name
-        self.template = template + group_template_additions
+        turn_action_template = """
+On your turn, choose one useful action. You do not need to reply to every message.
+You may reply in plain text, call a tool by returning {"exec":"namespace.tool_name","args":{}}, record a private thought by returning {"action":"think","content":"..."}, or wait silently by returning {"action":"wait"}.
+Only say that you created, changed, or called a tool if you actually returned a tool call for the runtime to execute.
+"""
+        self.template = template + group_template_additions + turn_action_template
         self.employee_dict = employee_dict
         self.conversation_history = {name: [] for name in employee_dict}
         self.group_conversation_history = {}
@@ -1279,6 +1284,23 @@ def parse_tool_instruction(s):
             return json.dumps(obj)
         except json.JSONDecodeError:
             continue
+    return None
+
+
+def parse_agent_action(s):
+    instruction = parse_tool_instruction(s)
+    if instruction is None:
+        return None
+    try:
+        action = json.loads(instruction)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(action, dict):
+        return None
+    if "exec" in action:
+        return action
+    if action.get("action") in {"wait", "think", "reply"}:
+        return action
     return None
 
 
@@ -1473,6 +1495,35 @@ class Session:
                 ops.update_group_conversations({"role": "system", "content": system_response})
         return [system_response]
 
+    def process_agent_action(self, message, sender=None):
+        if not isinstance(message, str) or message.strip() == "":
+            return "", []
+        action = parse_agent_action(message)
+        if action is None:
+            return message, []
+        action_type = action.get("action")
+        if action_type == "wait":
+            self.event_stream.emit(
+                "agent.waited",
+                self.run_id,
+                {
+                    "agent": getattr(sender, "name", None),
+                },
+            )
+            return "", []
+        if action_type == "think":
+            content = action.get("content", "")
+            if isinstance(content, str) and content.strip():
+                self.record_thought(getattr(sender, "name", "unknown"), content.strip())
+            return "", []
+        if action_type == "reply":
+            content = action.get("content", "")
+            return (content if isinstance(content, str) else ""), []
+        if "exec" in action:
+            system_events = self.process_tool_instruction(json.dumps(action), sender=sender)
+            return "", system_events
+        return message, []
+
     def record_turn(self, sender, receiver, prompt, response, directed=False, system_events=None):
         entry = TranscriptEntry(
             turn=self.turns_completed + 1,
@@ -1528,6 +1579,10 @@ class Session:
             prompt = "\n".join(reminders + [prompt])
         response = routed.receiver.interact(sender.name, prompt)
         response = "" if response is None else response
+        response, response_events = self.process_agent_action(response, sender=routed.receiver)
+        if response_events:
+            system_events.extend(response_events)
+            self.sync_scheduler_participants()
         if routed.receiver.name != "CEO" and response != "":
             print(colored(f"{routed.receiver.name} responds: {response}", "cyan"))
         self.record_turn(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -82,6 +82,25 @@ class RuntimeTests(unittest.TestCase):
             },
         )
 
+    def test_parse_agent_action_recognizes_wait_think_reply_and_tool(self):
+        self.assertEqual(
+            main.parse_agent_action('{"action": "wait"}'),
+            {"action": "wait"},
+        )
+        self.assertEqual(
+            main.parse_agent_action('{"action": "think", "content": "Need a plan."}'),
+            {"action": "think", "content": "Need a plan."},
+        )
+        self.assertEqual(
+            main.parse_agent_action('{"action": "reply", "content": "hello"}'),
+            {"action": "reply", "content": "hello"},
+        )
+        self.assertEqual(
+            main.parse_agent_action('{"exec": "tools.list", "args": {}}'),
+            {"exec": "tools.list", "args": {}},
+        )
+        self.assertIsNone(main.parse_agent_action('{"note": "plain JSON, not an action"}'))
+
     def test_loaded_create_role_executes_against_employee_dict(self):
         employee_dict = main.build_employee_dict()
         system = main.System(employee_dict)
@@ -1061,6 +1080,73 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertEqual(session.turns_completed, 1)
         self.assertEqual(session.transcript[0].prompt, "")
+
+    def test_wait_action_consumes_turn_without_replying(self):
+        participants = build_fake_participants()
+        participants["Ops"] = FakeRole("Ops", ['{"action": "wait"}'])
+        event_stream = main.RuntimeEventStream()
+        session = main.Session(
+            participants=participants,
+            run_id="session-1",
+            event_stream=event_stream,
+        )
+
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="hello", max_turns=1)
+
+        self.assertEqual(session.transcript[0].response, "")
+        self.assertIn("agent.waited", [event.event_type for event in event_stream.events()])
+
+    def test_think_action_records_private_thought_without_replying(self):
+        participants = build_fake_participants()
+        participants["Ops"] = FakeRole("Ops", ['{"action": "think", "content": "Check tool health later."}'])
+        event_stream = main.RuntimeEventStream()
+        session = main.Session(
+            participants=participants,
+            run_id="session-1",
+            event_stream=event_stream,
+        )
+
+        with redirect_stdout(StringIO()):
+            session.run(initial_message="hello", max_turns=1)
+
+        thought_events = [
+            event for event in event_stream.events() if event.event_type == "thought.recorded"
+        ]
+        self.assertEqual(session.transcript[0].response, "")
+        self.assertEqual(len(thought_events), 1)
+        self.assertEqual(thought_events[0].visibility, "private")
+        self.assertEqual(thought_events[0].payload["agent"], "Ops")
+
+    def test_agent_tool_action_executes_without_broadcast_reply(self):
+        participants = build_fake_participants()
+        participants["HR"] = FakeRole(
+            "HR",
+            [
+                json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+            ],
+        )
+        participants["HR"].capabilities = {"hr"}
+        participants["HR"].allowed_tools = {"org.*"}
+        system = main.System(participants)
+        session = main.Session(participants=participants, system=system, run_id="session-1")
+
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            session.run(initial_message="HR, create QA", max_turns=1)
+
+        self.assertIn("QA", participants)
+        self.assertEqual(session.transcript[0].response, "")
+        self.assertEqual(len(session.transcript[0].system_events), 1)
+        self.assertIn("Created a new role: QA", session.transcript[0].system_events[0])
 
     def test_non_string_message_does_not_parse_tool_instruction(self):
         session = main.Session(participants=build_fake_participants(), run_id="session-1")


### PR DESCRIPTION
## Summary
- add explicit turn actions so agents can wait silently or record private thoughts instead of replying to every message
- execute agent-emitted tool commands as system events without rebroadcasting raw tool JSON as chat
- update role prompts to make reply, tool, think, and wait distinct choices
- add regression coverage for action parsing, wait, think, and tool-action turns

## Validation
- py -3 -m unittest with a temporary OpenAI import stub because the local OpenAI dependency is blocked by application control in this shell
- git diff --check

Closes #37

Created by Codex GPT-5.5 on behalf of the user.