### PR TITLE
Add GitHub Actions CI for Python unittest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - run: uv python install
+      - run: uv pip install --system -r requirements.txt
+      - run: python -m unittest discover -s tests -v


### PR DESCRIPTION
Runs `python -m unittest discover -s tests -v` on every push and pull request.

Uses `astral-sh/setup-uv` for fast dependency installation with caching.

Closes #56