### PR TITLE
Add memory search cascade, depth limits, and large result offloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ Relevant environment variables:
 - `ROBITS_MODEL` or `OPENAI_MODEL`: default chat model.
 - `ROBITS_CHEAP_MODEL` and `ROBITS_COSTLY_MODEL`: optional per-role overrides.
 - `ROBITS_MEMORY_DB`: optional SQLite memory database path for memory introspection tools.
+- `ROBITS_MEMORY_MAX_DEPTH`: maximum recursive digest expansion depth (default `3`).
+- `ROBITS_MEMORY_MAX_ROWS`: maximum rows returned by any memory tool (default `100`).
+- `ROBITS_MEMORY_CACHE_THRESHOLD`: byte threshold above which memory tool results are offloaded to the agent's private workspace and a condensed snippet is returned (default `8192`).
 - `ROBITS_PROVIDER_API`: model API path, `responses` by default or `chat_completions` for compatibility.
 - `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
 - `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.

--- a/main.py
+++ b/main.py
@@ -64,6 +64,9 @@ model_call_gate = threading.BoundedSemaphore(max_parallelism)
 memory_db_path = os.environ.get("ROBITS_MEMORY_DB")
 memory_store = SQLiteMemoryStore(memory_db_path) if memory_db_path else None
 tool_proposal_store = None
+memory_max_depth = max(0, int(os.environ.get("ROBITS_MEMORY_MAX_DEPTH", "3")))
+memory_max_rows = max(1, int(os.environ.get("ROBITS_MEMORY_MAX_ROWS", "100")))
+memory_cache_threshold = max(512, int(os.environ.get("ROBITS_MEMORY_CACHE_THRESHOLD", "8192")))
 agent_workspace_store = AgentWorkspaceStore()
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
@@ -1348,7 +1351,41 @@ def _require_memory_store():
     return memory_store, None
 
 
-def memory_search(employee_dict, agent_name, query, limit=10):
+def _write_memory_cache(agent_name, filename, content):
+    """Write content to the agent's .memory-cache/ workspace directory."""
+    cache_path = f".memory-cache/{filename}"
+    try:
+        agent_workspace_store.write(agent_name, cache_path, content)
+        return cache_path
+    except Exception:
+        return None
+
+
+def _condense_if_large(agent_name, tool_label, result_json):
+    """Return result_json directly, or cache it and return a snippet if too large."""
+    if len(result_json) <= memory_cache_threshold:
+        return result_json
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"{timestamp}_{tool_label.replace('.', '_')}.json"
+    cache_path = _write_memory_cache(agent_name, filename, result_json)
+    snippet = result_json[:2048]
+    condensed = {
+        "truncated": True,
+        "total_chars": len(result_json),
+        "snippet": snippet,
+    }
+    if cache_path:
+        condensed["cache_path"] = cache_path
+        condensed["note"] = (
+            f"Full result ({len(result_json)} chars) cached in agent workspace at "
+            f"'{cache_path}'. Use agent.files_read to retrieve it."
+        )
+    else:
+        condensed["note"] = "Result truncated; workspace cache unavailable."
+    return json.dumps(condensed, sort_keys=True)
+
+
+def memory_search(employee_dict, agent_name, query, limit=10, cascade=True):
     del employee_dict
     store, error = _require_memory_store()
     if error:
@@ -1361,8 +1398,13 @@ def memory_search(employee_dict, agent_name, query, limit=10):
         return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
     if not isinstance(query, str) or not query.strip():
         return "Error: Memory query must be a non-empty string."
-    results = store.search(query, agent_id=normalized_name, limit=int(limit or 10))
-    return json.dumps([result.__dict__ for result in results], sort_keys=True)
+    effective_limit = min(int(limit or 10), memory_max_rows)
+    if cascade:
+        results = store.search_cascade(query, agent_id=normalized_name, limit=effective_limit)
+    else:
+        results = store.search(query, agent_id=normalized_name, limit=effective_limit)
+    result_json = json.dumps([result.__dict__ for result in results], sort_keys=True)
+    return _condense_if_large(normalized_name, "memory_search", result_json)
 
 
 def memory_list_digests(employee_dict, agent_name, digest_type=None, limit=10):
