### PR TITLE
Give agents private workspace tools

### DIFF
--- a/main.py
+++ b/main.py
@@ -804,8 +804,9 @@ def workspace_read(employee_dict, agent_name, path, max_bytes=65536):
     if error:
         return error
     try:
+        read_limit = 65536 if max_bytes is None else int(max_bytes)
         return json.dumps(
-            agent_workspace_store.read(normalized_name, path, max_bytes=int(max_bytes or 65536)),
+            agent_workspace_store.read(normalized_name, path, max_bytes=read_limit),
             sort_keys=True,
         )
     except (WorkspacePathError, ValueError) as e:

--- a/main.py
+++ b/main.py
@@ -20,6 +20,7 @@ from uuid import uuid4
 from robits.memory.sqlite import SQLiteMemoryStore
 from robits.runtime.sandbox import SandboxMetadata
 from robits.runtime.tool_proposals import ToolProposalStore
+from robits.runtime.workspace import AgentWorkspaceStore, WorkspacePathError
 
 
 class TeeStream:
@@ -63,6 +64,7 @@ model_call_gate = threading.BoundedSemaphore(max_parallelism)
 memory_db_path = os.environ.get("ROBITS_MEMORY_DB")
 memory_store = SQLiteMemoryStore(memory_db_path) if memory_db_path else None
 tool_proposal_store = None
+agent_workspace_store = AgentWorkspaceStore()
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
 SAFE_TOOL_BUILTINS = {
@@ -192,6 +194,10 @@ class ToolRegistry:
                 "approve_tool_proposal": approve_tool_proposal,
                 "reject_tool_proposal": reject_tool_proposal,
                 "rollout_tool_proposal": rollout_tool_proposal,
+                "workspace_list": workspace_list,
+                "workspace_read": workspace_read,
+                "workspace_write": workspace_write,
+                "workspace_delete": workspace_delete,
                 "current_agent_context": current_agent_context,
             },
             local_dict,
@@ -769,6 +775,63 @@ def _caller_can_act_for_agent(agent_name):
 
 def _caller_name_for_error():
     return active_tool_caller_name or getattr(active_tool_caller, "name", "unknown caller")
+
+
+def _workspace_agent_name(agent_name):
+    try:
+        normalized_name = validate_role_name(agent_name)
+    except ValueError as e:
+        return None, f"Error: {e}"
+    if not _caller_can_act_for_agent(normalized_name):
+        return None, f"Error: Role '{_caller_name_for_error()}' cannot access workspace for '{normalized_name}'."
+    return normalized_name, None
+
+
+def workspace_list(employee_dict, agent_name, path=""):
+    del employee_dict
+    normalized_name, error = _workspace_agent_name(agent_name)
+    if error:
+        return error
+    try:
+        return json.dumps(agent_workspace_store.list(normalized_name, path), sort_keys=True)
+    except WorkspacePathError as e:
+        return f"Error: {e}"
+
+
+def workspace_read(employee_dict, agent_name, path, max_bytes=65536):
+    del employee_dict
+    normalized_name, error = _workspace_agent_name(agent_name)
+    if error:
+        return error
+    try:
+        return json.dumps(
+            agent_workspace_store.read(normalized_name, path, max_bytes=int(max_bytes or 65536)),
+            sort_keys=True,
+        )
+    except (WorkspacePathError, ValueError) as e:
+        return f"Error: {e}"
+
+
+def workspace_write(employee_dict, agent_name, path, content, append=False):
+    del employee_dict
+    normalized_name, error = _workspace_agent_name(agent_name)
+    if error:
+        return error
+    try:
+        return json.dumps(agent_workspace_store.write(normalized_name, path, content, append=append), sort_keys=True)
+    except WorkspacePathError as e:
+        return f"Error: {e}"
+
+
+def workspace_delete(employee_dict, agent_name, path):
+    del employee_dict
+    normalized_name, error = _workspace_agent_name(agent_name)
+    if error:
+        return error
+    try:
+        return json.dumps(agent_workspace_store.delete(normalized_name, path), sort_keys=True)
+    except WorkspacePathError as e:
+        return f"Error: {e}"
 
 
 def grant_tool_access(employee_dict, role_name, tool_name, granted_by=None):

