### PR TITLE
Add builtin.* tool namespace mirroring OpenAI built-in tool types

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Relevant environment variables:
 - `ROBITS_PROVIDER_API`: model API path, `responses` by default or `chat_completions` for compatibility.
 - `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
 - `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.
+- `ROBITS_SEARCH_URL`: optional custom web search endpoint for `builtin.web_search`; falls back to the DuckDuckGo Instant Answers API.
 
 ## Tools
 
@@ -115,6 +116,22 @@ only expose tools allowed for the active role, and execution denies disallowed
 tool calls. Operator roles can grant or revoke tool access, SE can propose
 non-system tool changes, and system tools such as memory internals and HR role
 management cannot be changed through SE proposals.
+
+The `builtin.*` namespace provides equivalents of the OpenAI built-in tool types
+as client-side function tools that work with any OpenAI-compatible endpoint:
+
+| Tool | Description | Capability required |
+|---|---|---|
+| `builtin.web_search` | Search the web via DuckDuckGo or `ROBITS_SEARCH_URL` | — |
+| `builtin.file_search` | Search text in an agent's private workspace files | — |
+| `builtin.shell_run` | Run a shell command in the agent's workspace directory | `shell` |
+| `builtin.tool_search` | Search the tool registry by name or description | — |
+| `builtin.mcp_call` | Call a tool on an MCP server (not yet implemented) | `mcp` |
+| `builtin.computer_use` | Computer-use actions (not implemented) | `computer` |
+| `builtin.image_generation` | Generate images (not implemented) | — |
+
+All `builtin.*` tools are grantable. None are in the default tool grants; operators
+grant access explicitly via `tools.grant`.
 
 Example execution payload:
 

--- a/main.py
+++ b/main.py
@@ -1494,9 +1494,9 @@ def builtin_file_search(employee_dict, agent_name, query, path="", max_results=1
     limit = max(1, min(100, int(max_results or 10)))
     results = []
     try:
-        candidates = sorted(search_root.rglob("*"), key=lambda p: str(p))
+        candidates = search_root.rglob("*")
     except Exception:
-        candidates = []
+        candidates = iter([])
     for file_path in candidates:
         if len(results) >= limit:
             break
@@ -1521,6 +1521,10 @@ def builtin_file_search(employee_dict, agent_name, query, path="", max_results=1
 def builtin_shell_run(employee_dict, agent_name, command, timeout=30):
     del employee_dict
     import subprocess as _subprocess
+    caller_caps = getattr(active_tool_caller, "capabilities", set())
+    if "shell" not in caller_caps:
+        caller_label = getattr(active_tool_caller, "name", "unknown")
+        return f"Error: Role '{caller_label}' does not have the 'shell' capability."
     if not isinstance(command, str) or not command.strip():
         return "Error: Command must be a non-empty string."
     normalized_name, error = _workspace_agent_name(agent_name)
@@ -1552,7 +1556,6 @@ def builtin_tool_search(employee_dict, query, role_name=None):
     if not isinstance(query, str) or not query.strip():
         return "Error: Tool search query must be a non-empty string."
     query_lower = query.strip().lower()
-    role = None
     if role_name:
         try:
             normalized = validate_role_name(role_name)
@@ -1561,7 +1564,9 @@ def builtin_tool_search(employee_dict, query, role_name=None):
         role = employee_dict.get(normalized)
         if role is None:
             return f"Error: Role '{normalized}' not found."
-    rows = tool_registry.list_tools(include_system=True, role=role, include_denied=True)
+    else:
+        role = active_tool_caller
+    rows = tool_registry.list_tools(include_system=False, role=role, include_denied=False)
     matches = [
         row for row in rows
         if query_lower in row["name"].lower() or query_lower in row["description"].lower()

--- a/main.py
+++ b/main.py
@@ -61,6 +61,7 @@ max_api_retries = max(0, int(os.environ.get("ROBITS_MAX_API_RETRIES", "3")))
 api_retry_base_seconds = max(0.0, float(os.environ.get("ROBITS_API_RETRY_BASE_SECONDS", "0.25")))
 api_retry_max_seconds = max(api_retry_base_seconds, float(os.environ.get("ROBITS_API_RETRY_MAX_SECONDS", "4.0")))
 model_call_gate = threading.BoundedSemaphore(max_parallelism)
+builtin_search_url = os.environ.get("ROBITS_SEARCH_URL", "").strip()
 memory_db_path = os.environ.get("ROBITS_MEMORY_DB")
 memory_store = SQLiteMemoryStore(memory_db_path) if memory_db_path else None
 tool_proposal_store = None
@@ -199,6 +200,13 @@ class ToolRegistry:
                 "workspace_write": workspace_write,
                 "workspace_delete": workspace_delete,
                 "current_agent_context": current_agent_context,
+                "builtin_web_search": builtin_web_search,
+                "builtin_file_search": builtin_file_search,
+                "builtin_shell_run": builtin_shell_run,
+                "builtin_tool_search": builtin_tool_search,
+                "builtin_mcp_call": builtin_mcp_call,
+                "builtin_computer_use": builtin_computer_use,
+                "builtin_image_generation": builtin_image_generation,
             },
             local_dict,
         )
@@ -1416,6 +1424,164 @@ def memory_expand_digest(employee_dict, agent_name, digest_id, recursive=True):
         for row in rows
     ]
     return json.dumps(rows, sort_keys=True)