@@ -1376,17 +1418,19 @@ def memory_list_digests(employee_dict, agent_name, digest_type=None, limit=10):
         return f"Error: {e}"
     if not _caller_can_act_for_agent(normalized_name):
         return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
+    effective_limit = min(int(limit or 10), memory_max_rows)
     digests = store.list_memory_digests(
         agent_id=normalized_name,
         digest_type=digest_type,
         current_only=True,
         accessible_only=True,
-        limit=int(limit or 10),
+        limit=effective_limit,
     )
-    return json.dumps(digests, sort_keys=True)
+    result_json = json.dumps(digests, sort_keys=True)
+    return _condense_if_large(normalized_name, "memory_list_digests", result_json)
 
 
-def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True):
+def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True, max_depth=None, max_chars=None):
     del employee_dict
     store, error = _require_memory_store()
     if error:
@@ -1405,7 +1449,15 @@ def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True):
         return f"Error: Memory digest '{digest_id}' is not accessible to {normalized_name}."
     if digest.get("system_only") or digest.get("accessibility") != "agent":
         return f"Error: Memory digest '{digest_id}' is system-only."
-    rows = store.expand_memory_digest_sources(digest_id, recursive=recursive)
+    effective_depth = min(
+        int(max_depth) if max_depth is not None else memory_max_depth,
+        memory_max_depth,
+    )
+    rows = store.expand_memory_digest_sources(
+        digest_id,
+        recursive=recursive,
+        max_depth=effective_depth if recursive else None,
+    )
     rows = [
         {
             **row.__dict__,
@@ -1415,7 +1467,11 @@ def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True):
         else row
         for row in rows
     ]
-    return json.dumps(rows, sort_keys=True)
+    result_json = json.dumps(rows, sort_keys=True)
+    effective_max_chars = int(max_chars) if max_chars is not None else None
+    if effective_max_chars is not None and len(result_json) > effective_max_chars:
+        result_json = result_json[:effective_max_chars]
+    return _condense_if_large(normalized_name, "memory_expand_digest", result_json)
 
 
 def due_alarm_reminders(role, now=None):

