### PR TITLE
Integrate SQLite memory capture into live sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,6 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install
-      - run: uv pip install --system -r requirements.txt
-      - run: python -m unittest discover -s tests -v
+      - run: uv venv
+      - run: uv pip install -r requirements.txt
+      - run: uv run python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Relevant environment variables:
 - `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
 - `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.
 - `ROBITS_SEARCH_URL`: optional custom web search endpoint for `builtin.web_search`; falls back to the DuckDuckGo Instant Answers API.
+- `ROBITS_DIGEST_INTERVAL`: turns between automatic episodic digest creation; default `0` (disabled). When enabled, a raw transcript digest is created for every agent after each interval, making conversation history searchable via `memory.search`.
 
 ## Tools
 

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ tool_proposal_store = None
 memory_max_depth = max(0, int(os.environ.get("ROBITS_MEMORY_MAX_DEPTH", "3")))
 memory_max_rows = max(1, int(os.environ.get("ROBITS_MEMORY_MAX_ROWS", "100")))
 memory_cache_threshold = max(512, int(os.environ.get("ROBITS_MEMORY_CACHE_THRESHOLD", "8192")))
+memory_digest_interval = max(0, int(os.environ.get("ROBITS_DIGEST_INTERVAL", "0")))
 agent_workspace_store = AgentWorkspaceStore()
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
@@ -446,6 +447,21 @@ def _emit_role_tool_event(role, event_type, payload):
     session_id = getattr(role, "runtime_session_id", None)
     if event_stream is not None and session_id is not None:
         event_stream.emit(event_type, session_id, payload)
+    if memory_store is not None and event_type in {"tool_call.executed", "tool_call.failed"}:
+        agent_id = getattr(role, "name", None) or getattr(role, "runtime_role_name", None)
+        if agent_id:
+            try:
+                memory_store.append_tool_call(
+                    tool_call_id=payload.get("call_id") or str(uuid4()),
+                    agent_id=agent_id,
+                    tool_name=payload.get("tool_name", ""),
+                    arguments=payload.get("arguments"),
+                    result_content=str(payload.get("result", "")),
+                    status="executed" if event_type == "tool_call.executed" else "failed",
+                    session_id=session_id,
+                )
+            except Exception:
+                pass
 
 
 def _record_role_tool_result(role, result):
@@ -1086,6 +1102,29 @@ def record_lifecycle_event(
         role.lifecycle_events = []
     role.lifecycle_events.append(event)
     role.lifecycle_state = lifecycle_state
+    if memory_store is not None:
+        try:
+            memory_store.upsert_agent(
+                role.name,
+                type(role).__name__,
+                display_name=role.name,
+                lifecycle_state=lifecycle_state,
+            )
+            summary = f"[lifecycle:{action}] {role.name} -> {lifecycle_state}"
+            if requested_by:
+                summary += f" (requested_by={requested_by})"
+            if approved_by:
+                summary += f" (approved_by={approved_by})"
+            if reason:
+                summary += f" reason={reason}"
+            memory_store.append_memory_entry(
+                agent_id=role.name,
+                kind="lifecycle",
+                content=summary,
+                source="system",
+            )
+        except Exception:
+            pass
     return event
 
 
@@ -2026,6 +2065,14 @@ class Session:
                 "max_turns": self.max_turns,
             },
         )
+        if memory_store is not None:
+            try:
+                memory_store.create_session(self.run_id)
+                for name, participant in self.participants.items():
+                    role_type = type(participant).__name__
+                    memory_store.upsert_agent(name, role_type, display_name=name)
+            except Exception:
+                pass
 
     def route_message(self, message, last_receiver_name=None):
         prompt_split = message.split(",", 1) if isinstance(message, str) else []
@@ -2130,9 +2177,88 @@ class Session:
                 "system_event_count": len(entry.system_events),
             },
         )