+
+
+def builtin_web_search(employee_dict, query, num_results=5):
+    del employee_dict
+    if not isinstance(query, str) or not query.strip():
+        return "Error: Search query must be a non-empty string."
+    n = max(1, min(20, int(num_results or 5)))
+    if builtin_search_url:
+        import urllib.request
+        import urllib.parse
+        url = f"{builtin_search_url}?q={urllib.parse.quote(query.strip())}&num={n}"
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "robits/1.0"})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                return resp.read().decode()
+        except Exception as exc:
+            return f"Error: Search request failed: {exc}"
+    import urllib.request
+    import urllib.parse
+    qs = urllib.parse.urlencode({"q": query.strip(), "format": "json", "no_html": "1", "skip_disambig": "1"})
+    try:
+        req = urllib.request.Request(
+            f"https://api.duckduckgo.com/?{qs}",
+            headers={"User-Agent": "robits/1.0"},
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception as exc:
+        return f"Error: Web search failed: {exc}"
+    results = []
+    if data.get("AbstractText"):
+        results.append({
+            "title": data.get("Heading", query.strip()),
+            "url": data.get("AbstractURL", ""),
+            "snippet": data["AbstractText"],
+        })
+
+    def _extract_topics(topics):
+        for topic in topics:
+            if len(results) >= n:
+                break
+            if isinstance(topic, dict) and "Text" in topic:
+                results.append({
+                    "title": topic.get("Text", "")[:80],
+                    "url": topic.get("FirstURL", ""),
+                    "snippet": topic.get("Text", ""),
+                })
+            elif isinstance(topic, dict) and "Topics" in topic:
+                _extract_topics(topic["Topics"])
+
+    _extract_topics(data.get("RelatedTopics", []))
+    return json.dumps(results[:n], sort_keys=True)
+
+
+def builtin_file_search(employee_dict, agent_name, query, path="", max_results=10):
+    del employee_dict
+    if not isinstance(query, str) or not query.strip():
+        return "Error: Search query must be a non-empty string."
+    normalized_name, error = _workspace_agent_name(agent_name)
+    if error:
+        return error
+    workspace = agent_workspace_store.workspace_root(normalized_name)
+    search_root = workspace / path if path else workspace
+    search_root = search_root.resolve()
+    if workspace not in search_root.parents and search_root != workspace:
+        return "Error: Path escapes the agent workspace."
+    query_lower = query.strip().lower()
+    limit = max(1, min(100, int(max_results or 10)))
+    results = []
+    try:
+        candidates = sorted(search_root.rglob("*"), key=lambda p: str(p))
+    except Exception:
+        candidates = []
+    for file_path in candidates:
+        if len(results) >= limit:
+            break
+        if not file_path.is_file():
+            continue
+        try:
+            content = file_path.read_text(encoding="utf-8", errors="replace")
+        except Exception:
+            continue
+        idx = content.lower().find(query_lower)
+        if idx == -1:
+            continue
+        snippet = content[max(0, idx - 80) : idx + 160].strip()
+        results.append({
+            "path": file_path.relative_to(workspace).as_posix(),
+            "snippet": snippet,
+            "size": file_path.stat().st_size,
+        })
+    return json.dumps(results, sort_keys=True)
+
+
+def builtin_shell_run(employee_dict, agent_name, command, timeout=30):
+    del employee_dict
+    import subprocess as _subprocess
+    if not isinstance(command, str) or not command.strip():
+        return "Error: Command must be a non-empty string."
+    normalized_name, error = _workspace_agent_name(agent_name)
+    if error:
+        return error
+    workspace = agent_workspace_store.workspace_root(normalized_name)
+    workspace.mkdir(parents=True, exist_ok=True)
+    try:
+        proc = _subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=max(1, min(300, int(timeout or 30))),
+            cwd=str(workspace),
+        )
+        return json.dumps({
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "returncode": proc.returncode,
+        }, sort_keys=True)
+    except _subprocess.TimeoutExpired:
+        return "Error: Command timed out."
+    except Exception as exc:
+        return f"Error: Shell execution failed: {exc}"
+
+
+def builtin_tool_search(employee_dict, query, role_name=None):
+    if not isinstance(query, str) or not query.strip():
+        return "Error: Tool search query must be a non-empty string."
+    query_lower = query.strip().lower()
+    role = None
+    if role_name:
+        try:
+            normalized = validate_role_name(role_name)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        role = employee_dict.get(normalized)
+        if role is None:
+            return f"Error: Role '{normalized}' not found."
+    rows = tool_registry.list_tools(include_system=True, role=role, include_denied=True)
+    matches = [
+        row for row in rows
+        if query_lower in row["name"].lower() or query_lower in row["description"].lower()
+    ]
+    return json.dumps(matches[:20], sort_keys=True)
+
+
+def builtin_mcp_call(employee_dict, server_url, tool_name, arguments=None):
+    del employee_dict
+    return "Error: builtin.mcp_call is not implemented in this runtime. Configure an MCP server and use a supported MCP connector."
+
+
+def builtin_computer_use(employee_dict, action, coordinate=None):
+    del employee_dict
+    return "Error: builtin.computer_use is not implemented in this runtime."
+
+
+def builtin_image_generation(employee_dict, prompt, size=None, quality=None):
+    del employee_dict
+    return "Error: builtin.image_generation is not implemented in this runtime."
 
 
 def due_alarm_reminders(role, now=None):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2027,8 +2027,9 @@ class BuiltinToolTests(unittest.TestCase):
     def test_web_search_uses_configured_url(self):
         original = main.builtin_search_url
         try:
-            main.builtin_search_url = "http://example.invalid"
-            result = main.builtin_web_search({}, "test query")
+            main.builtin_search_url = "http://custom-search.invalid"
+            with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+                result = main.builtin_web_search({}, "test query")
         finally:
             main.builtin_search_url = original
         self.assertTrue(result.startswith("Error:"))
@@ -2089,6 +2090,8 @@ class BuiltinToolTests(unittest.TestCase):
                     main.tool_registry.register_definition(entry)
                 except Exception:
                     pass
+        # Grant all tools so builtin_tool_search (which filters to allowed tools) finds results.
+        main.active_tool_caller.allowed_tools = {"builtin.*"}
         result_json = main.builtin_tool_search({}, "web_search")
         results = json.loads(result_json)
         names = [r["name"] for r in results]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1995,5 +1995,179 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(session.event_stream.events("private"), [event])
 
 
+class BuiltinToolTests(unittest.TestCase):
+    """Tests for builtin.* tool implementations."""
+
+    def setUp(self):
+        self.workspace_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.workspace_temp.cleanup)
+
+        self.original_workspace = main.agent_workspace_store
+        main.agent_workspace_store = main.AgentWorkspaceStore(self.workspace_temp.name)
+        self.addCleanup(self._restore)
+
+        # Simulate the tool caller being SE.
+        self._prev_caller = main.active_tool_caller
+        self._prev_caller_name = main.active_tool_caller_name
+        fake_role = SimpleNamespace(name="SE", capabilities={"shell", "mcp", "computer"})
+        main.active_tool_caller = fake_role
+        main.active_tool_caller_name = "SE"
+
+    def _restore(self):
+        main.agent_workspace_store = self.original_workspace
+        main.active_tool_caller = self._prev_caller
+        main.active_tool_caller_name = self._prev_caller_name
+
+    # ── builtin.web_search ───────────────────────────────────────────────────
+
+    def test_web_search_validates_empty_query(self):
+        result = main.builtin_web_search({}, "  ")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_web_search_uses_configured_url(self):
+        original = main.builtin_search_url
+        try:
+            main.builtin_search_url = "http://example.invalid"
+            result = main.builtin_web_search({}, "test query")
+        finally:
+            main.builtin_search_url = original
+        self.assertTrue(result.startswith("Error:"))
+
+    # ── builtin.file_search ──────────────────────────────────────────────────
+
+    def test_file_search_finds_text_in_workspace_file(self):
+        main.agent_workspace_store.write("SE", "notes.txt", "The quick brown fox jumps.")
+        result_json = main.builtin_file_search({}, "SE", "brown fox")
+        results = json.loads(result_json)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["path"], "notes.txt")
+        self.assertIn("brown fox", results[0]["snippet"])
+
+    def test_file_search_returns_empty_for_no_match(self):
+        main.agent_workspace_store.write("SE", "notes.txt", "Nothing relevant here.")
+        result_json = main.builtin_file_search({}, "SE", "xyzzy12345")
+        results = json.loads(result_json)
+        self.assertEqual(results, [])
+
+    def test_file_search_blocked_for_different_agent(self):
+        result = main.builtin_file_search({}, "HR", "anything")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_file_search_validates_empty_query(self):
+        result = main.builtin_file_search({}, "SE", "")
+        self.assertTrue(result.startswith("Error:"))
+
+    # ── builtin.shell_run ────────────────────────────────────────────────────
+
+    def test_shell_run_executes_simple_command(self):
+        result_json = main.builtin_shell_run({}, "SE", "echo hello", timeout=10)
+        result = json.loads(result_json)
+        self.assertIn("hello", result["stdout"])
+        self.assertEqual(result["returncode"], 0)
+
+    def test_shell_run_captures_nonzero_exit(self):
+        result_json = main.builtin_shell_run({}, "SE", "exit 42", timeout=5)
+        result = json.loads(result_json)
+        self.assertEqual(result["returncode"], 42)
+
+    def test_shell_run_blocked_for_different_agent(self):
+        result = main.builtin_shell_run({}, "HR", "echo hi")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_shell_run_validates_empty_command(self):
+        result = main.builtin_shell_run({}, "SE", "   ")
+        self.assertTrue(result.startswith("Error:"))
+
+    # ── builtin.tool_search ──────────────────────────────────────────────────
+
+    def test_tool_search_finds_tools_by_name_fragment(self):
+        main.tool_registry.clear()
+        with open("tools.yaml", encoding="utf-8") as f:
+            import yaml
+            for entry in yaml.safe_load(f):
+                try:
+                    main.tool_registry.register_definition(entry)
+                except Exception:
+                    pass
+        result_json = main.builtin_tool_search({}, "web_search")
+        results = json.loads(result_json)
+        names = [r["name"] for r in results]
+        self.assertIn("builtin.web_search", names)
+        main.tool_registry.clear()
+
+    def test_tool_search_validates_empty_query(self):
+        result = main.builtin_tool_search({}, "")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_tool_search_returns_empty_list_for_no_match(self):
+        result_json = main.builtin_tool_search({}, "xyzzy_no_such_tool_xyz")
+        results = json.loads(result_json)
+        self.assertEqual(results, [])
+
+    # ── not-implemented stubs ────────────────────────────────────────────────
+
+    def test_mcp_call_returns_not_implemented(self):
+        result = main.builtin_mcp_call({}, "http://example.com/mcp", "some_tool")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_computer_use_returns_not_implemented(self):
+        result = main.builtin_computer_use({}, "screenshot")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_image_generation_returns_not_implemented(self):
+        result = main.builtin_image_generation({}, "a blue sky")
+        self.assertTrue(result.startswith("Error:"))
+
+    # ── tools.yaml integration ───────────────────────────────────────────────
+
+    def test_builtin_tools_load_from_yaml_without_error(self):
+        """All builtin.* entries must compile successfully."""
+        import yaml
+        main.tool_registry.clear()
+        errors = []
+        with open("tools.yaml", encoding="utf-8") as f:
+            for entry in yaml.safe_load(f):
+                try:
+                    main.tool_registry.register_definition(entry)
+                except Exception as exc:
+                    errors.append(f"{entry.get('name')}: {exc}")
+        builtin_names = [n for n in main.tool_registry._tools if n.startswith("builtin.")]
+        self.assertEqual(
+            sorted(builtin_names),
+            sorted([
+                "builtin.web_search",
+                "builtin.file_search",
+                "builtin.shell_run",
+                "builtin.tool_search",
+                "builtin.mcp_call",
+                "builtin.computer_use",
+                "builtin.image_generation",
+            ]),
+        )
+        self.assertEqual(errors, [], f"Tool registration errors: {errors}")
+        main.tool_registry.clear()
+
+    def test_shell_run_requires_shell_capability(self):
+        """Role without shell capability must be denied."""
+        main.tool_registry.clear()
+        import yaml
+        with open("tools.yaml", encoding="utf-8") as f:
+            for entry in yaml.safe_load(f):
+                try:
+                    main.tool_registry.register_definition(entry)
+                except Exception:
+                    pass
+        # Caller has no shell capability.
+        main.active_tool_caller.capabilities = set()
+        result = main.tool_registry.execute(
+            "builtin.shell_run",
+            {"agent_name": "SE", "command": "echo hi"},
+            {},
+            caller=main.active_tool_caller,
+        )
+        self.assertTrue(result.startswith("Error:"))
+        main.tool_registry.clear()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools.yaml
+++ b/tools.yaml
@@ -659,3 +659,157 @@
         granted_by=granted_by,
         rollout_notes=rollout_notes if rollout_notes is not None else "",
     )
