### PR TITLE
Add CLI log capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ For non-interactive smoke checks, provide an initial prompt and turn limit:
 python main.py --prompt "Ops, say hello to HR" --turns 1
 ```
 
+To capture the same console transcript to a file while still watching the run:
+
+```bash
+python main.py --prompt "Ops, say hello to HR" --turns 1 --log run.log
+```
+
 ## Testing
 
 The focused runtime tests do not call an external model service:

--- a/main.py
+++ b/main.py
@@ -12,11 +12,27 @@ import threading
 from datetime import datetime, timedelta, timezone
 from termcolor import colored
 import argparse
+import sys
 from pathlib import Path
 from uuid import uuid4
 
 from robits.memory.sqlite import SQLiteMemoryStore
 from robits.runtime.sandbox import SandboxMetadata
+
+
+class TeeStream:
+    def __init__(self, *streams):
+        self.streams = streams
+
+    def write(self, text):
+        for stream in self.streams:
+            stream.write(text)
+            stream.flush()
+        return len(text)
+
+    def flush(self):
+        for stream in self.streams:
+            stream.flush()
 
 
 def make_client():
@@ -1640,12 +1656,27 @@ def parse_args(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument("--prompt", help="Initial message to start the simulation.")
     parser.add_argument("--turns", type=int, help="Maximum model turns to run.")
+    parser.add_argument("--log", help="Write the console transcript to this file while still printing it.")
     return parser.parse_args(argv)
 
 
 def main(argv=None):
     args = parse_args(argv)
-    run_simulation(initial_message=args.prompt, max_turns=args.turns)
+    if args.log:
+        log_path = Path(args.log)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(log_path, "w", encoding="utf-8", buffering=1) as log_file:
+            original_stdout = sys.stdout
+            original_stderr = sys.stderr
+            sys.stdout = TeeStream(original_stdout, log_file)
+            sys.stderr = TeeStream(original_stderr, log_file)
+            try:
+                run_simulation(initial_message=args.prompt, max_turns=args.turns)
+            finally:
+                sys.stdout = original_stdout
+                sys.stderr = original_stderr
+    else:
+        run_simulation(initial_message=args.prompt, max_turns=args.turns)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,8 +1,9 @@
 import json
 import os
+import sys
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -36,6 +37,18 @@ class FakeCreate:
     def __call__(self, **kwargs):
         self.calls.append(kwargs)
         return self.responses.pop(0)
+
+
+class RecordingStream:
+    def __init__(self):
+        self.content = ""
+        self.flushes = 0
+
+    def write(self, text):
+        self.content += text
+
+    def flush(self):
+        self.flushes += 1
 
 
 def build_fake_participants():
@@ -973,6 +986,47 @@ class RuntimeTests(unittest.TestCase):
                 main.load_tools(system, path)
         finally:
             os.unlink(path)
+
+    def test_parse_args_accepts_log_path(self):
+        args = main.parse_args(["--prompt", "hello", "--turns", "1", "--log", "run.log"])
+
+        self.assertEqual(args.prompt, "hello")
+        self.assertEqual(args.turns, 1)
+        self.assertEqual(args.log, "run.log")
+
+    def test_main_tees_console_output_to_log_file(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_path = os.path.join(temp_dir, "logs", "run.log")
+
+            def fake_run_simulation(initial_message=None, max_turns=None):
+                print(f"prompt={initial_message} turns={max_turns}")
+                print("warning stream", file=sys.stderr)
+
+            with patch.object(main, "run_simulation", side_effect=fake_run_simulation):
+                stdout = StringIO()
+                stderr = StringIO()
+                with redirect_stdout(stdout), redirect_stderr(stderr):
+                    main.main(["--prompt", "hello", "--turns", "2", "--log", log_path])
+
+            self.assertIn("prompt=hello turns=2", stdout.getvalue())
+            self.assertIn("warning stream", stderr.getvalue())
+            with open(log_path, "r", encoding="utf-8") as handle:
+                content = handle.read()
+            self.assertIn("prompt=hello turns=2", content)
+            self.assertIn("warning stream", content)
+
+    def test_tee_stream_flushes_after_each_write(self):
+        first = RecordingStream()
+        second = RecordingStream()
+        tee = main.TeeStream(first, second)
+
+        written = tee.write("hello")
+
+        self.assertEqual(written, 5)
+        self.assertEqual(first.content, "hello")
+        self.assertEqual(second.content, "hello")
+        self.assertEqual(first.flushes, 1)
+        self.assertEqual(second.flushes, 1)
 
     def test_session_creation_records_run_id_participants_and_transcript(self):
         participants = build_fake_participants()


### PR DESCRIPTION
## Summary
- add --log PATH to tee simulation stdout and stderr into a run log while preserving terminal output
- create parent directories for the selected log path
- document the log capture flag in the simulation run instructions
- add tests for argument parsing and stdout/stderr log capture

## Validation
- py -3 -m unittest with a temporary OpenAI import stub because the local OpenAI dependency is blocked by application control in this shell
- git diff --check

Closes #39

Created by Codex GPT-5.5 on behalf of the user.