+        if memory_store is not None:
+            try:
+                if prompt:
+                    memory_store.append_message(
+                        session_id=self.run_id,
+                        sender_agent_id=sender,
+                        receiver_agent_id=receiver,
+                        content=prompt,
+                        kind="message",
+                    )
+                if response:
+                    memory_store.append_message(
+                        session_id=self.run_id,
+                        sender_agent_id=receiver,
+                        receiver_agent_id=sender,
+                        content=response,
+                        kind="message",
+                    )
+            except Exception:
+                pass
+            if (
+                memory_digest_interval > 0
+                and self.turns_completed % memory_digest_interval == 0
+            ):
+                self._auto_digest()
         return entry
 
+    def _auto_digest(self):
+        """Create a raw transcript digest covering the last memory_digest_interval turns."""
+        window = self.transcript[-memory_digest_interval:]
+        lines = []
+        for e in window:
+            if e.prompt:
+                lines.append(f"[turn {e.turn}] {e.sender} -> {e.receiver}: {e.prompt[:512]}")
+            if e.response:
+                lines.append(f"[turn {e.turn}] {e.receiver}: {e.response[:512]}")
+        content = "\n".join(lines)
+        if not content.strip():
+            return
+        source_refs = []
+        try:
+            recent_msg_rows = memory_store.connection.execute(
+                """
+                SELECT message_id FROM messages
+                WHERE session_id = ?
+                ORDER BY message_id DESC LIMIT ?
+                """,
+                (self.run_id, memory_digest_interval * 2),
+            ).fetchall()
+            source_refs = [
+                {"source_table": "messages", "source_id": row["message_id"]}
+                for row in recent_msg_rows
+            ]
+        except Exception:
+            pass
+        if not source_refs:
+            return
+        try:
+            for agent_id in list(self.participants):
+                memory_store.append_memory_digest(
+                    content=content,
+                    source_refs=source_refs,
+                    agent_id=agent_id,
+                    session_id=self.run_id,
+                    digest_type="episodic",
+                    accessibility="agent",
+                    system_only=False,
+                )
+        except Exception:
+            pass
+
     def record_thought(self, agent_name, content, visibility="private"):
+        if memory_store is not None:
+            try:
+                memory_store.append_thought(
+                    agent_id=agent_name,
+                    content=content,
+                    session_id=self.run_id,
+                    visibility=visibility,
+                )
+            except Exception:
+                pass
         return self.event_stream.emit(
             "thought.recorded",
             self.run_id,
@@ -2231,6 +2357,11 @@ class Session:
                 "turns_completed": self.turns_completed,
             },
         )
+        if memory_store is not None:
+            try:
+                memory_store.end_session(self.run_id)
+            except Exception:
+                pass
         return self
 
 

--- a/main.py
+++ b/main.py
@@ -448,7 +448,7 @@ def _emit_role_tool_event(role, event_type, payload):
     if event_stream is not None and session_id is not None:
         event_stream.emit(event_type, session_id, payload)
     if memory_store is not None and event_type in {"tool_call.executed", "tool_call.failed"}:
-        agent_id = getattr(role, "name", None) or getattr(role, "runtime_role_name", None)
+        agent_id = getattr(role, "runtime_role_name", None) or getattr(role, "name", None)
         if agent_id:
             try:
                 memory_store.append_tool_call(
@@ -2057,6 +2057,8 @@ class Session:
         self.transcript = []
         self.turns_completed = 0
         self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
+        # Map role.name → participant dict key for FK-safe persistence.
+        self._name_to_key = {getattr(p, "name", k): k for k, p in self.participants.items()}
         self.event_stream.emit(
             "session.created",
             self.run_id,
@@ -2178,20 +2180,22 @@ class Session:
             },
         )
         if memory_store is not None:
+            canonical_sender = self._canonical_agent_id(sender)
+            canonical_receiver = self._canonical_agent_id(receiver)
             try:
                 if prompt:
                     memory_store.append_message(
                         session_id=self.run_id,
-                        sender_agent_id=sender,
-                        receiver_agent_id=receiver,
+                        sender_agent_id=canonical_sender,
+                        receiver_agent_id=canonical_receiver,
                         content=prompt,
                         kind="message",
                     )
                 if response:
                     memory_store.append_message(
                         session_id=self.run_id,
-                        sender_agent_id=receiver,
-                        receiver_agent_id=sender,
+                        sender_agent_id=canonical_receiver,
+                        receiver_agent_id=canonical_sender,
                         content=response,
                         kind="message",
                     )