--- a/main.py
+++ b/main.py
@@ -1366,7 +1366,7 @@ def _condense_if_large(agent_name, tool_label, result_json):
     if len(result_json) <= memory_cache_threshold:
         return result_json
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    filename = f"{timestamp}_{tool_label.replace('.', '_')}.json"
+    filename = f"{timestamp}_{tool_label.replace('.', '_')}_{uuid4().hex[:8]}.json"
     cache_path = _write_memory_cache(agent_name, filename, result_json)
     snippet = result_json[:2048]
     condensed = {
@@ -1398,7 +1398,7 @@ def memory_search(employee_dict, agent_name, query, limit=10, cascade=True):
         return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
     if not isinstance(query, str) or not query.strip():
         return "Error: Memory query must be a non-empty string."
-    effective_limit = min(int(limit or 10), memory_max_rows)
+    effective_limit = max(1, min(int(limit or 10), memory_max_rows))
     if cascade:
         results = store.search_cascade(query, agent_id=normalized_name, limit=effective_limit)
     else:
@@ -1418,7 +1418,7 @@ def memory_list_digests(employee_dict, agent_name, digest_type=None, limit=10):
         return f"Error: {e}"
     if not _caller_can_act_for_agent(normalized_name):
         return f"Error: Role '{_caller_name_for_error()}' cannot inspect memory for '{normalized_name}'."
-    effective_limit = min(int(limit or 10), memory_max_rows)
+    effective_limit = max(1, min(int(limit or 10), memory_max_rows))
     digests = store.list_memory_digests(
         agent_id=normalized_name,
         digest_type=digest_type,
@@ -1449,9 +1449,12 @@ def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True, m
         return f"Error: Memory digest '{digest_id}' is not accessible to {normalized_name}."
     if digest.get("system_only") or digest.get("accessibility") != "agent":
         return f"Error: Memory digest '{digest_id}' is system-only."
-    effective_depth = min(
-        int(max_depth) if max_depth is not None else memory_max_depth,
-        memory_max_depth,
+    effective_depth = max(
+        0,
+        min(
+            int(max_depth) if max_depth is not None else memory_max_depth,
+            memory_max_depth,
+        ),
     )
     rows = store.expand_memory_digest_sources(
         digest_id,
@@ -1467,10 +1470,16 @@ def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True, m
         else row
         for row in rows
     ]
+    rows = rows[:memory_max_rows]
     result_json = json.dumps(rows, sort_keys=True)
-    effective_max_chars = int(max_chars) if max_chars is not None else None
+    effective_max_chars = max(1, int(max_chars)) if max_chars is not None else None
     if effective_max_chars is not None and len(result_json) > effective_max_chars:
-        result_json = result_json[:effective_max_chars]
+        condensed = {
+            "truncated": True,
+            "total_chars": len(result_json),
+            "note": f"Result exceeded max_chars={effective_max_chars}. Use a higher max_chars or memory.search to narrow results.",
+        }
+        return json.dumps(condensed, sort_keys=True)
     return _condense_if_large(normalized_name, "memory_expand_digest", result_json)
 
 

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -933,11 +933,13 @@ class SQLiteMemoryStore:
         digest_id,
         recursive=False,
         include_digest_records=True,
+        max_depth=None,
     ):
         if recursive:
             return self._expand_memory_digest_sources_recursive(
                 int(digest_id),
                 include_digest_records=include_digest_records,
+                max_depth=max_depth,
             )
         expanded = []
         for source_ref in self.get_memory_digest_sources(digest_id):
@@ -1109,6 +1111,103 @@ class SQLiteMemoryStore:
         ).fetchall()
         return [MemorySearchResult(**dict(row)) for row in rows]
 
+    def search_cascade(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ):
+        """Search outer FTS records and surface parent digests for inner hits."""
+        outer = self.search(
+            query,
+            agent_id=agent_id,
+            session_id=session_id,
+            relationship_type=relationship_type,
+            conversation_type=conversation_type,
+            source=source,
+            start_at=start_at,
+            end_at=end_at,
+            limit=limit,
+        )
+
+        # Map FTS kind values to their canonical source_table names so we can
+        # look up whether each hit is a source of a parent digest.
+        _kind_to_table: dict[str, str] = {
+            "message": "messages",
+            "thought": "thoughts",
+            "tool_call": "tool_calls",
+        }
+
+        # Group non-digest outer hits by their source_table.
+        source_ids_by_table: dict[str, list[str]] = {
+            "messages": [],
+            "thoughts": [],
+            "tool_calls": [],
+            "memory_entries": [],
+        }
+        outer_digest_ids: set[str] = set()
+        for result in outer:
+            if result.kind == "memory_digest":
+                outer_digest_ids.add(result.record_id)
+                continue
+            table = _kind_to_table.get(result.kind, "memory_entries")
+            source_ids_by_table[table].append(result.record_id)
+
+        # For each non-digest outer hit, find accessible parent digests that
+        # reference it as a source.  Surface those digests at the outer level.
+        for source_table, source_ids in source_ids_by_table.items():
+            if not source_ids:
+                continue
+            placeholders = ", ".join("?" * len(source_ids))
+            params: list[Any] = [source_table] + source_ids
+            agent_clauses = []
+            if agent_id is not None:
+                agent_clauses.append("md.agent_id = ?")
+                params.append(agent_id)
+            params.append(limit)
+            agent_filter = f"AND ({' OR '.join(agent_clauses)})" if agent_clauses else ""
+            rows = self.connection.execute(
+                f"""
+                SELECT DISTINCT md.digest_id, md.agent_id, md.session_id,
+                       md.source, md.relationship_type, md.conversation_type,
+                       md.created_at, md.content
+                FROM memory_digest_sources mds
+                JOIN memory_digests md ON md.digest_id = mds.digest_id
+                WHERE mds.source_table = ?
+                  AND mds.source_id IN ({placeholders})
+                  AND md.accessibility = 'agent'
+                  AND md.system_only = 0
+                  {agent_filter}
+                LIMIT ?
+                """,
+                params,
+            ).fetchall()
+            for row in rows:
+                digest_id_str = str(row["digest_id"])
+                if digest_id_str not in outer_digest_ids:
+                    outer.append(
+                        MemorySearchResult(
+                            kind="memory_digest",
+                            record_id=digest_id_str,
+                            content=row["content"],
+                            agent_id=row["agent_id"],
+                            session_id=row["session_id"],
+                            source=row["source"],
+                            relationship_type=row["relationship_type"],
+                            conversation_type=row["conversation_type"],
+                            created_at=row["created_at"],
+                        )
+                    )
+                    outer_digest_ids.add(digest_id_str)
+
+        return outer[:limit]
+
     def _index(
         self,
         kind,
@@ -1214,11 +1313,14 @@ class SQLiteMemoryStore:
         self,
         digest_id,
         include_digest_records=True,
+        max_depth=None,
     ):
         expanded: list[ExpandedMemoryDigestSource] = []
 
         def visit(current_digest_id, depth, path, visited):
             if current_digest_id in visited:
+                return
+            if max_depth is not None and depth > max_depth:
                 return
             next_visited = visited | {current_digest_id}
             for source_ref in self.get_memory_digest_sources(current_digest_id):

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -1123,7 +1123,12 @@ class SQLiteMemoryStore:
         end_at=None,
         limit=20,
     ):