--- a/robits/runtime/workspace.py
+++ b/robits/runtime/workspace.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path, PurePosixPath
 
+MAX_READ_BYTES = 1024 * 1024
+
 
 class WorkspacePathError(ValueError):
     pass
@@ -26,8 +28,10 @@ class AgentWorkspaceStore:
     def _resolve(self, agent_name, relative_path=""):
         workspace = self.workspace_root(agent_name).resolve()
         raw_path = "" if relative_path is None else str(relative_path).strip()
+        if "\\" in raw_path or ":" in raw_path:
+            raise WorkspacePathError("Path must use relative POSIX-style separators inside the agent workspace.")
         posix_path = PurePosixPath(raw_path)
-        if posix_path.is_absolute() or any(part == ".." for part in posix_path.parts):
+        if posix_path.is_absolute() or posix_path.anchor or any(part == ".." for part in posix_path.parts):
             raise WorkspacePathError("Path must be relative and stay inside the agent workspace.")
         target = (workspace / Path(*posix_path.parts)).resolve()
         if target != workspace and workspace not in target.parents:
@@ -51,16 +55,21 @@ class AgentWorkspaceStore:
 
     def read(self, agent_name, relative_path, max_bytes=65536):
         workspace, target = self._resolve(agent_name, relative_path)
+        max_bytes = int(max_bytes)
+        if max_bytes < 0 or max_bytes > MAX_READ_BYTES:
+            raise WorkspacePathError(f"max_bytes must be between 0 and {MAX_READ_BYTES}.")
         if not target.exists() or not target.is_file():
             raise WorkspacePathError("File not found.")
-        data = target.read_bytes()
+        with open(target, "rb") as handle:
+            data = handle.read(max_bytes + 1)
+        size = target.stat().st_size
         truncated = len(data) > max_bytes
         content = data[:max_bytes].decode("utf-8", errors="replace")
         return {
             "path": target.relative_to(workspace).as_posix(),
             "content": content,
             "truncated": truncated,
-            "size": len(data),
+            "size": size,
         }
 
     def write(self, agent_name, relative_path, content, append=False):
@@ -84,9 +93,19 @@ class AgentWorkspaceStore:
         if not target.exists():
             raise WorkspacePathError("Path not found.")
         if target.is_dir():
-            target.rmdir()
+            try:
+                target.rmdir()
+            except OSError as error:
+                raise WorkspacePathError(
+                    f"Could not delete directory '{target.relative_to(workspace).as_posix()}': directory is not empty or is unavailable."
+                ) from error
             kind = "directory"
         else:
-            target.unlink()
+            try:
+                target.unlink()
+            except OSError as error:
+                raise WorkspacePathError(
+                    f"Could not delete file '{target.relative_to(workspace).as_posix()}': file is unavailable."
+                ) from error
             kind = "file"
         return {"path": target.relative_to(workspace).as_posix(), "kind": kind}