@@ -2218,17 +2222,12 @@ class Session:
             return
         source_refs = []
         try:
-            recent_msg_rows = memory_store.connection.execute(
-                """
-                SELECT message_id FROM messages
-                WHERE session_id = ?
-                ORDER BY message_id DESC LIMIT ?
-                """,
-                (self.run_id, memory_digest_interval * 2),
-            ).fetchall()
+            msg_ids = memory_store.list_recent_message_ids(
+                self.run_id, memory_digest_interval * 2
+            )
             source_refs = [
-                {"source_table": "messages", "source_id": row["message_id"]}
-                for row in recent_msg_rows
+                {"source_table": "messages", "source_id": mid}
+                for mid in msg_ids
             ]
         except Exception:
             pass
@@ -2252,7 +2251,7 @@ class Session:
         if memory_store is not None:
             try:
                 memory_store.append_thought(
-                    agent_id=agent_name,
+                    agent_id=self._canonical_agent_id(agent_name),
                     content=content,
                     session_id=self.run_id,
                     visibility=visibility,
@@ -2268,6 +2267,10 @@ class Session:
             },
             visibility=visibility,
         )
+
+    def _canonical_agent_id(self, name):
+        """Return the participant dict key for a role, resolving role.name → key mismatches."""
+        return self._name_to_key.get(name, name)
 
     def sync_scheduler_participants(self):
         for name, participant in self.participants.items():

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -295,6 +295,13 @@ class SQLiteMemoryStore:
         self.connection.commit()
         return session_id
 
+    def end_session(self, session_id, ended_at=None):
+        self.connection.execute(
+            "UPDATE sessions SET ended_at = ? WHERE session_id = ?",
+            (ended_at or _utc_now(), session_id),
+        )
+        self.connection.commit()
+
     def upsert_agent(
         self,
         agent_id,

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -295,6 +295,18 @@ class SQLiteMemoryStore:
         self.connection.commit()
         return session_id
 
+    def list_recent_message_ids(self, session_id, limit):
+        """Return the last ``limit`` message IDs for a session in chronological order."""
+        rows = self.connection.execute(
+            """
+            SELECT message_id FROM messages
+            WHERE session_id = ?
+            ORDER BY message_id DESC LIMIT ?
+            """,
+            (session_id, limit),
+        ).fetchall()
+        return [row["message_id"] for row in reversed(rows)]
+
     def end_session(self, session_id, ended_at=None):
         self.connection.execute(
             "UPDATE sessions SET ended_at = ? WHERE session_id = ?",

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -691,5 +691,28 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(events[0]["payload_json"], '{"agent": "SE", "content": "Private note."}')
 
 
+    def test_end_session_sets_ended_at(self):
+        store = self.build_store()
+        store.create_session("s-end")
+        row = store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = 's-end'"
+        ).fetchone()
+        self.assertIsNone(row["ended_at"])
+        store.end_session("s-end")
+        row = store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = 's-end'"
+        ).fetchone()
+        self.assertIsNotNone(row["ended_at"])
+
+    def test_end_session_accepts_explicit_timestamp(self):
+        store = self.build_store()
+        store.create_session("s-ts")
+        store.end_session("s-ts", ended_at="2024-01-01T00:00:00")
+        row = store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = 's-ts'"
+        ).fetchone()
+        self.assertEqual(row["ended_at"], "2024-01-01T00:00:00")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -691,6 +691,28 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(events[0]["payload_json"], '{"agent": "SE", "content": "Private note."}')
 
 
+    def test_list_recent_message_ids_returns_chronological_order(self):
+        store = self.build_store()
+        store.create_session("s-order")
+        store.upsert_agent("A", "Role", "A")
+        store.upsert_agent("B", "Role", "B")
+        id1 = store.append_message("s-order", "A", "B", "first")
+        id2 = store.append_message("s-order", "B", "A", "second")
+        id3 = store.append_message("s-order", "A", "B", "third")
+        ids = store.list_recent_message_ids("s-order", 3)
+        self.assertEqual(ids, [id1, id2, id3])
+
+    def test_list_recent_message_ids_limits_to_last_n(self):
+        store = self.build_store()
+        store.create_session("s-limit")
+        store.upsert_agent("A", "Role", "A")
+        store.upsert_agent("B", "Role", "B")
+        store.append_message("s-limit", "A", "B", "first")
+        id2 = store.append_message("s-limit", "B", "A", "second")
+        id3 = store.append_message("s-limit", "A", "B", "third")
+        ids = store.list_recent_message_ids("s-limit", 2)
+        self.assertEqual(ids, [id2, id3])
+
     def test_end_session_sets_ended_at(self):
         store = self.build_store()
         store.create_session("s-end")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2370,5 +2370,155 @@ class MemoryToolTests(unittest.TestCase):
         self.assertTrue(result.startswith("Error:"))
 
 