-        """Search outer FTS records and surface parent digests for inner hits."""
+        """Search outer FTS records and surface parent digests for inner hits.
+
+        Fetch more than ``limit`` inner records so that cascade-surfaced parent
+        digests have room after the final ``outer[:limit]`` trim.
+        """
+        inner_limit = max(limit, limit * 2)
         outer = self.search(
             query,
             agent_id=agent_id,
@@ -1133,7 +1138,7 @@ class SQLiteMemoryStore:
             source=source,
             start_at=start_at,
             end_at=end_at,
-            limit=limit,
+            limit=inner_limit,
         )
 
         # Map FTS kind values to their canonical source_table names so we can

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -583,6 +583,92 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
                 agent_id="SE",
             )
 
+    def test_search_cascade_surfaces_parent_digest_for_inner_hits(self):
+        store = self.seed_store()
+        message_id = store.append_message(
+            "session-1",
+            "SE",
+            "HR",
+            "cascade inner content",
+            created_at="2026-05-07T10:00:00+00:00",
+        )
+        digest_id = store.append_memory_digest(
+            "Digest summarising the inner message.",
+            [{"source_table": "messages", "source_id": message_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+
+        # Direct FTS on inner content surfaces the message…
+        direct = store.search("cascade inner content", agent_id="SE")
+        # …but cascade should surface the parent digest at the outer level.
+        cascade = store.search_cascade("cascade inner content", agent_id="SE")
+
+        direct_kinds = {r.kind for r in direct}
+        cascade_kinds = {r.kind for r in cascade}
+        cascade_record_ids = {r.record_id for r in cascade}
+
+        self.assertIn("message", direct_kinds)
+        # The outer message hit is preserved…
+        self.assertIn("message", cascade_kinds)
+        # …and the parent digest is also surfaced.
+        self.assertIn("memory_digest", cascade_kinds)
+        self.assertIn(str(digest_id), cascade_record_ids)
+
+    def test_search_cascade_deduplicates_digest_already_in_outer_hits(self):
+        store = self.seed_store()
+        message_id = store.append_message(
+            "session-1",
+            "SE",
+            "HR",
+            "unique term xyzzy",
+            created_at="2026-05-07T10:00:00+00:00",
+        )
+        digest_id = store.append_memory_digest(
+            "Digest with unique term xyzzy in content.",
+            [{"source_table": "messages", "source_id": message_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+
+        cascade = store.search_cascade("xyzzy", agent_id="SE")
+
+        digest_hits = [r for r in cascade if r.kind == "memory_digest"]
+        self.assertEqual(len(digest_hits), 1, "Digest should appear exactly once.")
+        self.assertEqual(digest_hits[0].record_id, str(digest_id))
+
+    def test_expand_memory_digest_sources_respects_max_depth(self):
+        store = self.seed_store()
+        message_id = store.append_message("session-1", "CEO", "SE", "Leaf message.")
+        d1 = store.append_memory_digest(
+            "Depth 1 digest.",
+            [{"source_table": "messages", "source_id": message_id}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+        d2 = store.append_memory_digest(
+            "Depth 2 digest.",
+            [{"source_table": "memory_digests", "source_id": d1}],
+            agent_id="SE",
+            session_id="session-1",
+        )
+
+        # max_depth=0 means don't recurse into child digests.
+        depth0 = store.expand_memory_digest_sources(d2, recursive=True, max_depth=0)
+        # max_depth=1 allows one level of recursion into d1 and its raw sources.
+        depth1 = store.expand_memory_digest_sources(d2, recursive=True, max_depth=1)
+
+        depth0_tables = [r.source_table for r in depth0]
+        depth1_tables = [r.source_table for r in depth1]
+
+        # At depth 0 we see the immediate source (d1 digest record).
+        self.assertIn("memory_digests", depth0_tables)
+        self.assertNotIn("messages", depth0_tables)
+
+        # At depth 1 we also see the message inside d1.
+        self.assertIn("memory_digests", depth1_tables)
+        self.assertIn("messages", depth1_tables)
+
     def test_runtime_events_can_be_persisted_and_filtered(self):
         store = self.seed_store()
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2,9 +2,11 @@ import json
 import os
 import sys
 import tempfile
+import types
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -1993,6 +1995,202 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(event.event_type, "thought.recorded")
         self.assertEqual(event.visibility, "private")
         self.assertEqual(session.event_stream.events("private"), [event])
+
+
+class MemoryToolTests(unittest.TestCase):
+    """Tests for memory_search, memory_list_digests, memory_expand_digest in main.py."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.workspace_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.addCleanup(self.workspace_temp.cleanup)
+
+        from robits.memory.sqlite import SQLiteMemoryStore
+
+        self.store = SQLiteMemoryStore(
+            Path(self.store_temp.name) / "mem.sqlite3"
+        )
+        self.addCleanup(self.store.close)
+
+        self.original_store = main.memory_store
+        self.original_workspace = main.agent_workspace_store
+        main.memory_store = self.store
+        main.agent_workspace_store = main.AgentWorkspaceStore(self.workspace_temp.name)
+        self.addCleanup(self._restore)
+
+        # Seed baseline records.
+        self.store.create_session("s1")
+        self.store.upsert_agent("SE", "SoftwareEngineer", "SE")
+
+        # Make main think the tool caller is SE.
+        self._prev_caller = main.active_tool_caller
+        self._prev_caller_name = main.active_tool_caller_name
+        fake_role = types.SimpleNamespace(name="SE", capabilities=set())
+        main.active_tool_caller = fake_role
+        main.active_tool_caller_name = "SE"
+        self.fake_role = fake_role
+
+    def _restore(self):
+        main.memory_store = self.original_store
+        main.agent_workspace_store = self.original_workspace
+        main.active_tool_caller = self._prev_caller
+        main.active_tool_caller_name = self._prev_caller_name
+
+    # ── cascade search ────────────────────────────────────────────────────────
+
+    def test_memory_search_cascade_true_surfaces_parent_digest(self):
+        msg_id = self.store.append_message("s1", "SE", "SE", "cascade content unique_kw")
+        digest_id = self.store.append_memory_digest(
+            "Digest summary.",
+            [{"source_table": "messages", "source_id": msg_id}],
+            agent_id="SE",
+            session_id="s1",
+        )
+
+        result_json = main.memory_search({}, "SE", "unique_kw", cascade=True)
+        results = json.loads(result_json)
+
+        kinds = {r["kind"] for r in results}
+        self.assertIn("memory_digest", kinds)
+
+    def test_memory_search_cascade_false_returns_only_outer(self):
+        msg_id = self.store.append_message("s1", "SE", "SE", "inner only content abc123")
+        self.store.append_memory_digest(
+            "Digest with inner content.",
+            [{"source_table": "messages", "source_id": msg_id}],
+            agent_id="SE",
+            session_id="s1",
+        )
+
+        result_json = main.memory_search({}, "SE", "abc123", cascade=False)
+        results = json.loads(result_json)
+
+        # Without cascade, only the raw message hit is returned, not the digest.
+        kinds = {r["kind"] for r in results}
+        self.assertIn("message", kinds)
+        self.assertNotIn("memory_digest", kinds)
+
+    # ── large result offloading ───────────────────────────────────────────────
+
+    def test_condense_if_large_returns_raw_when_small(self):
+        small = json.dumps({"ok": True})
+        result = main._condense_if_large("SE", "memory_search", small)
+        self.assertEqual(result, small)
+
+    def test_condense_if_large_caches_and_returns_snippet_when_big(self):
+        big = json.dumps({"data": "x" * (main.memory_cache_threshold + 1)})
+        original_threshold = main.memory_cache_threshold
+        # Lower threshold temporarily.
+        main.memory_cache_threshold = 64
+        try:
+            padded = json.dumps({"data": "y" * 200})
+            result_json = main._condense_if_large("SE", "memory_search", padded)
+        finally:
+            main.memory_cache_threshold = original_threshold
+
+        result = json.loads(result_json)
+        self.assertTrue(result.get("truncated"))
+        self.assertIn("snippet", result)
+        self.assertIn("cache_path", result)
+        self.assertIn(".memory-cache/", result["cache_path"])
+
+    def test_large_memory_search_result_is_offloaded_to_workspace(self):
+        # Insert many records so the result JSON exceeds the cache threshold.
+        for i in range(20):
+            self.store.append_message("s1", "SE", "SE", f"searchable content record number {i} verbosity padding")
+
+        original_threshold = main.memory_cache_threshold
+        main.memory_cache_threshold = 64
+        main.tool_registry.clear()
+        try:
+            result_json = main.memory_search({}, "SE", "searchable content", limit=20)
+            result = json.loads(result_json)
+        finally:
+            main.memory_cache_threshold = original_threshold
+
+        self.assertTrue(result.get("truncated"))
+        cache_path = result.get("cache_path")
+        self.assertIsNotNone(cache_path)
+
+        # The full result should be readable from the workspace.
+        full = main.agent_workspace_store.read("SE", cache_path)
+        self.assertFalse(full["truncated"])
+        self.assertIn("searchable content", full["content"])
+
+    # ── expand digest depth limit ─────────────────────────────────────────────
+
+    def test_expand_digest_respects_max_depth_param(self):
+        msg_id = self.store.append_message("s1", "SE", "SE", "leaf node content")
+        d1 = self.store.append_memory_digest(
+            "Depth-1 digest.",
+            [{"source_table": "messages", "source_id": msg_id}],
+            agent_id="SE",
+            session_id="s1",
+        )
+        d2 = self.store.append_memory_digest(
+            "Depth-2 digest.",
+            [{"source_table": "memory_digests", "source_id": d1}],
+            agent_id="SE",
+            session_id="s1",
+        )
+
+        result_json = main.memory_expand_digest({}, "SE", d2, recursive=True, max_depth=0)
+        rows = json.loads(result_json)
+
+        tables = [r["source_table"] for r in rows]
+        self.assertIn("memory_digests", tables)
+        self.assertNotIn("messages", tables)
+
+    def test_expand_digest_max_depth_capped_by_global_limit(self):
+        original = main.memory_max_depth
+        main.memory_max_depth = 1
+        try:
+            msg_id = self.store.append_message("s1", "SE", "SE", "deep leaf")
+            d1 = self.store.append_memory_digest(
+                "d1", [{"source_table": "messages", "source_id": msg_id}], agent_id="SE"
+            )
+            d2 = self.store.append_memory_digest(
+                "d2", [{"source_table": "memory_digests", "source_id": d1}], agent_id="SE"
+            )
+            d3 = self.store.append_memory_digest(
+                "d3", [{"source_table": "memory_digests", "source_id": d2}], agent_id="SE"
+            )
+
+            # Ask for max_depth=99 but global limit is 1.
+            result_json = main.memory_expand_digest({}, "SE", d3, recursive=True, max_depth=99)
+            rows = json.loads(result_json)
+        finally:
+            main.memory_max_depth = original
+
+        tables = [r["source_table"] for r in rows]
+        # At global max_depth=1 we see d2 (depth 0) and d1 (depth 1) but not messages (depth 2).
+        self.assertIn("memory_digests", tables)
+        self.assertNotIn("messages", tables)
+
+    # ── agent isolation ───────────────────────────────────────────────────────
+
+    def test_memory_search_blocked_for_different_agent(self):
+        self.store.upsert_agent("HR", "HR", "HR")
+        self.store.append_message("s1", "HR", "HR", "private HR content")
+
+        # Caller is SE, trying to inspect HR's memory.
+        result = main.memory_search({}, "HR", "private HR content")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_memory_list_digests_blocked_for_different_agent(self):
+        self.store.upsert_agent("HR", "HR", "HR")
+        result = main.memory_list_digests({}, "HR")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_memory_expand_digest_blocked_for_different_agent_digest(self):
+        self.store.upsert_agent("HR", "HR", "HR")
+        msg_id = self.store.append_message("s1", "HR", "HR", "HR private.")
+        digest_id = self.store.append_memory_digest(
+            "HR digest.", [{"source_table": "messages", "source_id": msg_id}], agent_id="HR"
+        )
+        result = main.memory_expand_digest({}, "HR", digest_id)
+        self.assertTrue(result.startswith("Error:"))
 
 
 if __name__ == "__main__":

--- a/tools.yaml
+++ b/tools.yaml
@@ -342,7 +342,7 @@
   system_tool: true
   grantable: true
   owner_capability: system
-  description: Search an agent's accessible SQLite memory records.
+  description: Search an agent's accessible SQLite memory records. Returns outer-level FTS hits and surfaces parent digests for any inner records that also match.
   parameters:
     type: object
     properties:
@@ -355,6 +355,9 @@
       limit:
         type: integer
         description: Maximum number of records to return.
+      cascade:
+        type: boolean
+        description: Also search inner source records of digests and surface parent digests for matches (default true).
     required:
       - agent_name
       - query
@@ -364,6 +367,7 @@
         agent_name,
         query,
         limit=limit if limit is not None else 10,
+        cascade=cascade if cascade is not None else True,
     )
 - name: memory.list_digests
   system_tool: true
@@ -413,6 +417,12 @@
       recursive:
         type: boolean
         description: Include cascading digest sources recursively.
+      max_depth:
+        type: integer
+        description: Maximum recursive expansion depth (capped by ROBITS_MEMORY_MAX_DEPTH).
+      max_chars:
+        type: integer
+        description: Maximum characters to include in the returned result before truncation.
     required:
       - agent_name
       - digest_id
@@ -422,6 +432,8 @@
         agent_name,
         digest_id,
         recursive=recursive if recursive is not None else True,
+        max_depth=max_depth,
+        max_chars=max_chars,
     )
 - name: tools.list
   system_tool: true


### PR DESCRIPTION
Closes #51

## Summary

- **Cascade search**: `memory.search` now searches both outer FTS records and inner source records of accessible digests. If a raw record (message, thought, tool_call, memory_entry) matches the query AND is a source of a parent digest, that digest is surfaced at the outer level. Agents drill into it with `memory.expand_digest`. The new `cascade` boolean param (default `true`) controls this.

- **Traversal depth limits**: `memory.expand_digest` accepts `max_depth` (capped globally by `ROBITS_MEMORY_MAX_DEPTH`, default 3). `ROBITS_MEMORY_MAX_ROWS` (default 100) caps result rows across all three memory tools.

- **Large result offloading**: `_condense_if_large` checks result size against `ROBITS_MEMORY_CACHE_THRESHOLD` (default 8192 bytes). When exceeded, the full JSON is written to `.memory-cache/<timestamp>_<tool>.json` in the agent's private workspace. A snippet + `cache_path` reference are returned; the agent reads the full result with `agent.files_read`.

- `tools.yaml`: `memory.search` gains `cascade`; `memory.expand_digest` gains `max_depth` and `max_chars`.

## Test plan

- [ ] `python -m unittest` passes (128 tests, +13 new)
- [ ] `test_search_cascade_surfaces_parent_digest_for_inner_hits` — cascade finds parent digests
- [ ] `test_search_cascade_deduplicates_digest_already_in_outer_hits` — no double digest entries
- [ ] `test_expand_memory_digest_sources_respects_max_depth` — depth 0 stops at digest node, depth 1 reaches messages
- [ ] `test_large_memory_search_result_is_offloaded_to_workspace` — full result readable from `.memory-cache/`
- [ ] `test_memory_search_blocked_for_different_agent` — isolation still enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)