--- a/robits/runtime/workspace.py
+++ b/robits/runtime/workspace.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path, PurePosixPath
+
+
+class WorkspacePathError(ValueError):
+    pass
+
+
+def safe_agent_workspace_name(agent_name):
+    if not isinstance(agent_name, str) or not agent_name.strip():
+        raise WorkspacePathError("Agent name must be a non-empty string.")
+    return "".join(char if char.isalnum() or char in ("-", "_") else "_" for char in agent_name.strip())
+
+
+class AgentWorkspaceStore:
+    """Private persistent filesystem roots for agents."""
+
+    def __init__(self, root=None):
+        self.root = Path(root or os.environ.get("ROBITS_AGENT_WORKSPACE_ROOT", "var/agents"))
+
+    def workspace_root(self, agent_name):
+        return self.root / safe_agent_workspace_name(agent_name)
+
+    def _resolve(self, agent_name, relative_path=""):
+        workspace = self.workspace_root(agent_name).resolve()
+        raw_path = "" if relative_path is None else str(relative_path).strip()
+        posix_path = PurePosixPath(raw_path)
+        if posix_path.is_absolute() or any(part == ".." for part in posix_path.parts):
+            raise WorkspacePathError("Path must be relative and stay inside the agent workspace.")
+        target = (workspace / Path(*posix_path.parts)).resolve()
+        if target != workspace and workspace not in target.parents:
+            raise WorkspacePathError("Path escapes the agent workspace.")
+        return workspace, target
+
+    def list(self, agent_name, relative_path=""):
+        workspace, target = self._resolve(agent_name, relative_path)
+        target.mkdir(parents=True, exist_ok=True)
+        entries = []
+        for child in sorted(target.iterdir(), key=lambda item: item.name.lower()):
+            relative = child.relative_to(workspace).as_posix()
+            entries.append(
+                {
+                    "path": relative,
+                    "kind": "directory" if child.is_dir() else "file",
+                    "size": child.stat().st_size if child.is_file() else None,
+                }
+            )
+        return entries
+
+    def read(self, agent_name, relative_path, max_bytes=65536):
+        workspace, target = self._resolve(agent_name, relative_path)
+        if not target.exists() or not target.is_file():
+            raise WorkspacePathError("File not found.")
+        data = target.read_bytes()
+        truncated = len(data) > max_bytes
+        content = data[:max_bytes].decode("utf-8", errors="replace")
+        return {
+            "path": target.relative_to(workspace).as_posix(),
+            "content": content,
+            "truncated": truncated,
+            "size": len(data),
+        }
+
+    def write(self, agent_name, relative_path, content, append=False):
+        workspace, target = self._resolve(agent_name, relative_path)
+        if target == workspace:
+            raise WorkspacePathError("Path must name a file.")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        mode = "a" if append else "w"
+        with open(target, mode, encoding="utf-8") as handle:
+            handle.write("" if content is None else str(content))
+        return {
+            "path": target.relative_to(workspace).as_posix(),
+            "size": target.stat().st_size,
+            "append": bool(append),
+        }
+
+    def delete(self, agent_name, relative_path):
+        workspace, target = self._resolve(agent_name, relative_path)
+        if target == workspace:
+            raise WorkspacePathError("Cannot delete the workspace root.")
+        if not target.exists():
+            raise WorkspacePathError("Path not found.")
+        if target.is_dir():
+            target.rmdir()
+            kind = "directory"
+        else:
+            target.unlink()
+            kind = "file"
+        return {"path": target.relative_to(workspace).as_posix(), "kind": kind}

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -65,11 +65,16 @@ class RuntimeTests(unittest.TestCase):
     def setUp(self):
         main.tool_registry.clear()
         self.original_tool_proposal_store = main.tool_proposal_store
+        self.original_agent_workspace_store = main.agent_workspace_store
         main.tool_proposal_store = main.ToolProposalStore()
+        self.workspace_temp_dir = tempfile.TemporaryDirectory()
+        main.agent_workspace_store = main.AgentWorkspaceStore(self.workspace_temp_dir.name)
         self.addCleanup(self.restore_tool_proposal_store)
+        self.addCleanup(self.workspace_temp_dir.cleanup)
 
     def restore_tool_proposal_store(self):
         main.tool_proposal_store = self.original_tool_proposal_store
+        main.agent_workspace_store = self.original_agent_workspace_store
 
     def test_parse_tool_instruction_handles_surrounding_text(self):
         response = 'Ops should run this:\n{"exec": "create_role", "args": {"role_name": "QA"}}\nDone.'
@@ -1608,6 +1613,92 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(context["location"], "Philadelphia, PA")
         self.assertEqual(context["timezone"], "America/New_York")
         self.assertIn("current_datetime_local", context)