+class SessionMemoryCaptureTests(unittest.TestCase):
+    """Tests that Session persists messages, thoughts, tool calls, and lifecycle events."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "mem.sqlite3")
+        self.addCleanup(self.store.close)
+
+        self.original_store = main.memory_store
+        self.original_digest_interval = main.memory_digest_interval
+        main.memory_store = self.store
+        main.memory_digest_interval = 0
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.memory_store = self.original_store
+        main.memory_digest_interval = self.original_digest_interval
+
+    def _make_session(self):
+        participants = {
+            "A": SimpleNamespace(
+                name="A",
+                lifecycle_state="active",
+                interact=lambda *a, **kw: "hello",
+                update_group_conversations=lambda m: None,
+                runtime_tool_results=[],
+            ),
+            "B": SimpleNamespace(
+                name="B",
+                lifecycle_state="active",
+                interact=lambda *a, **kw: "world",
+                update_group_conversations=lambda m: None,
+                runtime_tool_results=[],
+            ),
+        }
+        system = SimpleNamespace(interact=lambda *a, **kw: None)
+        scheduler = main.RoundRobinScheduler(list(participants))
+        return main.Session(
+            participants=participants,
+            system=system,
+            scheduler=scheduler,
+        )
+
+    def test_session_creation_is_persisted(self):
+        session = self._make_session()
+        row = self.store.connection.execute(
+            "SELECT session_id FROM sessions WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertIsNotNone(row)
+
+    def test_agents_are_upserted_on_session_init(self):
+        session = self._make_session()
+        agents = self.store.connection.execute(
+            "SELECT agent_id FROM agents WHERE agent_id IN ('A', 'B')"
+        ).fetchall()
+        self.assertEqual({r["agent_id"] for r in agents}, {"A", "B"})
+
+    def test_turn_messages_are_persisted(self):
+        session = self._make_session()
+        session.record_turn("A", "B", "hello prompt", "world response")
+        rows = self.store.connection.execute(
+            "SELECT content FROM messages WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        contents = {r["content"] for r in rows}
+        self.assertIn("hello prompt", contents)
+        self.assertIn("world response", contents)
+
+    def test_empty_prompt_and_response_not_persisted(self):
+        session = self._make_session()
+        session.record_turn("A", "B", "", "")
+        rows = self.store.connection.execute(
+            "SELECT COUNT(*) AS n FROM messages WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertEqual(rows["n"], 0)
+
+    def test_thought_is_persisted(self):
+        session = self._make_session()
+        session.record_thought("A", "my private thought")
+        rows = self.store.connection.execute(
+            "SELECT content, visibility FROM thoughts WHERE agent_id = 'A'"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["content"], "my private thought")
+        self.assertEqual(rows[0]["visibility"], "private")
+
+    def test_session_ended_at_set_on_run_completion(self):
+        session = self._make_session()
+        session.turns_completed = 0
+        session.run(initial_message="go", max_turns=1)
+        row = self.store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertIsNotNone(row["ended_at"])
+
+    def test_auto_digest_fires_at_interval(self):
+        main.memory_digest_interval = 2
+        session = self._make_session()
+        session.record_turn("A", "B", "turn one prompt", "turn one response")
+        session.record_turn("A", "B", "turn two prompt", "turn two response")
+        rows = self.store.connection.execute(
+            "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertGreater(len(rows), 0)
+
+    def test_auto_digest_not_fired_before_interval(self):
+        main.memory_digest_interval = 5
+        session = self._make_session()
+        session.record_turn("A", "B", "only one turn", "response")
+        rows = self.store.connection.execute(
+            "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertEqual(len(rows), 0)
+
+    def test_lifecycle_event_persisted_as_memory_entry(self):
+        role = SimpleNamespace(
+            name="NewRole",
+            lifecycle_state="active",
+            lifecycle_events=[],
+        )
+        main.record_lifecycle_event(role, "create", "active", requested_by="CEO")
+        rows = self.store.connection.execute(
+            "SELECT content FROM memory_entries WHERE agent_id = 'NewRole' AND kind = 'lifecycle'"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertIn("create", rows[0]["content"])
+        self.assertIn("active", rows[0]["content"])
+
+    def test_tool_call_persisted_on_executed_event(self):
+        role = SimpleNamespace(
+            name="SE",
+            runtime_event_stream=None,
+            runtime_session_id="test-session",
+        )
+        self.store.create_session("test-session")
+        self.store.upsert_agent("SE", "SoftwareEngineer", "SE")
+        main._emit_role_tool_event(role, "tool_call.executed", {
+            "call_id": "call-1",
+            "tool_name": "org.create_role",
+            "arguments": {"role_name": "QA"},
+            "result": "Created role QA",
+        })
+        rows = self.store.connection.execute(
+            "SELECT tool_name, status FROM tool_calls WHERE agent_id = 'SE'"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["tool_name"], "org.create_role")
+        self.assertEqual(rows[0]["status"], "executed")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2390,6 +2390,7 @@ class SessionMemoryCaptureTests(unittest.TestCase):
         main.memory_digest_interval = self.original_digest_interval
 
     def _make_session(self):
+        # "SE" key with name="SoftwareEngineer" exercises key≠name FK resolution.
         participants = {
             "A": SimpleNamespace(
                 name="A",
@@ -2398,8 +2399,8 @@ class SessionMemoryCaptureTests(unittest.TestCase):
                 update_group_conversations=lambda m: None,
                 runtime_tool_results=[],
             ),
-            "B": SimpleNamespace(
-                name="B",
+            "SE": SimpleNamespace(
+                name="SoftwareEngineer",
                 lifecycle_state="active",
                 interact=lambda *a, **kw: "world",
                 update_group_conversations=lambda m: None,
@@ -2424,13 +2425,13 @@ class SessionMemoryCaptureTests(unittest.TestCase):
     def test_agents_are_upserted_on_session_init(self):
         session = self._make_session()
         agents = self.store.connection.execute(
-            "SELECT agent_id FROM agents WHERE agent_id IN ('A', 'B')"
+            "SELECT agent_id FROM agents WHERE agent_id IN ('A', 'SE')"
         ).fetchall()
-        self.assertEqual({r["agent_id"] for r in agents}, {"A", "B"})
+        self.assertEqual({r["agent_id"] for r in agents}, {"A", "SE"})
 
     def test_turn_messages_are_persisted(self):
         session = self._make_session()
-        session.record_turn("A", "B", "hello prompt", "world response")
+        session.record_turn("A", "SE", "hello prompt", "world response")
         rows = self.store.connection.execute(
             "SELECT content FROM messages WHERE session_id = ?", (session.run_id,)
         ).fetchall()
@@ -2440,7 +2441,7 @@ class SessionMemoryCaptureTests(unittest.TestCase):
 
     def test_empty_prompt_and_response_not_persisted(self):
         session = self._make_session()
-        session.record_turn("A", "B", "", "")
+        session.record_turn("A", "SE", "", "")
         rows = self.store.connection.execute(
             "SELECT COUNT(*) AS n FROM messages WHERE session_id = ?", (session.run_id,)
         ).fetchone()
@@ -2468,8 +2469,8 @@ class SessionMemoryCaptureTests(unittest.TestCase):
     def test_auto_digest_fires_at_interval(self):
         main.memory_digest_interval = 2
         session = self._make_session()
-        session.record_turn("A", "B", "turn one prompt", "turn one response")
-        session.record_turn("A", "B", "turn two prompt", "turn two response")
+        session.record_turn("A", "SE", "turn one prompt", "turn one response")
+        session.record_turn("A", "SE", "turn two prompt", "turn two response")
         rows = self.store.connection.execute(
             "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
         ).fetchall()
@@ -2478,11 +2479,34 @@ class SessionMemoryCaptureTests(unittest.TestCase):
     def test_auto_digest_not_fired_before_interval(self):
         main.memory_digest_interval = 5
         session = self._make_session()
-        session.record_turn("A", "B", "only one turn", "response")
+        session.record_turn("A", "SE", "only one turn", "response")
         rows = self.store.connection.execute(
             "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
         ).fetchall()
         self.assertEqual(len(rows), 0)
+
+    def test_mismatched_key_name_uses_participant_key_for_messages(self):
+        """SE key with role.name='SoftwareEngineer' must persist under key 'SE'."""
+        session = self._make_session()
+        # record_turn with role.name values — should be resolved to participant keys.
+        session.record_turn("SoftwareEngineer", "A", "hi from SE", "hi back")
+        rows = self.store.connection.execute(
+            "SELECT sender_agent_id, receiver_agent_id FROM messages WHERE session_id = ?",
+            (session.run_id,),
+        ).fetchall()
+        agent_ids = {r["sender_agent_id"] for r in rows} | {r["receiver_agent_id"] for r in rows}
+        self.assertIn("SE", agent_ids)
+        self.assertNotIn("SoftwareEngineer", agent_ids)
+
+    def test_mismatched_key_name_uses_participant_key_for_thoughts(self):
+        """Thought recorded under role.name='SoftwareEngineer' must land on key 'SE'."""
+        session = self._make_session()
+        session.record_thought("SoftwareEngineer", "thinking hard")
+        rows = self.store.connection.execute(
+            "SELECT agent_id FROM thoughts WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["agent_id"], "SE")
 
     def test_lifecycle_event_persisted_as_memory_entry(self):
         role = SimpleNamespace(


### PR DESCRIPTION
Wires the existing `SQLiteMemoryStore` to the `Session` class so that all runtime activity is persisted automatically when `ROBITS_MEMORY_DB` is set.

## What's captured

- Session creation and `ended_at` timestamp on completion
- All participants upserted to `agents` on session init
- Each turn's prompt and response as `messages` rows
- Agent thoughts via `record_thought`
- Tool calls and results on `tool_call.executed` / `tool_call.failed` events
- Lifecycle events (create/pause/retire) as `memory_entries` with `kind=lifecycle`

## Automatic digestion

A new `ROBITS_DIGEST_INTERVAL` env var (default `0` = disabled) triggers episodic digest creation every N turns. Each digest captures a raw transcript window for all agents, making conversation history searchable via `memory.search` immediately.

## No-op when unconfigured

All capture paths guard `if memory_store is not None`, so existing runs without `ROBITS_MEMORY_DB` are unaffected.

Closes #58

## Test plan
- `python -m unittest` passes (158 tests)
- `SessionMemoryCaptureTests` covers session/agent init, message/thought/tool-call/lifecycle persistence, `ended_at` stamping, digest interval trigger
- `test_end_session_*` covers the new `SQLiteMemoryStore.end_session()` method