### PR TITLE
Ground agent claims in verified tool results

### DIFF
--- a/main.py
+++ b/main.py
@@ -656,7 +656,7 @@ def format_verified_tool_results(system_events):
         return ""
     lines = "\n".join(f"- {event}" for event in verified_events)
     return (
-        "Verified runtime results from your tool calls:\n"
+        "Verified runtime results from recent tool calls:\n"
         f"{lines}\n"
         "You may rely on these results as completed runtime facts. "
         "Do not claim other tool-created artifacts or side effects without a verified result."

--- a/main.py
+++ b/main.py
@@ -650,6 +650,34 @@ def current_agent_context(employee_dict):
     return json.dumps(agent_runtime_context(active_tool_caller), sort_keys=True)
 
 
+def format_verified_tool_results(system_events):
+    verified_events = [event for event in system_events if isinstance(event, str) and event.strip()]
+    if not verified_events:
+        return ""
+    lines = "\n".join(f"- {event}" for event in verified_events)
+    return (
+        "Verified runtime results from your tool calls:\n"
+        f"{lines}\n"
+        "You may rely on these results as completed runtime facts. "
+        "Do not claim other tool-created artifacts or side effects without a verified result."
+    )
+
+
+def deliver_verified_tool_results(role, system_events):
+    content = format_verified_tool_results(system_events)
+    if not content or not hasattr(role, "conversation_history"):
+        return
+    role_history = role.conversation_history.setdefault(getattr(role, "name", ""), [])
+    role_history.append({"role": "system", "content": content})
+
+
+def prepend_verified_tool_results(prompt, system_events):
+    content = format_verified_tool_results(system_events)
+    if not content:
+        return prompt
+    return f"{content}\n\n{prompt}" if prompt else content
+
+
 def _parse_datetime(value):
     if not isinstance(value, str) or not value.strip():
         raise ValueError("Timestamp must be a non-empty ISO datetime string.")
@@ -1259,7 +1287,7 @@ class Role:
         turn_action_template = """
 On your turn, choose one useful action. You do not need to reply to every message.
 You may reply in plain text, call a tool by returning {"exec":"namespace.tool_name","args":{}}, record a private thought by returning {"action":"think","content":"..."}, or wait silently by returning {"action":"wait"}.
-Only say that you created, changed, or called a tool if you actually returned a tool call for the runtime to execute.
+Only say that you created, changed, or called a tool after the runtime has returned a verified tool result. Without a verified result, describe the work as a request, proposal, or plan instead of a completed fact.
 """
         self.template = template + group_template_additions + turn_action_template
         self.employee_dict = employee_dict
@@ -1706,25 +1734,43 @@ class Session:
                 return
         role.runtime_role_name = getattr(role, "name", None)
 
+    def recent_system_events(self, limit=5):
+        events = []
+        for entry in reversed(self.transcript):
+            for event in reversed(entry.system_events):
+                if isinstance(event, str) and event.strip():
+                    events.append(event)
+                    if len(events) >= limit:
+                        return list(reversed(events))
+        return list(reversed(events))
+
     def step(self, message):
         sender = self.last_receiver
         self.sync_scheduler_participants()
         routed = self.route_message(message, sender.name)
         system_events = self.process_tool_instruction(message, sender=sender)
+        if system_events:
+            deliver_verified_tool_results(sender, system_events)
         self.sync_scheduler_participants()
         prompt = routed.prompt
         reminders = due_alarm_reminders(routed.receiver)
         if reminders:
             prompt = "\n".join(reminders + [prompt])
+        prompt = prepend_verified_tool_results(
+            prompt,
+            self.recent_system_events() + system_events,
+        )
         self.prepare_agent_runtime(routed.receiver)
         response = routed.receiver.interact(sender.name, prompt)
         response = "" if response is None else response
         native_tool_events = list(getattr(routed.receiver, "runtime_tool_results", []))
         if native_tool_events:
             system_events.extend(native_tool_events)
+            deliver_verified_tool_results(routed.receiver, native_tool_events)
         response, response_events = self.process_agent_action(response, sender=routed.receiver)
         if response_events:
             system_events.extend(response_events)
+            deliver_verified_tool_results(routed.receiver, response_events)
             self.sync_scheduler_participants()
         if routed.receiver.name != "CEO" and response != "":
             print(colored(f"{routed.receiver.name} responds: {response}", "cyan"))

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1211,6 +1211,52 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(len(session.transcript[0].system_events), 1)
         self.assertIn("Created a new role: QA", session.transcript[0].system_events[0])
 
+    def test_plain_text_tool_claim_does_not_create_verified_result(self):
+        participants = build_fake_participants()
+        participants["HR"] = FakeRole("HR", ["Created QA."])
+        system = main.System(participants)
+        session = main.Session(participants=participants, system=system, run_id="session-1")
+
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            session.run(initial_message="HR, create QA", max_turns=1)
+
+        self.assertNotIn("QA", participants)
+        self.assertEqual(session.transcript[0].response, "Created QA.")
+        self.assertEqual(session.transcript[0].system_events, [])
+
+    def test_agent_tool_action_result_is_returned_to_agent_context(self):
+        class ToolActionProvider:
+            def generate(self, *_):
+                return json.dumps(
+                    {
+                        "exec": "org.create_role",
+                        "args": {
+                            "role_name": "QA",
+                            "role_description": "Tests the organization",
+                        },
+                    }
+                )
+
+        participants = main.build_employee_dict()
+        system = main.System(participants)
+        session = main.Session(participants=participants, system=system, run_id="session-1")
+
+        with patch.object(main, "model_provider", ToolActionProvider()):
+            with redirect_stdout(StringIO()):
+                main.load_tools(system)
+                session.run(initial_message="HR, create QA", max_turns=1)
+
+        history = participants["HR"].conversation_history["HR"]
+        verified_messages = [
+            message["content"]
+            for message in history
+            if message.get("role") == "system" and "Verified runtime results" in message.get("content", "")
+        ]
+
+        self.assertTrue(verified_messages)
+        self.assertIn("Created a new role: QA", verified_messages[-1])
+
     def test_non_string_message_does_not_parse_tool_instruction(self):
         session = main.Session(participants=build_fake_participants(), run_id="session-1")
 
@@ -1565,6 +1611,44 @@ class RuntimeTests(unittest.TestCase):
 
         self.assertEqual(session.transcript[0].response, "")
         self.assertIn("tool_call.executed: agent__context", session.transcript[0].system_events[0])
+
+    def test_recent_verified_events_are_included_in_next_agent_prompt(self):
+        participants = build_fake_participants()
+        session = main.Session(participants=participants, run_id="session-1")
+        session.transcript.append(
+            main.TranscriptEntry(
+                turn=1,
+                sender="HR",
+                receiver="Ops",
+                prompt="create QA",
+                response="",
+                system_events=["Executed tool 'org.create_role' with args {}. Result: Created a new role: QA."],
+            )
+        )
+        session.turns_completed = 1
+
+        with redirect_stdout(StringIO()):
+            session.step("SE, what changed?")
+
+        self.assertIn("Verified runtime results", participants["SE"].received[0][1])
+        self.assertIn("Created a new role: QA", participants["SE"].received[0][1])
+
+    def test_session_returns_native_tool_events_to_agent_context(self):
+        class NativeToolEventProvider:
+            def generate(self, role, *_):
+                role.runtime_tool_results.append("tool_call.executed: agent__context({}) -> {}")
+                return ""
+
+        participants = main.build_employee_dict()
+        session = main.Session(participants=participants, run_id="session-1")
+
+        with patch.object(main, "model_provider", NativeToolEventProvider()):
+            with redirect_stdout(StringIO()):
+                session.run(initial_message="HR, inspect context", max_turns=1)
+
+        history = participants["HR"].conversation_history["HR"]
+        self.assertIn("Verified runtime results", history[-1]["content"])
+        self.assertIn("tool_call.executed: agent__context", history[-1]["content"])
 
     def test_event_subscriber_errors_do_not_break_runtime(self):
         event_stream = main.RuntimeEventStream()


### PR DESCRIPTION
## Summary
- feed verified runtime/tool results back into the calling agent context
- include recent verified runtime events in the next routed agent prompt
- tighten role instructions so completed tool claims require verified results, and add regressions for narrated-only claims

## Validation
- `$stub = Join-Path $env:TEMP 'robits-openai-stub'; $env:PYTHONPATH = "$stub;$PWD"; py -3 -m unittest`

Closes #42

Created by Codex GPT-5.5.