+- name: builtin.web_search
+  grantable: true
+  owner_capability: agent
+  description: Search the web and return results. Uses ROBITS_SEARCH_URL if set, otherwise falls back to the DuckDuckGo Instant Answers API.
+  parameters:
+    type: object
+    properties:
+      query:
+        type: string
+        description: Search query string.
+      num_results:
+        type: integer
+        description: Maximum number of results to return (default 5, max 20).
+    required:
+      - query
+  code: |
+    return builtin_web_search(employee_dict, query, num_results=num_results if num_results is not None else 5)
+- name: builtin.file_search
+  grantable: true
+  owner_capability: agent
+  description: Search the text content of files in an agent's private workspace and return matching snippets.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: Agent that owns the workspace to search.
+      query:
+        type: string
+        description: Text to search for (case-insensitive substring match).
+      path:
+        type: string
+        description: Relative directory path to search within (default is workspace root).
+      max_results:
+        type: integer
+        description: Maximum number of matching files to return (default 10).
+    required:
+      - agent_name
+      - query
+  code: |
+    return builtin_file_search(
+        employee_dict,
+        agent_name,
+        query,
+        path=path if path is not None else "",
+        max_results=max_results if max_results is not None else 10,
+    )
+- name: builtin.shell_run
+  grantable: true
+  owner_capability: agent
+  required_capabilities:
+    - shell
+  description: Run a shell command in the agent's private workspace directory. Requires the shell capability. Output is captured and returned as stdout, stderr, and returncode.
+  parameters:
+    type: object
+    properties:
+      agent_name:
+        type: string
+        description: Agent whose workspace directory the command runs in.
+      command:
+        type: string
+        description: Shell command string to execute.
+      timeout:
+        type: integer
+        description: Timeout in seconds (default 30, max 300).
+    required:
+      - agent_name
+      - command
+  code: |
+    return builtin_shell_run(
+        employee_dict,
+        agent_name,
+        command,
+        timeout=timeout if timeout is not None else 30,
+    )
+- name: builtin.tool_search
+  grantable: true
+  owner_capability: agent
+  description: Search the tool registry by name or description to discover available tools.
+  parameters:
+    type: object
+    properties:
+      query:
+        type: string
+        description: Keyword to search tool names and descriptions.
+      role_name:
+        type: string
+        description: Optional role name to evaluate tool access for.
+    required:
+      - query
+  code: |
+    return builtin_tool_search(employee_dict, query, role_name=role_name)
+- name: builtin.mcp_call
+  grantable: true
+  owner_capability: agent
+  required_capabilities:
+    - mcp
+  description: Call a tool on an external MCP (Model Context Protocol) server. Not yet implemented; returns an error with guidance.
+  parameters:
+    type: object
+    properties:
+      server_url:
+        type: string
+        description: URL of the MCP server endpoint.
+      tool_name:
+        type: string
+        description: Name of the tool to call on the MCP server.
+      arguments:
+        type: string
+        description: JSON-encoded arguments object to pass to the tool.
+    required:
+      - server_url
+      - tool_name
+  code: |
+    return builtin_mcp_call(employee_dict, server_url, tool_name, arguments=arguments)
+- name: builtin.computer_use
+  grantable: true
+  owner_capability: agent
+  required_capabilities:
+    - computer
+  description: Perform computer-use actions (click, type, screenshot, etc.). Not implemented in this runtime; returns an error.
+  parameters:
+    type: object
+    properties:
+      action:
+        type: string
+        description: Action type (click, type, screenshot, etc.).
+      coordinate:
+        type: string
+        description: Optional screen coordinate for pointer actions, as "x,y".
+    required:
+      - action
+  code: |
+    return builtin_computer_use(employee_dict, action, coordinate=coordinate)
+- name: builtin.image_generation
+  grantable: true
+  owner_capability: agent
+  description: Generate or edit an image using a configured image model. Not implemented in this runtime; returns an error.
+  parameters:
+    type: object
+    properties:
+      prompt:
+        type: string
+        description: Text description of the image to generate.
+      size:
+        type: string
+        description: Image dimensions, e.g. 1024x1024.
+      quality:
+        type: string
+        description: Image quality, e.g. standard or hd.
+    required:
+      - prompt
+  code: |
+    return builtin_image_generation(employee_dict, prompt, size=size, quality=quality)


