### PR TITLE
Persist and operationalize tool proposals

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from robits.memory.sqlite import SQLiteMemoryStore
 from robits.runtime.sandbox import SandboxMetadata
+from robits.runtime.tool_proposals import ToolProposalStore
 
 
 class TeeStream:
@@ -61,6 +62,7 @@ api_retry_max_seconds = max(api_retry_base_seconds, float(os.environ.get("ROBITS
 model_call_gate = threading.BoundedSemaphore(max_parallelism)
 memory_db_path = os.environ.get("ROBITS_MEMORY_DB")
 memory_store = SQLiteMemoryStore(memory_db_path) if memory_db_path else None
+tool_proposal_store = ToolProposalStore(os.environ.get("ROBITS_TOOL_PROPOSALS_FILE", "var/tool_proposals.json"))
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
 SAFE_TOOL_BUILTINS = {
@@ -186,6 +188,10 @@ class ToolRegistry:
                 "revoke_tool_access": revoke_tool_access,
                 "list_registered_tools": list_registered_tools,
                 "propose_tool_change": propose_tool_change,
+                "list_tool_proposals": list_tool_proposals,
+                "approve_tool_proposal": approve_tool_proposal,
+                "reject_tool_proposal": reject_tool_proposal,
+                "rollout_tool_proposal": rollout_tool_proposal,
                 "current_agent_context": current_agent_context,
             },
             local_dict,
@@ -823,10 +829,49 @@ def list_registered_tools(employee_dict, role_name=None, include_system=True, on
     )
 
 
-def propose_tool_change(employee_dict, requested_by, tool_name, description, action="create"):
+def _coerce_json_object(value, default=None):
+    if value is None:
+        return {} if default is None else default
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"Invalid JSON object: {error}")
+    if not isinstance(value, dict):
+        raise ValueError("Value must be a JSON object.")
+    return value
+
+
+def _coerce_string_list(value):
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [item.strip() for item in value.split(",") if item.strip()]
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError("Value must be a list of strings.")
+    return value
+
+
+def propose_tool_change(
+    employee_dict,
+    requested_by,
+    tool_name,
+    description,
+    action="create",
+    parameters=None,
+    required_capabilities=None,
+    owner_capability=None,
+    safety_notes="",
+    implementation_notes="",
+):
     del employee_dict
     try:
         tool_registry.validate_tool_name(tool_name)
+        normalized_parameters = _coerce_json_object(
+            parameters,
+            {"type": "object", "properties": {}, "required": []},
+        )
+        normalized_capabilities = _coerce_string_list(required_capabilities)
     except ValueError as e:
         return f"Error: {e}"
     if not isinstance(description, str) or not description.strip():
@@ -837,15 +882,84 @@ def propose_tool_change(employee_dict, requested_by, tool_name, description, act
         tool = tool_registry.get(tool_name)
         if tool.system_tool:
             return f"Error: System tool '{tool_name}' cannot be changed by SE proposal."
-    proposal = {
-        "proposal_id": f"tool-proposal-{uuid4()}",
-        "requested_by": requested_by,
-        "tool_name": tool_name,
-        "action": action,
-        "description": description.strip(),
-        "status": "proposed",
-    }
+    proposal = tool_proposal_store.create(
+        requested_by=requested_by,
+        tool_name=tool_name,
+        action=action,
+        description=description.strip(),
+        parameters=normalized_parameters,
+        required_capabilities=normalized_capabilities,
+        owner_capability=owner_capability,
+        safety_notes=safety_notes,
+        implementation_notes=implementation_notes,
+    )
     return json.dumps(proposal, sort_keys=True)
+
+
+def list_tool_proposals(employee_dict, status=None):
+    del employee_dict
+    return json.dumps(tool_proposal_store.list(status=status), sort_keys=True)
+
+
+def approve_tool_proposal(employee_dict, proposal_id, approved_by, implementation_notes=""):
+    del employee_dict
+    proposal = tool_proposal_store.get(proposal_id)
+    if proposal is None:
+        return f"Error: Tool proposal '{proposal_id}' not found."
+    if proposal["status"] not in {"proposed", "approved"}:
+        return f"Error: Tool proposal '{proposal_id}' cannot be approved from status '{proposal['status']}'."
+    updated = tool_proposal_store.update(
+        proposal_id,
+        status="approved",
+        approver=approved_by,
+        implementation_notes=implementation_notes or proposal.get("implementation_notes", ""),
+    )
+    return json.dumps(updated, sort_keys=True)
+
+
+def reject_tool_proposal(employee_dict, proposal_id, rejected_by, reason):
+    del employee_dict
+    if not isinstance(reason, str) or not reason.strip():
+        return "Error: Rejection reason must be a non-empty string."
+    proposal = tool_proposal_store.get(proposal_id)
+    if proposal is None:
+        return f"Error: Tool proposal '{proposal_id}' not found."
+    if proposal["status"] in {"operationalized", "rejected"}:
+        return f"Error: Tool proposal '{proposal_id}' cannot be rejected from status '{proposal['status']}'."
+    updated = tool_proposal_store.update(
+        proposal_id,
+        status="rejected",
+        approver=rejected_by,
+        rejection_reason=reason.strip(),
+    )
+    return json.dumps(updated, sort_keys=True)
+
+
+def rollout_tool_proposal(employee_dict, proposal_id, role_name, granted_by=None, rollout_notes=""):
+    proposal = tool_proposal_store.get(proposal_id)
+    if proposal is None:
+        return f"Error: Tool proposal '{proposal_id}' not found."
+    if proposal["status"] != "approved":
+        return f"Error: Tool proposal '{proposal_id}' must be approved before rollout."
+    tool_name = proposal["tool_name"]
+    if tool_name not in tool_registry:
+        return f"Error: Tool '{tool_name}' is not registered; implement it before rollout."
+    grant_result = grant_tool_access(
+        employee_dict,
+        role_name,
+        tool_name,
+        granted_by=granted_by,
+    )
+    if grant_result.startswith("Error:"):
+        return grant_result
+    granted_roles = sorted(set(proposal.get("granted_roles", [])) | {validate_role_name(role_name)})
+    updated = tool_proposal_store.update(
+        proposal_id,
+        status="operationalized",
+        rollout_notes=rollout_notes or proposal.get("rollout_notes", ""),
+        granted_roles=granted_roles,
+    )
+    return json.dumps({"proposal": updated, "grant_result": grant_result}, sort_keys=True)
 
 
 def validate_role_name(role_name):
@@ -1406,7 +1520,7 @@ class SoftwareEngineer(Role):
         group_template_additions = """You are part of the Engineering group. Tools are trusted, repo-loaded functions described by namespaced OpenAI-compatible metadata. Propose tool behavior in plain language; do not assume untrusted chat output can define executable tools directly."""
         super().__init__(self.__class__.__name__, template, employee_dict, group_template_additions)
         self.capabilities = {"engineer"}
-        self.allowed_tools.update({"tools.list", "tools.propose"})
+        self.allowed_tools.update({"tools.list", "tools.list_proposals", "tools.propose"})
 
     def interact(self, sender, prompt):
         return interact_costly(self, sender, prompt)

--- a/main.py
+++ b/main.py
@@ -62,7 +62,7 @@ api_retry_max_seconds = max(api_retry_base_seconds, float(os.environ.get("ROBITS
 model_call_gate = threading.BoundedSemaphore(max_parallelism)
 memory_db_path = os.environ.get("ROBITS_MEMORY_DB")
 memory_store = SQLiteMemoryStore(memory_db_path) if memory_db_path else None
-tool_proposal_store = ToolProposalStore(os.environ.get("ROBITS_TOOL_PROPOSALS_FILE", "var/tool_proposals.json"))
+tool_proposal_store = None
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
 SAFE_TOOL_BUILTINS = {
@@ -852,6 +852,15 @@ def _coerce_string_list(value):
     return value
 
 
+def get_tool_proposal_store():
+    global tool_proposal_store
+    if tool_proposal_store is None:
+        tool_proposal_store = ToolProposalStore(
+            os.environ.get("ROBITS_TOOL_PROPOSALS_FILE", "var/tool_proposals.json")
+        )
+    return tool_proposal_store
+
+
 def propose_tool_change(
     employee_dict,
     requested_by,
@@ -882,7 +891,7 @@ def propose_tool_change(
         tool = tool_registry.get(tool_name)
         if tool.system_tool:
             return f"Error: System tool '{tool_name}' cannot be changed by SE proposal."
-    proposal = tool_proposal_store.create(
+    proposal = get_tool_proposal_store().create(
         requested_by=requested_by,
         tool_name=tool_name,
         action=action,
@@ -898,17 +907,18 @@ def propose_tool_change(
 
 def list_tool_proposals(employee_dict, status=None):
     del employee_dict
-    return json.dumps(tool_proposal_store.list(status=status), sort_keys=True)
+    return json.dumps(get_tool_proposal_store().list(status=status), sort_keys=True)
 
 
 def approve_tool_proposal(employee_dict, proposal_id, approved_by, implementation_notes=""):
     del employee_dict
-    proposal = tool_proposal_store.get(proposal_id)
+    store = get_tool_proposal_store()
+    proposal = store.get(proposal_id)
     if proposal is None:
         return f"Error: Tool proposal '{proposal_id}' not found."
     if proposal["status"] not in {"proposed", "approved"}:
         return f"Error: Tool proposal '{proposal_id}' cannot be approved from status '{proposal['status']}'."
-    updated = tool_proposal_store.update(
+    updated = store.update(
         proposal_id,
         status="approved",
         approver=approved_by,
@@ -921,12 +931,13 @@ def reject_tool_proposal(employee_dict, proposal_id, rejected_by, reason):
     del employee_dict
     if not isinstance(reason, str) or not reason.strip():
         return "Error: Rejection reason must be a non-empty string."
-    proposal = tool_proposal_store.get(proposal_id)
+    store = get_tool_proposal_store()
+    proposal = store.get(proposal_id)
     if proposal is None:
         return f"Error: Tool proposal '{proposal_id}' not found."
     if proposal["status"] in {"operationalized", "rejected"}:
         return f"Error: Tool proposal '{proposal_id}' cannot be rejected from status '{proposal['status']}'."
-    updated = tool_proposal_store.update(
+    updated = store.update(
         proposal_id,
         status="rejected",
         approver=rejected_by,
@@ -936,7 +947,8 @@ def reject_tool_proposal(employee_dict, proposal_id, rejected_by, reason):
 
 
 def rollout_tool_proposal(employee_dict, proposal_id, role_name, granted_by=None, rollout_notes=""):
-    proposal = tool_proposal_store.get(proposal_id)
+    store = get_tool_proposal_store()
+    proposal = store.get(proposal_id)
     if proposal is None:
         return f"Error: Tool proposal '{proposal_id}' not found."
     if proposal["status"] != "approved":
@@ -953,7 +965,7 @@ def rollout_tool_proposal(employee_dict, proposal_id, role_name, granted_by=None
     if grant_result.startswith("Error:"):
         return grant_result
     granted_roles = sorted(set(proposal.get("granted_roles", [])) | {validate_role_name(role_name)})
-    updated = tool_proposal_store.update(
+    updated = store.update(
         proposal_id,
         status="operationalized",
         rollout_notes=rollout_notes or proposal.get("rollout_notes", ""),

--- a/robits/runtime/tool_proposals.py
+++ b/robits/runtime/tool_proposals.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class ToolProposalStore:
+    """Small JSON-backed registry for managed tool proposal lifecycle state."""
+
+    def __init__(self, path=None):
+        self.path = Path(path) if path else None
+        self._proposals = {}
+        if self.path is not None:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            if self.path.exists():
+                with open(self.path, "r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                for proposal in data.get("proposals", []):
+                    self._proposals[proposal["proposal_id"]] = proposal
+
+    def _save(self):
+        if self.path is None:
+            return
+        data = {"proposals": sorted(self._proposals.values(), key=lambda item: item["created_at"])}
+        with open(self.path, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+
+    def clear(self):
+        self._proposals.clear()
+        self._save()
+
+    def create(
+        self,
+        requested_by,
+        tool_name,
+        description,
+        action="create",
+        parameters=None,
+        required_capabilities=None,
+        owner_capability=None,
+        safety_notes="",
+        implementation_notes="",
+    ):
+        now = _utc_now()
+        proposal = {
+            "proposal_id": f"tool-proposal-{uuid4()}",
+            "requested_by": requested_by,
+            "tool_name": tool_name,
+            "action": action,
+            "description": description,
+            "parameters": parameters or {"type": "object", "properties": {}, "required": []},
+            "required_capabilities": list(required_capabilities or []),
+            "owner_capability": owner_capability,
+            "safety_notes": safety_notes or "",
+            "implementation_notes": implementation_notes or "",
+            "status": "proposed",
+            "approver": None,
+            "rejection_reason": "",
+            "rollout_notes": "",
+            "granted_roles": [],
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._proposals[proposal["proposal_id"]] = proposal
+        self._save()
+        return dict(proposal)
+
+    def get(self, proposal_id):
+        proposal = self._proposals.get(proposal_id)
+        return dict(proposal) if proposal else None
+
+    def list(self, status=None):
+        proposals = sorted(self._proposals.values(), key=lambda item: item["created_at"])
+        if status:
+            proposals = [proposal for proposal in proposals if proposal["status"] == status]
+        return [dict(proposal) for proposal in proposals]
+
+    def update(self, proposal_id, **changes):
+        proposal = self._proposals.get(proposal_id)
+        if proposal is None:
+            return None
+        proposal.update(changes)
+        proposal["updated_at"] = _utc_now()
+        self._save()
+        return dict(proposal)

--- a/robits/runtime/tool_proposals.py
+++ b/robits/runtime/tool_proposals.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -16,17 +17,19 @@ class ToolProposalStore:
     def __init__(self, path=None):
         self.path = Path(path) if path else None
         self._proposals = {}
-        if self.path is not None:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
-            if self.path.exists():
+        if self.path is not None and self.path.exists():
+            try:
                 with open(self.path, "r", encoding="utf-8") as handle:
                     data = json.load(handle)
-                for proposal in data.get("proposals", []):
-                    self._proposals[proposal["proposal_id"]] = proposal
+            except (OSError, json.JSONDecodeError) as error:
+                raise ValueError(f"Could not load tool proposal store '{self.path}': {error}") from error
+            for proposal in data.get("proposals", []):
+                self._proposals[proposal["proposal_id"]] = proposal
 
     def _save(self):
         if self.path is None:
             return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
         data = {"proposals": sorted(self._proposals.values(), key=lambda item: item["created_at"])}
         with open(self.path, "w", encoding="utf-8") as handle:
             json.dump(data, handle, indent=2, sort_keys=True)
@@ -55,8 +58,8 @@ class ToolProposalStore:
             "tool_name": tool_name,
             "action": action,
             "description": description,
-            "parameters": parameters or {"type": "object", "properties": {}, "required": []},
-            "required_capabilities": list(required_capabilities or []),
+            "parameters": deepcopy(parameters or {"type": "object", "properties": {}, "required": []}),
+            "required_capabilities": deepcopy(list(required_capabilities or [])),
             "owner_capability": owner_capability,
             "safety_notes": safety_notes or "",
             "implementation_notes": implementation_notes or "",
@@ -70,23 +73,23 @@ class ToolProposalStore:
         }
         self._proposals[proposal["proposal_id"]] = proposal
         self._save()
-        return dict(proposal)
+        return deepcopy(proposal)
 
     def get(self, proposal_id):
         proposal = self._proposals.get(proposal_id)
-        return dict(proposal) if proposal else None
+        return deepcopy(proposal) if proposal else None
 
     def list(self, status=None):
         proposals = sorted(self._proposals.values(), key=lambda item: item["created_at"])
         if status:
             proposals = [proposal for proposal in proposals if proposal["status"] == status]
-        return [dict(proposal) for proposal in proposals]
+        return deepcopy(proposals)
 
     def update(self, proposal_id, **changes):
         proposal = self._proposals.get(proposal_id)
         if proposal is None:
             return None
-        proposal.update(changes)
+        proposal.update(deepcopy(changes))
         proposal["updated_at"] = _utc_now()
         self._save()
-        return dict(proposal)
+        return deepcopy(proposal)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -64,6 +64,12 @@ def build_fake_participants():
 class RuntimeTests(unittest.TestCase):
     def setUp(self):
         main.tool_registry.clear()
+        self.original_tool_proposal_store = main.tool_proposal_store
+        main.tool_proposal_store = main.ToolProposalStore()
+        self.addCleanup(self.restore_tool_proposal_store)
+
+    def restore_tool_proposal_store(self):
+        main.tool_proposal_store = self.original_tool_proposal_store
 
     def test_parse_tool_instruction_handles_surrounding_text(self):
         response = 'Ops should run this:\n{"exec": "create_role", "args": {"role_name": "QA"}}\nDone.'
@@ -741,6 +747,203 @@ class RuntimeTests(unittest.TestCase):
             )
 
         self.assertIn("System tool", response)
+
+    def test_tool_proposal_lifecycle_can_be_listed_and_approved(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            propose_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.propose",
+                        "args": {
+                            "requested_by": "SE",
+                            "tool_name": "weather.lookup",
+                            "description": "Look up current weather for an agent location.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"location": {"type": "string"}},
+                                "required": ["location"],
+                            },
+                            "owner_capability": "operator",
+                            "safety_notes": "Network-backed; cache results.",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+            proposal = json.loads(propose_response.split("Result: ", 1)[1])
+            list_response = system.interact(
+                json.dumps({"exec": "tools.list_proposals", "args": {"status": "proposed"}}),
+                caller=employee_dict["SE"],
+            )
+            approve_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.approve_proposal",
+                        "args": {
+                            "proposal_id": proposal["proposal_id"],
+                            "approved_by": "Ops",
+                            "implementation_notes": "Implement as a provider-backed function tool.",
+                        },
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+
+        proposals = json.loads(list_response.split("Result: ", 1)[1])
+        approved = json.loads(approve_response.split("Result: ", 1)[1])
+
+        self.assertEqual(proposal["status"], "proposed")
+        self.assertEqual(proposal["parameters"]["required"], ["location"])
+        self.assertEqual(proposals[0]["proposal_id"], proposal["proposal_id"])
+        self.assertEqual(approved["status"], "approved")
+        self.assertEqual(approved["approver"], "Ops")
+
+    def test_operator_can_reject_tool_proposal(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            proposal = json.loads(
+                system.interact(
+                    json.dumps(
+                        {
+                            "exec": "tools.propose",
+                            "args": {
+                                "requested_by": "SE",
+                                "tool_name": "weather.lookup",
+                                "description": "Look up current weather.",
+                            },
+                        }
+                    ),
+                    caller=employee_dict["SE"],
+                ).split("Result: ", 1)[1]
+            )
+            reject_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.reject_proposal",
+                        "args": {
+                            "proposal_id": proposal["proposal_id"],
+                            "rejected_by": "Ops",
+                            "reason": "Needs a safer provider design.",
+                        },
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+
+        rejected = json.loads(reject_response.split("Result: ", 1)[1])
+
+        self.assertEqual(rejected["status"], "rejected")
+        self.assertEqual(rejected["rejection_reason"], "Needs a safer provider design.")
+
+    def test_tool_proposal_rollout_grants_registered_tool_access(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            system.interact(
+                json.dumps(
+                    {
+                        "name": "weather.lookup",
+                        "description": "Look up current weather.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"location": {"type": "string"}},
+                            "required": ["location"],
+                        },
+                        "code": "return 'sunny'",
+                    }
+                ),
+                trusted=True,
+            )
+            proposal = json.loads(
+                system.interact(
+                    json.dumps(
+                        {
+                            "exec": "tools.propose",
+                            "args": {
+                                "requested_by": "SE",
+                                "tool_name": "weather.lookup",
+                                "description": "Roll weather lookup out to SE.",
+                                "action": "update",
+                            },
+                        }
+                    ),
+                    caller=employee_dict["SE"],
+                ).split("Result: ", 1)[1]
+            )
+            system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.approve_proposal",
+                        "args": {"proposal_id": proposal["proposal_id"], "approved_by": "Ops"},
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+            rollout_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.rollout_proposal",
+                        "args": {
+                            "proposal_id": proposal["proposal_id"],
+                            "role_name": "SE",
+                            "granted_by": "Ops",
+                        },
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+
+        rollout = json.loads(rollout_response.split("Result: ", 1)[1])
+
+        self.assertEqual(rollout["proposal"]["status"], "operationalized")
+        self.assertIn("weather.lookup", employee_dict["SE"].allowed_tools)
+
+    def test_tool_proposal_rollout_requires_registered_tool(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            proposal = json.loads(
+                system.interact(
+                    json.dumps(
+                        {
+                            "exec": "tools.propose",
+                            "args": {
+                                "requested_by": "SE",
+                                "tool_name": "weather.lookup",
+                                "description": "Look up current weather.",
+                            },
+                        }
+                    ),
+                    caller=employee_dict["SE"],
+                ).split("Result: ", 1)[1]
+            )
+            system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.approve_proposal",
+                        "args": {"proposal_id": proposal["proposal_id"], "approved_by": "Ops"},
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+            response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "tools.rollout_proposal",
+                        "args": {"proposal_id": proposal["proposal_id"], "role_name": "SE"},
+                    }
+                ),
+                caller=employee_dict["Ops"],
+            )
+
+        self.assertIn("not registered", response)
 
     def test_tools_list_reports_allowed_access_for_role(self):
         employee_dict = main.build_employee_dict()

--- a/tests/test_tool_proposals.py
+++ b/tests/test_tool_proposals.py
@@ -1,0 +1,25 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from robits.runtime.tool_proposals import ToolProposalStore
+
+
+class ToolProposalStoreTests(unittest.TestCase):
+    def test_json_store_persists_proposals(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "tool_proposals.json"
+            store = ToolProposalStore(path)
+            proposal = store.create(
+                requested_by="SE",
+                tool_name="weather.lookup",
+                description="Look up weather.",
+            )
+
+            reloaded = ToolProposalStore(path)
+
+        self.assertEqual(reloaded.get(proposal["proposal_id"])["tool_name"], "weather.lookup")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_proposals.py
+++ b/tests/test_tool_proposals.py
@@ -20,6 +20,34 @@ class ToolProposalStoreTests(unittest.TestCase):
 
         self.assertEqual(reloaded.get(proposal["proposal_id"])["tool_name"], "weather.lookup")
 
+    def test_constructor_defers_directory_creation_until_save(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "nested" / "tool_proposals.json"
+
+            ToolProposalStore(path)
+
+            self.assertFalse(path.parent.exists())
+
+    def test_returned_records_do_not_mutate_store_state(self):
+        store = ToolProposalStore()
+        proposal = store.create(
+            requested_by="SE",
+            tool_name="weather.lookup",
+            description="Look up weather.",
+            parameters={
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        )
+
+        proposal["parameters"]["required"].append("unit")
+        listed = store.list()
+        listed[0]["parameters"]["required"].append("country")
+        fetched = store.get(proposal["proposal_id"])
+
+        self.assertEqual(fetched["parameters"]["required"], ["location"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools.yaml
+++ b/tools.yaml
@@ -428,6 +428,23 @@
           - create
           - update
         description: Proposal action.
+      parameters:
+        type: object
+        description: Proposed JSON Schema parameters for the model-facing function.
+      required_capabilities:
+        type: array
+        items:
+          type: string
+        description: Capabilities required to call the proposed tool.
+      owner_capability:
+        type: string
+        description: Capability that owns operational approval for this tool.
+      safety_notes:
+        type: string
+        description: Safety or operational constraints for implementation.
+      implementation_notes:
+        type: string
+        description: Notes for the engineer or operator implementing the proposal.
     required:
       - requested_by
       - tool_name
@@ -439,4 +456,114 @@
         tool_name,
         description,
         action=action if action is not None else "create",
+        parameters=parameters,
+        required_capabilities=required_capabilities,
+        owner_capability=owner_capability,
+        safety_notes=safety_notes if safety_notes is not None else "",
+        implementation_notes=implementation_notes if implementation_notes is not None else "",
+    )
+- name: tools.list_proposals
+  system_tool: true
+  grantable: false
+  description: List managed tool proposals and their lifecycle status.
+  parameters:
+    type: object
+    properties:
+      status:
+        type: string
+        enum:
+          - proposed
+          - approved
+          - rejected
+          - operationalized
+        description: Optional proposal status filter.
+    required: []
+  code: |
+    return list_tool_proposals(employee_dict, status=status)
+- name: tools.approve_proposal
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - operator
+  owner_capability: operator
+  description: Approve a proposed tool change for implementation or rollout.
+  parameters:
+    type: object
+    properties:
+      proposal_id:
+        type: string
+        description: Proposal ID to approve.
+      approved_by:
+        type: string
+        description: Operator approving the proposal.
+      implementation_notes:
+        type: string
+        description: Notes on implementation or rollout conditions.
+    required:
+      - proposal_id
+      - approved_by
+  code: |
+    return approve_tool_proposal(
+        employee_dict,
+        proposal_id,
+        approved_by,
+        implementation_notes=implementation_notes if implementation_notes is not None else "",
+    )
+- name: tools.reject_proposal
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - operator
+  owner_capability: operator
+  description: Reject a proposed tool change with a reason.
+  parameters:
+    type: object
+    properties:
+      proposal_id:
+        type: string
+        description: Proposal ID to reject.
+      rejected_by:
+        type: string
+        description: Operator rejecting the proposal.
+      reason:
+        type: string
+        description: Reason for rejection.
+    required:
+      - proposal_id
+      - rejected_by
+      - reason
+  code: |
+    return reject_tool_proposal(employee_dict, proposal_id, rejected_by, reason)
+- name: tools.rollout_proposal
+  system_tool: true
+  grantable: false
+  required_capabilities:
+    - operator
+  owner_capability: operator
+  description: Roll out an approved, implemented proposal by granting its tool to a role.
+  parameters:
+    type: object
+    properties:
+      proposal_id:
+        type: string
+        description: Proposal ID to roll out.
+      role_name:
+        type: string
+        description: Role receiving access to the approved tool.
+      granted_by:
+        type: string
+        description: Operator granting access.
+      rollout_notes:
+        type: string
+        description: Notes about rollout scope or operating constraints.
+    required:
+      - proposal_id
+      - role_name
+  code: |
+    return rollout_tool_proposal(
+        employee_dict,
+        proposal_id,
+        role_name,
+        granted_by=granted_by,
+        rollout_notes=rollout_notes if rollout_notes is not None else "",
     )


### PR DESCRIPTION
## Summary
- add a JSON-backed tool proposal registry for durable proposal state
- extend `tools.propose` with schema, capability, safety, and implementation metadata
- add proposal list, approve, reject, and rollout tools so Ops can operationalize approved tools through grants

## Validation
- `$stub = Join-Path $env:TEMP 'robits-openai-stub'; $env:PYTHONPATH = "$stub;$PWD"; py -3 -m unittest`

Closes #43

Created by Codex GPT-5.5.