+
+    def test_agent_workspace_tools_write_list_read_and_delete_private_files(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            write_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_write",
+                        "args": {
+                            "agent_name": "SE",
+                            "path": "NOTES.md",
+                            "content": "Remember the build plan.",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+            list_response = system.interact(
+                json.dumps({"exec": "agent.files_list", "args": {"agent_name": "SE"}}),
+                caller=employee_dict["SE"],
+            )
+            read_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_read",
+                        "args": {"agent_name": "SE", "path": "NOTES.md"},
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+            delete_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_delete",
+                        "args": {"agent_name": "SE", "path": "NOTES.md"},
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+
+        written = json.loads(write_response.split("Result: ", 1)[1])
+        listed = json.loads(list_response.split("Result: ", 1)[1])
+        read = json.loads(read_response.split("Result: ", 1)[1])
+        deleted = json.loads(delete_response.split("Result: ", 1)[1])
+
+        self.assertEqual(written["path"], "NOTES.md")
+        self.assertEqual(listed[0]["path"], "NOTES.md")
+        self.assertEqual(read["content"], "Remember the build plan.")
+        self.assertEqual(deleted["kind"], "file")
+
+    def test_agent_workspace_rejects_cross_agent_and_escaping_paths(self):
+        employee_dict = main.build_employee_dict()
+        system = main.System(employee_dict)
+        with redirect_stdout(StringIO()):
+            main.load_tools(system)
+            cross_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_write",
+                        "args": {
+                            "agent_name": "HR",
+                            "path": "NOTES.md",
+                            "content": "nope",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+            escape_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_write",
+                        "args": {
+                            "agent_name": "SE",
+                            "path": "../escape.txt",
+                            "content": "nope",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+
+        self.assertIn("cannot access workspace", cross_response)
+        self.assertIn("Path must be relative", escape_response)
 
     def test_alarm_creation_rejects_past_due_at(self):
         employee_dict = main.build_employee_dict()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1696,9 +1696,37 @@ class RuntimeTests(unittest.TestCase):
                 ),
                 caller=employee_dict["SE"],
             )
+            windows_escape_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_write",
+                        "args": {
+                            "agent_name": "SE",
+                            "path": "..\\escape.txt",
+                            "content": "nope",
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
+            negative_read_response = system.interact(
+                json.dumps(
+                    {
+                        "exec": "agent.files_read",
+                        "args": {
+                            "agent_name": "SE",
+                            "path": "NOTES.md",
+                            "max_bytes": -1,
+                        },
+                    }
+                ),
+                caller=employee_dict["SE"],
+            )
 
         self.assertIn("cannot access workspace", cross_response)
         self.assertIn("Path must be relative", escape_response)
+        self.assertIn("POSIX-style separators", windows_escape_response)
+        self.assertIn("max_bytes must be between", negative_read_response)
 
     def test_alarm_creation_rejects_past_due_at(self):
         employee_dict = main.build_employee_dict()

--- a/tests/test_workspace_runtime.py
+++ b/tests/test_workspace_runtime.py
@@ -23,6 +23,33 @@ class AgentWorkspaceStoreTests(unittest.TestCase):
             with self.assertRaises(WorkspacePathError):
                 store.write("SE", "../escape.txt", "nope")
 
+            with self.assertRaises(WorkspacePathError):
+                store.write("SE", "..\\escape.txt", "nope")
+
+            with self.assertRaises(WorkspacePathError):
+                store.write("SE", "C:/escape.txt", "nope")
+
+    def test_workspace_read_streams_to_limit_and_validates_max_bytes(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AgentWorkspaceStore(temp_dir)
+            store.write("SE", "LOG.txt", "abcdef")
+
+            result = store.read("SE", "LOG.txt", max_bytes=3)
+
+            self.assertEqual(result["content"], "abc")
+            self.assertTrue(result["truncated"])
+            self.assertEqual(result["size"], 6)
+            with self.assertRaises(WorkspacePathError):
+                store.read("SE", "LOG.txt", max_bytes=-1)
+
+    def test_workspace_delete_sanitizes_non_empty_directory_error(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AgentWorkspaceStore(temp_dir)
+            store.write("SE", "notes/TODO.md", "ship it")
+
+            with self.assertRaisesRegex(WorkspacePathError, "Could not delete directory 'notes'"):
+                store.delete("SE", "notes")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workspace_runtime.py
+++ b/tests/test_workspace_runtime.py
@@ -1,0 +1,28 @@
+import tempfile
+import unittest
+
+from robits.runtime.workspace import AgentWorkspaceStore, WorkspacePathError
+
+
+class AgentWorkspaceStoreTests(unittest.TestCase):
+    def test_workspace_persists_files_under_agent_root(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AgentWorkspaceStore(temp_dir)
+            store.write("SE", "TODO.md", "ship it")
+            reloaded = AgentWorkspaceStore(temp_dir)
+
+            result = reloaded.read("SE", "TODO.md")
+
+        self.assertEqual(result["content"], "ship it")
+        self.assertEqual(result["path"], "TODO.md")
+
+    def test_workspace_rejects_path_escape(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            store = AgentWorkspaceStore(temp_dir)
+
+            with self.assertRaises(WorkspacePathError):
+                store.write("SE", "../escape.txt", "nope")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools.yaml
+++ b/tools.yaml
@@ -169,6 +169,98 @@
     required: []
   code: |
     return current_agent_context(employee_dict)
+- name: agent.files_list
+  required_capabilities: []
+  owner_capability: agent
+  description: List files in an agent's private workspace.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: Agent that owns the private workspace.
+      path:
+        type: string
+        description: Relative directory path to list.
+    required:
+      - agent_name
+  code: |
+    return workspace_list(employee_dict, agent_name, path=path if path is not None else "")
+- name: agent.files_read
+  required_capabilities: []
+  owner_capability: agent
+  description: Read a UTF-8 text file from an agent's private workspace.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: Agent that owns the private workspace.
+      path:
+        type: string
+        description: Relative file path to read.
+      max_bytes:
+        type: integer
+        description: Maximum bytes to read before truncation.
+    required:
+      - agent_name
+      - path
+  code: |
+    return workspace_read(
+        employee_dict,
+        agent_name,
+        path,
+        max_bytes=max_bytes if max_bytes is not None else 65536,
+    )
+- name: agent.files_write
+  required_capabilities: []
+  owner_capability: agent
+  description: Write or append a UTF-8 text file in an agent's private workspace.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: Agent that owns the private workspace.
+      path:
+        type: string
+        description: Relative file path to write.
+      content:
+        type: string
+        description: Text content to write.
+      append:
+        type: boolean
+        description: Append instead of replacing the file.
+    required:
+      - agent_name
+      - path
+      - content
+  code: |
+    return workspace_write(
+        employee_dict,
+        agent_name,
+        path,
+        content,
+        append=append if append is not None else False,
+    )
+- name: agent.files_delete
+  required_capabilities: []
+  owner_capability: agent
+  description: Delete a file or empty directory from an agent's private workspace.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: Agent that owns the private workspace.
+      path:
+        type: string
+        description: Relative file or empty directory path to delete.
+    required:
+      - agent_name
+      - path
+  code: |
+    return workspace_delete(employee_dict, agent_name, path)
 - name: agent.create_alarm
   required_capabilities: []
   owner_capability: agent


### PR DESCRIPTION
## Summary
- add a persistent per-agent private workspace store rooted under ignored runtime storage by default
- expose concise `agent.files_*` tools for list/read/write/delete within an agent workspace
- enforce relative path confinement and caller ownership checks so agents cannot access other agents' private files

## Validation
- `$stub = Join-Path $env:TEMP 'robits-openai-stub'; $env:PYTHONPATH = "$stub;$PWD"; py -3 -m unittest`

Closes #46

Created by Codex GPT-5.5.