### PR DESCRIPTION
Closes #53

## Summary

Adds a `builtin.*` tool namespace that provides client-side implementations of each OpenAI built-in tool type. All tools work with any OpenAI-compatible endpoint (LM Studio included) as standard function-call tools.

| Tool | Status | Notes |
|---|---|---|
| `builtin.web_search` | ✅ | DuckDuckGo Instant Answers or `ROBITS_SEARCH_URL`; stdlib only |
| `builtin.file_search` | ✅ | Text search in agent workspace; respects agent boundaries |
| `builtin.shell_run` | ✅ | subprocess in workspace dir; requires `shell` capability |
| `builtin.tool_search` | ✅ | Search tool registry by name/description |
| `builtin.mcp_call` | stub | NOT IMPLEMENTED — requires `mcp` capability |
| `builtin.computer_use` | stub | NOT IMPLEMENTED — requires `computer` capability |
| `builtin.image_generation` | stub | NOT IMPLEMENTED |

## Protocol note

Function calling via the Responses API already uses `function_call_output` objects correctly. The `ResponsesProvider` loop exits correctly for server-side built-in types (e.g. `web_search_call` from OpenAI) because they produce a final `message` output in the same response — no client action is needed. Native built-in pass-through (passing `{"type": "web_search"}` to OpenAI endpoints) is a future enhancement.

## Test plan

- [ ] `python -m unittest` passes (133 tests, +18 new)
- [ ] `test_builtin_tools_load_from_yaml_without_error` — all 7 entries compile
- [ ] `test_file_search_finds_text_in_workspace_file` — workspace file search works
- [ ] `test_shell_run_executes_simple_command` — subprocess capture works
- [ ] `test_shell_run_requires_shell_capability` — capability gate enforced
- [ ] `test_tool_search_finds_tools_by_name_fragment` — registry search works
- [ ] not-implemented stubs return `Error:` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)