### PR TITLE
Add org chat memory, response brevity, and reasoning effort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,6 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install
-      - run: uv pip install --system -r requirements.txt
-      - run: python -m unittest discover -s tests -v
+      - run: uv venv
+      - run: uv pip install -r requirements.txt
+      - run: uv run python -m unittest discover -s tests -v

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Relevant environment variables:
 - `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
 - `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.
 - `ROBITS_SEARCH_URL`: optional custom web search endpoint for `builtin.web_search`; falls back to the DuckDuckGo Instant Answers API.
+- `ROBITS_DIGEST_INTERVAL`: turns between automatic episodic digest creation; default `0` (disabled). When enabled, a raw transcript digest is created for every agent after each interval, making conversation history searchable via `memory.search`.
 
 ## Tools
 

--- a/main.py
+++ b/main.py
@@ -68,6 +68,7 @@ tool_proposal_store = None
 memory_max_depth = max(0, int(os.environ.get("ROBITS_MEMORY_MAX_DEPTH", "3")))
 memory_max_rows = max(1, int(os.environ.get("ROBITS_MEMORY_MAX_ROWS", "100")))
 memory_cache_threshold = max(512, int(os.environ.get("ROBITS_MEMORY_CACHE_THRESHOLD", "8192")))
+memory_digest_interval = max(0, int(os.environ.get("ROBITS_DIGEST_INTERVAL", "0")))
 agent_workspace_store = AgentWorkspaceStore()
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
@@ -446,6 +447,21 @@ def _emit_role_tool_event(role, event_type, payload):
     session_id = getattr(role, "runtime_session_id", None)
     if event_stream is not None and session_id is not None:
         event_stream.emit(event_type, session_id, payload)
+    if memory_store is not None and event_type in {"tool_call.executed", "tool_call.failed"}:
+        agent_id = getattr(role, "name", None) or getattr(role, "runtime_role_name", None)
+        if agent_id:
+            try:
+                memory_store.append_tool_call(
+                    tool_call_id=payload.get("call_id") or str(uuid4()),
+                    agent_id=agent_id,
+                    tool_name=payload.get("tool_name", ""),
+                    arguments=payload.get("arguments"),
+                    result_content=str(payload.get("result", "")),
+                    status="executed" if event_type == "tool_call.executed" else "failed",
+                    session_id=session_id,
+                )
+            except Exception:
+                pass
 
 
 def _record_role_tool_result(role, result):
@@ -1086,6 +1102,29 @@ def record_lifecycle_event(
         role.lifecycle_events = []
     role.lifecycle_events.append(event)
     role.lifecycle_state = lifecycle_state
+    if memory_store is not None:
+        try:
+            memory_store.upsert_agent(
+                role.name,
+                type(role).__name__,
+                display_name=role.name,
+                lifecycle_state=lifecycle_state,
+            )
+            summary = f"[lifecycle:{action}] {role.name} -> {lifecycle_state}"
+            if requested_by:
+                summary += f" (requested_by={requested_by})"
+            if approved_by:
+                summary += f" (approved_by={approved_by})"
+            if reason:
+                summary += f" reason={reason}"
+            memory_store.append_memory_entry(
+                agent_id=role.name,
+                kind="lifecycle",
+                content=summary,
+                source="system",
+            )
+        except Exception:
+            pass
     return event
 
 
@@ -2026,6 +2065,14 @@ class Session:
                 "max_turns": self.max_turns,
             },
         )
+        if memory_store is not None:
+            try:
+                memory_store.create_session(self.run_id)
+                for name, participant in self.participants.items():
+                    role_type = type(participant).__name__
+                    memory_store.upsert_agent(name, role_type, display_name=name)
+            except Exception:
+                pass
 
     def route_message(self, message, last_receiver_name=None):
         prompt_split = message.split(",", 1) if isinstance(message, str) else []
@@ -2130,9 +2177,88 @@ class Session:
                 "system_event_count": len(entry.system_events),
             },
         )
+        if memory_store is not None:
+            try:
+                if prompt:
+                    memory_store.append_message(
+                        session_id=self.run_id,
+                        sender_agent_id=sender,
+                        receiver_agent_id=receiver,
+                        content=prompt,
+                        kind="message",
+                    )
+                if response:
+                    memory_store.append_message(
+                        session_id=self.run_id,
+                        sender_agent_id=receiver,
+                        receiver_agent_id=sender,
+                        content=response,
+                        kind="message",
+                    )
+            except Exception:
+                pass
+            if (
+                memory_digest_interval > 0
+                and self.turns_completed % memory_digest_interval == 0
+            ):
+                self._auto_digest()
         return entry
 
+    def _auto_digest(self):
+        """Create a raw transcript digest covering the last memory_digest_interval turns."""
+        window = self.transcript[-memory_digest_interval:]
+        lines = []
+        for e in window:
+            if e.prompt:
+                lines.append(f"[turn {e.turn}] {e.sender} -> {e.receiver}: {e.prompt[:512]}")
+            if e.response:
+                lines.append(f"[turn {e.turn}] {e.receiver}: {e.response[:512]}")
+        content = "\n".join(lines)
+        if not content.strip():
+            return
+        source_refs = []
+        try:
+            recent_msg_rows = memory_store.connection.execute(
+                """
+                SELECT message_id FROM messages
+                WHERE session_id = ?
+                ORDER BY message_id DESC LIMIT ?
+                """,
+                (self.run_id, memory_digest_interval * 2),
+            ).fetchall()
+            source_refs = [
+                {"source_table": "messages", "source_id": row["message_id"]}
+                for row in recent_msg_rows
+            ]
+        except Exception:
+            pass
+        if not source_refs:
+            return
+        try:
+            for agent_id in list(self.participants):
+                memory_store.append_memory_digest(
+                    content=content,
+                    source_refs=source_refs,
+                    agent_id=agent_id,
+                    session_id=self.run_id,
+                    digest_type="episodic",
+                    accessibility="agent",
+                    system_only=False,
+                )
+        except Exception:
+            pass
+
     def record_thought(self, agent_name, content, visibility="private"):
+        if memory_store is not None:
+            try:
+                memory_store.append_thought(
+                    agent_id=agent_name,
+                    content=content,
+                    session_id=self.run_id,
+                    visibility=visibility,
+                )
+            except Exception:
+                pass
         return self.event_stream.emit(
             "thought.recorded",
             self.run_id,
@@ -2231,6 +2357,11 @@ class Session:
                 "turns_completed": self.turns_completed,
             },
         )
+        if memory_store is not None:
+            try:
+                memory_store.end_session(self.run_id)
+            except Exception:
+                pass
         return self
 
 

--- a/main.py
+++ b/main.py
@@ -448,7 +448,7 @@ def _emit_role_tool_event(role, event_type, payload):
     if event_stream is not None and session_id is not None:
         event_stream.emit(event_type, session_id, payload)
     if memory_store is not None and event_type in {"tool_call.executed", "tool_call.failed"}:
-        agent_id = getattr(role, "name", None) or getattr(role, "runtime_role_name", None)
+        agent_id = getattr(role, "runtime_role_name", None) or getattr(role, "name", None)
         if agent_id:
             try:
                 memory_store.append_tool_call(
@@ -2057,6 +2057,8 @@ class Session:
         self.transcript = []
         self.turns_completed = 0
         self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
+        # Map role.name → participant dict key for FK-safe persistence.
+        self._name_to_key = {getattr(p, "name", k): k for k, p in self.participants.items()}
         self.event_stream.emit(
             "session.created",
             self.run_id,
@@ -2178,20 +2180,22 @@ class Session:
             },
         )
         if memory_store is not None:
+            canonical_sender = self._canonical_agent_id(sender)
+            canonical_receiver = self._canonical_agent_id(receiver)
             try:
                 if prompt:
                     memory_store.append_message(
                         session_id=self.run_id,
-                        sender_agent_id=sender,
-                        receiver_agent_id=receiver,
+                        sender_agent_id=canonical_sender,
+                        receiver_agent_id=canonical_receiver,
                         content=prompt,
                         kind="message",
                     )
                 if response:
                     memory_store.append_message(
                         session_id=self.run_id,
-                        sender_agent_id=receiver,
-                        receiver_agent_id=sender,
+                        sender_agent_id=canonical_receiver,
+                        receiver_agent_id=canonical_sender,
                         content=response,
                         kind="message",
                     )
@@ -2218,17 +2222,12 @@ class Session:
             return
         source_refs = []
         try:
-            recent_msg_rows = memory_store.connection.execute(
-                """
-                SELECT message_id FROM messages
-                WHERE session_id = ?
-                ORDER BY message_id DESC LIMIT ?
-                """,
-                (self.run_id, memory_digest_interval * 2),
-            ).fetchall()
+            msg_ids = memory_store.list_recent_message_ids(
+                self.run_id, memory_digest_interval * 2
+            )
             source_refs = [
-                {"source_table": "messages", "source_id": row["message_id"]}
-                for row in recent_msg_rows
+                {"source_table": "messages", "source_id": mid}
+                for mid in msg_ids
             ]
         except Exception:
             pass
@@ -2252,7 +2251,7 @@ class Session:
         if memory_store is not None:
             try:
                 memory_store.append_thought(
-                    agent_id=agent_name,
+                    agent_id=self._canonical_agent_id(agent_name),
                     content=content,
                     session_id=self.run_id,
                     visibility=visibility,
@@ -2268,6 +2267,10 @@ class Session:
             },
             visibility=visibility,
         )
+
+    def _canonical_agent_id(self, name):
+        """Return the participant dict key for a role, resolving role.name → key mismatches."""
+        return self._name_to_key.get(name, name)
 
     def sync_scheduler_participants(self):
         for name, participant in self.participants.items():

--- a/main.py
+++ b/main.py
@@ -215,6 +215,7 @@ class ToolRegistry:
                 "builtin_mcp_call": builtin_mcp_call,
                 "builtin_computer_use": builtin_computer_use,
                 "builtin_image_generation": builtin_image_generation,
+                "org_chat_read": org_chat_read,
             },
             local_dict,
         )
@@ -681,6 +682,7 @@ def agent_runtime_context(role=None):
         or getattr(role, "name", None)
     )
     agent_name = getattr(role, "name", None)
+    canonical_id = getattr(role, "runtime_role_name", None) or agent_name
     context = {
         "agent_name": agent_name,
         "role_name": role_name,
@@ -690,7 +692,7 @@ def agent_runtime_context(role=None):
         "current_date_local": now_local.date().isoformat(),
         "timezone": _runtime_timezone_name(local_tz),
         "location": default_location or None,
-        "identity_digest": _latest_identity_digest_content(agent_name) if agent_name else None,
+        "identity_digest": _latest_identity_digest_content(canonical_id) if canonical_id else None,
     }
     return {key: value for key, value in context.items() if value is not None}
 
@@ -903,8 +905,11 @@ def org_chat_read(employee_dict, limit=20):
         result = _org_workspace.read("org", "org_chat.jsonl")
     except Exception:
         return json.dumps({"lines": [], "note": "no org chat history yet"})
+    effective_limit = max(0, min(int(limit or 20), 100))
+    if effective_limit == 0:
+        return json.dumps({"lines": [], "total": 0})
     all_lines = [ln for ln in result["content"].splitlines() if ln.strip()]
-    tail = all_lines[-int(limit):]
+    tail = all_lines[-effective_limit:]
     parsed = []
     for ln in tail:
         try:
@@ -2428,15 +2433,15 @@ class Session:
         reminders = due_alarm_reminders(routed.receiver)
         if reminders:
             prompt = "\n".join(reminders + [prompt])
-        prompt = prepend_verified_tool_results(
+        raw_prompt = prepend_verified_tool_results(
             prompt,
             self.recent_system_events() + system_events,
         )
+        # Inject org chat context for the model only — not stored in transcript to avoid bloat.
         org_context = format_org_chat_context(self.transcript, org_chat_context_lines)
-        if org_context:
-            prompt = org_context + prompt
+        model_prompt = org_context + raw_prompt if org_context else raw_prompt
         self.prepare_agent_runtime(routed.receiver)
-        response = routed.receiver.interact(sender.name, prompt)
+        response = routed.receiver.interact(sender.name, model_prompt)
         response = "" if response is None else response
         native_tool_events = list(getattr(routed.receiver, "runtime_tool_results", []))
         if native_tool_events:
@@ -2452,7 +2457,7 @@ class Session:
         self.record_turn(
             sender=sender.name,
             receiver=routed.receiver.name,
-            prompt=prompt,
+            prompt=raw_prompt,
             response=response,
             directed=routed.directed,
             system_events=system_events,

--- a/main.py
+++ b/main.py
@@ -69,7 +69,11 @@ memory_max_depth = max(0, int(os.environ.get("ROBITS_MEMORY_MAX_DEPTH", "3")))
 memory_max_rows = max(1, int(os.environ.get("ROBITS_MEMORY_MAX_ROWS", "100")))
 memory_cache_threshold = max(512, int(os.environ.get("ROBITS_MEMORY_CACHE_THRESHOLD", "8192")))
 memory_digest_interval = max(0, int(os.environ.get("ROBITS_DIGEST_INTERVAL", "0")))
+org_chat_context_lines = max(0, int(os.environ.get("ROBITS_ORG_CHAT_CONTEXT_LINES", "20")))
+org_digest_interval = max(0, int(os.environ.get("ROBITS_ORG_DIGEST_INTERVAL", "0")))
+_reasoning_effort_env = os.environ.get("ROBITS_REASONING_EFFORT", "").strip().lower() or None
 agent_workspace_store = AgentWorkspaceStore()
+_org_workspace = agent_workspace_store if memory_store is not None else None
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
 default_timezone = os.environ.get("ROBITS_TIMEZONE", "").strip()
 SAFE_TOOL_BUILTINS = {
@@ -532,6 +536,9 @@ class ResponsesProvider(ModelProvider):
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
+        effort = getattr(role, "reasoning_effort", None) or _reasoning_effort_env
+        if effort and effort in {"low", "medium", "high"}:
+            kwargs["reasoning"] = {"effort": effort}
 
         response = _with_model_retries(lambda: self.client.responses.create(**kwargs))
         for _ in range(8):
@@ -652,6 +659,18 @@ def _runtime_timezone_name(tzinfo):
     return getattr(tzinfo, "key", None) or str(tzinfo)
 
 
+def _latest_identity_digest_content(agent_id):
+    if memory_store is None:
+        return None
+    try:
+        digests = memory_store.list_memory_digests(
+            agent_id=agent_id, digest_type="identity", current_only=True, limit=1
+        )
+        return digests[0]["content"] if digests else None
+    except Exception:
+        return None
+
+
 def agent_runtime_context(role=None):
     now_utc = datetime.now(timezone.utc)
     local_tz = _runtime_timezone()
@@ -661,8 +680,9 @@ def agent_runtime_context(role=None):
         or getattr(role, "runtime_role_name", None)
         or getattr(role, "name", None)
     )
+    agent_name = getattr(role, "name", None)
     context = {
-        "agent_name": getattr(role, "name", None),
+        "agent_name": agent_name,
         "role_name": role_name,
         "session_id": getattr(role, "runtime_session_id", None),
         "current_datetime_utc": now_utc.isoformat(timespec="seconds"),
@@ -670,6 +690,7 @@ def agent_runtime_context(role=None):
         "current_date_local": now_local.date().isoformat(),
         "timezone": _runtime_timezone_name(local_tz),
         "location": default_location or None,
+        "identity_digest": _latest_identity_digest_content(agent_name) if agent_name else None,
     }
     return {key: value for key, value in context.items() if value is not None}
 
@@ -682,6 +703,18 @@ def format_agent_context(role=None):
         "Use this context for dates, times, location, identity, and session references. "
         "Do not invent missing context; call agent.context if you need to refresh it.\n"
     )
+
+
+def format_org_chat_context(transcript, limit):
+    if not transcript or limit == 0:
+        return ""
+    recent = transcript[-limit:]
+    lines = []
+    for e in recent:
+        lines.append(f"[Turn {e.turn}] {e.sender} -> {e.receiver}: {e.prompt[:400]}")
+        if e.response:
+            lines.append(f"  -> {e.response[:400]}")
+    return "\nRecent org chat:\n" + "\n".join(lines) + "\n"
 
 
 def current_agent_context(employee_dict):
@@ -860,6 +893,25 @@ def workspace_delete(employee_dict, agent_name, path):
         return json.dumps(agent_workspace_store.delete(normalized_name, path), sort_keys=True)
     except WorkspacePathError as e:
         return f"Error: {e}"
+
+
+def org_chat_read(employee_dict, limit=20):
+    del employee_dict
+    if _org_workspace is None:
+        return json.dumps({"lines": [], "note": "org chat not available"})
+    try:
+        result = _org_workspace.read("org", "org_chat.jsonl")
+    except Exception:
+        return json.dumps({"lines": [], "note": "no org chat history yet"})
+    all_lines = [ln for ln in result["content"].splitlines() if ln.strip()]
+    tail = all_lines[-int(limit):]
+    parsed = []
+    for ln in tail:
+        try:
+            parsed.append(json.loads(ln))
+        except Exception:
+            pass
+    return json.dumps({"lines": parsed, "total": len(all_lines)})
 
 
 def grant_tool_access(employee_dict, role_name, tool_name, granted_by=None):
@@ -1715,13 +1767,20 @@ def due_alarm_reminders(role, now=None):
     return reminders
 
 
+BREVITY_GUIDANCE = (
+    "\nCommunication style: default to concise responses — short clarifying questions, "
+    "statements of intent, and brief insights. Reserve longer responses for moments "
+    "where depth is explicitly needed or signaled by the conversation.\n"
+)
+
+
 def interact(self, model, sender, message):
     if self.template != "" and self.name not in self.conversation_history:
         self.conversation_history[self.name] = [
             {"role": "system", "content": self.template},
         ]
     messages = self.conversation_history.get(self.name, [])
-    system_content = self.template + format_agent_context(self)
+    system_content = self.template + BREVITY_GUIDANCE + format_agent_context(self)
     if messages and messages[0].get("role") == "system":
         messages[0]["content"] = system_content
     elif self.template:
@@ -2067,6 +2126,7 @@ class Session:
                 "max_turns": self.max_turns,
             },
         )
+        self._org_workspace = _org_workspace
         if memory_store is not None:
             try:
                 memory_store.create_session(self.run_id)
@@ -2190,6 +2250,7 @@ class Session:
                         receiver_agent_id=canonical_receiver,
                         content=prompt,
                         kind="message",
+                        conversation_type="org_chat",
                     )
                 if response:
                     memory_store.append_message(
@@ -2198,6 +2259,7 @@ class Session:
                         receiver_agent_id=canonical_sender,
                         content=response,
                         kind="message",
+                        conversation_type="org_chat",
                     )
             except Exception:
                 pass
@@ -2206,6 +2268,12 @@ class Session:
                 and self.turns_completed % memory_digest_interval == 0
             ):
                 self._auto_digest()
+            if (
+                org_digest_interval > 0
+                and self.turns_completed % org_digest_interval == 0
+            ):
+                self._auto_org_digest()
+        self._write_org_chat_jsonl(entry)
         return entry
 
     def _auto_digest(self):
@@ -2246,6 +2314,55 @@ class Session:
                 )
         except Exception:
             pass
+
+    def _write_org_chat_jsonl(self, entry):
+        if self._org_workspace is None:
+            return
+        line = json.dumps({
+            "turn": entry.turn,
+            "sender": entry.sender,
+            "receiver": entry.receiver,
+            "prompt": entry.prompt,
+            "response": entry.response,
+        })
+        try:
+            self._org_workspace.write("org", "org_chat.jsonl", line + "\n", append=True)
+        except Exception:
+            pass
+
+    def _auto_org_digest(self):
+        if memory_store is None:
+            return
+        window = self.transcript[-org_digest_interval:]
+        lines = [
+            f"[turn {e.turn}] {e.sender}->{e.receiver}: {e.prompt[:300]} | {e.response[:300]}"
+            for e in window
+        ]
+        content = "Org chat digest:\n" + "\n".join(lines)
+        source_refs = []
+        try:
+            msg_ids = memory_store.list_recent_message_ids_by_type(
+                self.run_id, org_digest_interval * 2, "org_chat"
+            )
+            source_refs = [{"source_table": "messages", "source_id": mid} for mid in msg_ids]
+        except Exception:
+            pass
+        if not source_refs:
+            return
+        for agent_id in list(self.participants):
+            try:
+                memory_store.append_memory_digest(
+                    content=content,
+                    source_refs=source_refs,
+                    agent_id=agent_id,
+                    session_id=self.run_id,
+                    digest_type="episodic",
+                    conversation_type="org_chat",
+                    accessibility="agent",
+                    system_only=False,
+                )
+            except Exception:
+                pass
 
     def record_thought(self, agent_name, content, visibility="private"):
         if memory_store is not None:
@@ -2315,6 +2432,9 @@ class Session:
             prompt,
             self.recent_system_events() + system_events,
         )
+        org_context = format_org_chat_context(self.transcript, org_chat_context_lines)
+        if org_context:
+            prompt = org_context + prompt
         self.prepare_agent_runtime(routed.receiver)
         response = routed.receiver.interact(sender.name, prompt)
         response = "" if response is None else response

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -307,6 +307,18 @@ class SQLiteMemoryStore:
         ).fetchall()
         return [row["message_id"] for row in reversed(rows)]
 
+    def list_recent_message_ids_by_type(self, session_id, limit, conversation_type):
+        """Return the last ``limit`` message IDs for a session filtered by conversation_type."""
+        rows = self.connection.execute(
+            """
+            SELECT message_id FROM messages
+            WHERE session_id = ? AND conversation_type = ?
+            ORDER BY message_id DESC LIMIT ?
+            """,
+            (session_id, conversation_type, limit),
+        ).fetchall()
+        return [row["message_id"] for row in reversed(rows)]
+
     def end_session(self, session_id, ended_at=None):
         self.connection.execute(
             "UPDATE sessions SET ended_at = ? WHERE session_id = ?",

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -295,6 +295,13 @@ class SQLiteMemoryStore:
         self.connection.commit()
         return session_id
 
+    def end_session(self, session_id, ended_at=None):
+        self.connection.execute(
+            "UPDATE sessions SET ended_at = ? WHERE session_id = ?",
+            (ended_at or _utc_now(), session_id),
+        )
+        self.connection.commit()
+
     def upsert_agent(
         self,
         agent_id,

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -295,6 +295,18 @@ class SQLiteMemoryStore:
         self.connection.commit()
         return session_id
 
+    def list_recent_message_ids(self, session_id, limit):
+        """Return the last ``limit`` message IDs for a session in chronological order."""
+        rows = self.connection.execute(
+            """
+            SELECT message_id FROM messages
+            WHERE session_id = ?
+            ORDER BY message_id DESC LIMIT ?
+            """,
+            (session_id, limit),
+        ).fetchall()
+        return [row["message_id"] for row in reversed(rows)]
+
     def end_session(self, session_id, ended_at=None):
         self.connection.execute(
             "UPDATE sessions SET ended_at = ? WHERE session_id = ?",

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -691,5 +691,28 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(events[0]["payload_json"], '{"agent": "SE", "content": "Private note."}')
 
 
+    def test_end_session_sets_ended_at(self):
+        store = self.build_store()
+        store.create_session("s-end")
+        row = store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = 's-end'"
+        ).fetchone()
+        self.assertIsNone(row["ended_at"])
+        store.end_session("s-end")
+        row = store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = 's-end'"
+        ).fetchone()
+        self.assertIsNotNone(row["ended_at"])
+
+    def test_end_session_accepts_explicit_timestamp(self):
+        store = self.build_store()
+        store.create_session("s-ts")
+        store.end_session("s-ts", ended_at="2024-01-01T00:00:00")
+        row = store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = 's-ts'"
+        ).fetchone()
+        self.assertEqual(row["ended_at"], "2024-01-01T00:00:00")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -691,6 +691,28 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(events[0]["payload_json"], '{"agent": "SE", "content": "Private note."}')
 
 
+    def test_list_recent_message_ids_returns_chronological_order(self):
+        store = self.build_store()
+        store.create_session("s-order")
+        store.upsert_agent("A", "Role", "A")
+        store.upsert_agent("B", "Role", "B")
+        id1 = store.append_message("s-order", "A", "B", "first")
+        id2 = store.append_message("s-order", "B", "A", "second")
+        id3 = store.append_message("s-order", "A", "B", "third")
+        ids = store.list_recent_message_ids("s-order", 3)
+        self.assertEqual(ids, [id1, id2, id3])
+
+    def test_list_recent_message_ids_limits_to_last_n(self):
+        store = self.build_store()
+        store.create_session("s-limit")
+        store.upsert_agent("A", "Role", "A")
+        store.upsert_agent("B", "Role", "B")
+        store.append_message("s-limit", "A", "B", "first")
+        id2 = store.append_message("s-limit", "B", "A", "second")
+        id3 = store.append_message("s-limit", "A", "B", "third")
+        ids = store.list_recent_message_ids("s-limit", 2)
+        self.assertEqual(ids, [id2, id3])
+
     def test_end_session_sets_ended_at(self):
         store = self.build_store()
         store.create_session("s-end")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2370,5 +2370,155 @@ class MemoryToolTests(unittest.TestCase):
         self.assertTrue(result.startswith("Error:"))
 
 
+class SessionMemoryCaptureTests(unittest.TestCase):
+    """Tests that Session persists messages, thoughts, tool calls, and lifecycle events."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "mem.sqlite3")
+        self.addCleanup(self.store.close)
+
+        self.original_store = main.memory_store
+        self.original_digest_interval = main.memory_digest_interval
+        main.memory_store = self.store
+        main.memory_digest_interval = 0
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.memory_store = self.original_store
+        main.memory_digest_interval = self.original_digest_interval
+
+    def _make_session(self):
+        participants = {
+            "A": SimpleNamespace(
+                name="A",
+                lifecycle_state="active",
+                interact=lambda *a, **kw: "hello",
+                update_group_conversations=lambda m: None,
+                runtime_tool_results=[],
+            ),
+            "B": SimpleNamespace(
+                name="B",
+                lifecycle_state="active",
+                interact=lambda *a, **kw: "world",
+                update_group_conversations=lambda m: None,
+                runtime_tool_results=[],
+            ),
+        }
+        system = SimpleNamespace(interact=lambda *a, **kw: None)
+        scheduler = main.RoundRobinScheduler(list(participants))
+        return main.Session(
+            participants=participants,
+            system=system,
+            scheduler=scheduler,
+        )
+
+    def test_session_creation_is_persisted(self):
+        session = self._make_session()
+        row = self.store.connection.execute(
+            "SELECT session_id FROM sessions WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertIsNotNone(row)
+
+    def test_agents_are_upserted_on_session_init(self):
+        session = self._make_session()
+        agents = self.store.connection.execute(
+            "SELECT agent_id FROM agents WHERE agent_id IN ('A', 'B')"
+        ).fetchall()
+        self.assertEqual({r["agent_id"] for r in agents}, {"A", "B"})
+
+    def test_turn_messages_are_persisted(self):
+        session = self._make_session()
+        session.record_turn("A", "B", "hello prompt", "world response")
+        rows = self.store.connection.execute(
+            "SELECT content FROM messages WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        contents = {r["content"] for r in rows}
+        self.assertIn("hello prompt", contents)
+        self.assertIn("world response", contents)
+
+    def test_empty_prompt_and_response_not_persisted(self):
+        session = self._make_session()
+        session.record_turn("A", "B", "", "")
+        rows = self.store.connection.execute(
+            "SELECT COUNT(*) AS n FROM messages WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertEqual(rows["n"], 0)
+
+    def test_thought_is_persisted(self):
+        session = self._make_session()
+        session.record_thought("A", "my private thought")
+        rows = self.store.connection.execute(
+            "SELECT content, visibility FROM thoughts WHERE agent_id = 'A'"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["content"], "my private thought")
+        self.assertEqual(rows[0]["visibility"], "private")
+
+    def test_session_ended_at_set_on_run_completion(self):
+        session = self._make_session()
+        session.turns_completed = 0
+        session.run(initial_message="go", max_turns=1)
+        row = self.store.connection.execute(
+            "SELECT ended_at FROM sessions WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertIsNotNone(row["ended_at"])
+
+    def test_auto_digest_fires_at_interval(self):
+        main.memory_digest_interval = 2
+        session = self._make_session()
+        session.record_turn("A", "B", "turn one prompt", "turn one response")
+        session.record_turn("A", "B", "turn two prompt", "turn two response")
+        rows = self.store.connection.execute(
+            "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertGreater(len(rows), 0)
+
+    def test_auto_digest_not_fired_before_interval(self):
+        main.memory_digest_interval = 5
+        session = self._make_session()
+        session.record_turn("A", "B", "only one turn", "response")
+        rows = self.store.connection.execute(
+            "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertEqual(len(rows), 0)
+
+    def test_lifecycle_event_persisted_as_memory_entry(self):
+        role = SimpleNamespace(
+            name="NewRole",
+            lifecycle_state="active",
+            lifecycle_events=[],
+        )
+        main.record_lifecycle_event(role, "create", "active", requested_by="CEO")
+        rows = self.store.connection.execute(
+            "SELECT content FROM memory_entries WHERE agent_id = 'NewRole' AND kind = 'lifecycle'"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertIn("create", rows[0]["content"])
+        self.assertIn("active", rows[0]["content"])
+
+    def test_tool_call_persisted_on_executed_event(self):
+        role = SimpleNamespace(
+            name="SE",
+            runtime_event_stream=None,
+            runtime_session_id="test-session",
+        )
+        self.store.create_session("test-session")
+        self.store.upsert_agent("SE", "SoftwareEngineer", "SE")
+        main._emit_role_tool_event(role, "tool_call.executed", {
+            "call_id": "call-1",
+            "tool_name": "org.create_role",
+            "arguments": {"role_name": "QA"},
+            "result": "Created role QA",
+        })
+        rows = self.store.connection.execute(
+            "SELECT tool_name, status FROM tool_calls WHERE agent_id = 'SE'"
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["tool_name"], "org.create_role")
+        self.assertEqual(rows[0]["status"], "executed")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2390,6 +2390,7 @@ class SessionMemoryCaptureTests(unittest.TestCase):
         main.memory_digest_interval = self.original_digest_interval
 
     def _make_session(self):
+        # "SE" key with name="SoftwareEngineer" exercises key≠name FK resolution.
         participants = {
             "A": SimpleNamespace(
                 name="A",
@@ -2398,8 +2399,8 @@ class SessionMemoryCaptureTests(unittest.TestCase):
                 update_group_conversations=lambda m: None,
                 runtime_tool_results=[],
             ),
-            "B": SimpleNamespace(
-                name="B",
+            "SE": SimpleNamespace(
+                name="SoftwareEngineer",
                 lifecycle_state="active",
                 interact=lambda *a, **kw: "world",
                 update_group_conversations=lambda m: None,
@@ -2424,13 +2425,13 @@ class SessionMemoryCaptureTests(unittest.TestCase):
     def test_agents_are_upserted_on_session_init(self):
         session = self._make_session()
         agents = self.store.connection.execute(
-            "SELECT agent_id FROM agents WHERE agent_id IN ('A', 'B')"
+            "SELECT agent_id FROM agents WHERE agent_id IN ('A', 'SE')"
         ).fetchall()
-        self.assertEqual({r["agent_id"] for r in agents}, {"A", "B"})
+        self.assertEqual({r["agent_id"] for r in agents}, {"A", "SE"})
 
     def test_turn_messages_are_persisted(self):
         session = self._make_session()
-        session.record_turn("A", "B", "hello prompt", "world response")
+        session.record_turn("A", "SE", "hello prompt", "world response")
         rows = self.store.connection.execute(
             "SELECT content FROM messages WHERE session_id = ?", (session.run_id,)
         ).fetchall()
@@ -2440,7 +2441,7 @@ class SessionMemoryCaptureTests(unittest.TestCase):
 
     def test_empty_prompt_and_response_not_persisted(self):
         session = self._make_session()
-        session.record_turn("A", "B", "", "")
+        session.record_turn("A", "SE", "", "")
         rows = self.store.connection.execute(
             "SELECT COUNT(*) AS n FROM messages WHERE session_id = ?", (session.run_id,)
         ).fetchone()
@@ -2468,8 +2469,8 @@ class SessionMemoryCaptureTests(unittest.TestCase):
     def test_auto_digest_fires_at_interval(self):
         main.memory_digest_interval = 2
         session = self._make_session()
-        session.record_turn("A", "B", "turn one prompt", "turn one response")
-        session.record_turn("A", "B", "turn two prompt", "turn two response")
+        session.record_turn("A", "SE", "turn one prompt", "turn one response")
+        session.record_turn("A", "SE", "turn two prompt", "turn two response")
         rows = self.store.connection.execute(
             "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
         ).fetchall()
@@ -2478,11 +2479,34 @@ class SessionMemoryCaptureTests(unittest.TestCase):
     def test_auto_digest_not_fired_before_interval(self):
         main.memory_digest_interval = 5
         session = self._make_session()
-        session.record_turn("A", "B", "only one turn", "response")
+        session.record_turn("A", "SE", "only one turn", "response")
         rows = self.store.connection.execute(
             "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
         ).fetchall()
         self.assertEqual(len(rows), 0)
+
+    def test_mismatched_key_name_uses_participant_key_for_messages(self):
+        """SE key with role.name='SoftwareEngineer' must persist under key 'SE'."""
+        session = self._make_session()
+        # record_turn with role.name values — should be resolved to participant keys.
+        session.record_turn("SoftwareEngineer", "A", "hi from SE", "hi back")
+        rows = self.store.connection.execute(
+            "SELECT sender_agent_id, receiver_agent_id FROM messages WHERE session_id = ?",
+            (session.run_id,),
+        ).fetchall()
+        agent_ids = {r["sender_agent_id"] for r in rows} | {r["receiver_agent_id"] for r in rows}
+        self.assertIn("SE", agent_ids)
+        self.assertNotIn("SoftwareEngineer", agent_ids)
+
+    def test_mismatched_key_name_uses_participant_key_for_thoughts(self):
+        """Thought recorded under role.name='SoftwareEngineer' must land on key 'SE'."""
+        session = self._make_session()
+        session.record_thought("SoftwareEngineer", "thinking hard")
+        rows = self.store.connection.execute(
+            "SELECT agent_id FROM thoughts WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["agent_id"], "SE")
 
     def test_lifecycle_event_persisted_as_memory_entry(self):
         role = SimpleNamespace(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2544,5 +2544,317 @@ class SessionMemoryCaptureTests(unittest.TestCase):
         self.assertEqual(rows[0]["status"], "executed")
 
 
+class OrgChatContextTests(unittest.TestCase):
+    """Tests for format_org_chat_context and JSONL write."""
+
+    def test_empty_transcript_returns_empty_string(self):
+        self.assertEqual(main.format_org_chat_context([], 10), "")
+
+    def test_zero_limit_returns_empty_string(self):
+        entries = [main.TranscriptEntry(1, "A", "B", "hello", "world")]
+        self.assertEqual(main.format_org_chat_context(entries, 0), "")
+
+    def test_formats_recent_entries(self):
+        entries = [
+            main.TranscriptEntry(1, "Alice", "Bob", "question", "answer"),
+            main.TranscriptEntry(2, "Bob", "Alice", "follow-up", "ok"),
+        ]
+        result = main.format_org_chat_context(entries, 5)
+        self.assertIn("Turn 1", result)
+        self.assertIn("Alice", result)
+        self.assertIn("question", result)
+        self.assertIn("answer", result)
+        self.assertIn("Turn 2", result)
+
+    def test_limit_truncates_to_last_n_entries(self):
+        entries = [main.TranscriptEntry(i, "A", "B", f"msg{i}", "") for i in range(1, 6)]
+        result = main.format_org_chat_context(entries, 2)
+        self.assertNotIn("msg1", result)
+        self.assertIn("msg4", result)
+        self.assertIn("msg5", result)
+
+    def test_prompt_truncated_at_400_chars(self):
+        long_prompt = "x" * 600
+        entries = [main.TranscriptEntry(1, "A", "B", long_prompt, "")]
+        result = main.format_org_chat_context(entries, 5)
+        self.assertNotIn("x" * 401, result)
+
+    def test_write_org_chat_jsonl_writes_entry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = main.AgentWorkspaceStore(tmp)
+            session = main.Session(
+                participants={"A": SimpleNamespace(
+                    name="A", lifecycle_state="active",
+                    interact=lambda *a, **kw: "hi",
+                    update_group_conversations=lambda m: None,
+                )},
+            )
+            session._org_workspace = store
+            entry = main.TranscriptEntry(1, "A", "B", "hello", "world")
+            session._write_org_chat_jsonl(entry)
+            result = store.read("org", "org_chat.jsonl")
+            parsed = json.loads(result["content"].strip())
+            self.assertEqual(parsed["turn"], 1)
+            self.assertEqual(parsed["sender"], "A")
+
+    def test_org_chat_injected_in_step(self):
+        received_prompts = []
+
+        class CapturingRole:
+            name = "B"
+            lifecycle_state = "active"
+            conversation_history = {}
+            template = ""
+            max_tokens = 100
+            temperature = 0.0
+            runtime_tool_results = []
+            runtime_event_stream = None
+            runtime_session_id = None
+            runtime_role_name = None
+            allowed_tools = set()
+
+            def interact(self, sender=None, prompt=None):
+                received_prompts.append(prompt or "")
+                return "response"
+
+            def update_group_conversations(self, m):
+                pass
+
+        a = SimpleNamespace(
+            name="A", lifecycle_state="active",
+            interact=lambda *a, **kw: "initial",
+            update_group_conversations=lambda m: None,
+        )
+        b = CapturingRole()
+        old_lines = main.org_chat_context_lines
+        main.org_chat_context_lines = 5
+        try:
+            session = main.Session(participants={"A": a, "B": b})
+            # seed transcript with one entry manually
+            session.transcript.append(main.TranscriptEntry(1, "A", "B", "seed prompt", "seed response"))
+            session.turns_completed = 1
+            session.last_receiver = a
+            session.step("hello")
+        finally:
+            main.org_chat_context_lines = old_lines
+
+        self.assertTrue(any("Recent org chat" in p for p in received_prompts))
+
+
+class OrgDigestTests(unittest.TestCase):
+    """Tests for _auto_org_digest and list_recent_message_ids_by_type."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "org.sqlite3")
+        self.addCleanup(self.store.close)
+        self.original_store = main.memory_store
+        self.original_org_interval = main.org_digest_interval
+        main.memory_store = self.store
+        main.org_digest_interval = 2
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.memory_store = self.original_store
+        main.org_digest_interval = self.original_org_interval
+
+    def _make_session(self):
+        participants = {
+            "X": SimpleNamespace(
+                name="X", lifecycle_state="active",
+                interact=lambda *a, **kw: "resp",
+                update_group_conversations=lambda m: None,
+            ),
+            "Y": SimpleNamespace(
+                name="Y", lifecycle_state="active",
+                interact=lambda *a, **kw: "resp",
+                update_group_conversations=lambda m: None,
+            ),
+        }
+        return main.Session(participants=participants)
+
+    def test_messages_tagged_as_org_chat(self):
+        session = self._make_session()
+        session.record_turn("X", "Y", "hello", "world")
+        rows = self.store.connection.execute(
+            "SELECT conversation_type FROM messages WHERE session_id=?", (session.run_id,)
+        ).fetchall()
+        self.assertTrue(all(r["conversation_type"] == "org_chat" for r in rows))
+
+    def test_list_recent_message_ids_by_type_filters_correctly(self):
+        session = self._make_session()
+        session.record_turn("X", "Y", "msg1", "resp1")
+        ids = self.store.list_recent_message_ids_by_type(session.run_id, 10, "org_chat")
+        self.assertGreater(len(ids), 0)
+        # Non-matching type returns empty
+        ids_other = self.store.list_recent_message_ids_by_type(session.run_id, 10, "personal")
+        self.assertEqual(ids_other, [])
+
+    def test_org_digest_fires_at_interval(self):
+        session = self._make_session()
+        # Two turns should trigger digest (interval=2)
+        session.record_turn("X", "Y", "first", "one")
+        session.record_turn("Y", "X", "second", "two")
+        digests = self.store.list_memory_digests(
+            agent_id="X", digest_type="episodic", limit=10
+        )
+        org_digests = [d for d in digests if d.get("conversation_type") == "org_chat"]
+        self.assertEqual(len(org_digests), 1)
+        self.assertIn("Org chat digest", org_digests[0]["content"])
+
+    def test_org_digest_not_fired_before_interval(self):
+        session = self._make_session()
+        session.record_turn("X", "Y", "only one turn", "yes")
+        digests = self.store.list_memory_digests(
+            agent_id="X", digest_type="episodic", limit=10
+        )
+        org_digests = [d for d in digests if d.get("conversation_type") == "org_chat"]
+        self.assertEqual(len(org_digests), 0)
+
+
+class ReasoningEffortTests(unittest.TestCase):
+    """Tests that ResponsesProvider forwards reasoning_effort when set."""
+
+    def _make_fake_response(self, text="done"):
+        output = SimpleNamespace(type="message", content=[SimpleNamespace(type="output_text", text=text)])
+        return SimpleNamespace(id="resp-1", output=[output])
+
+    def _make_provider_and_role(self, role_effort=None):
+        role = SimpleNamespace(
+            name="TestRole",
+            max_tokens=100,
+            temperature=0.0,
+            employee_dict=None,
+            allowed_tools=set(),
+            reasoning_effort=role_effort,
+        )
+        registry = SimpleNamespace(
+            as_responses_tools=lambda r: [],
+        )
+        return role, registry
+
+    def test_valid_effort_forwarded_to_api(self):
+        role, registry = self._make_provider_and_role()
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return self._make_fake_response()
+
+        provider = main.ResponsesProvider.__new__(main.ResponsesProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+        old_effort = main._reasoning_effort_env
+        main._reasoning_effort_env = "low"
+        try:
+            with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+                provider.generate(role, "gpt-4o", "sender", [])
+        finally:
+            main._reasoning_effort_env = old_effort
+
+        self.assertEqual(captured.get("reasoning"), {"effort": "low"})
+
+    def test_invalid_effort_not_forwarded(self):
+        role, registry = self._make_provider_and_role()
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return self._make_fake_response()
+
+        provider = main.ResponsesProvider.__new__(main.ResponsesProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+        old_effort = main._reasoning_effort_env
+        main._reasoning_effort_env = "ultra"
+        try:
+            with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+                provider.generate(role, "gpt-4o", "sender", [])
+        finally:
+            main._reasoning_effort_env = old_effort
+
+        self.assertNotIn("reasoning", captured)
+
+    def test_role_effort_overrides_env(self):
+        role, registry = self._make_provider_and_role(role_effort="high")
+        captured = {}
+
+        def fake_create(**kwargs):
+            captured.update(kwargs)
+            return self._make_fake_response()
+
+        provider = main.ResponsesProvider.__new__(main.ResponsesProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(responses=SimpleNamespace(create=fake_create))
+
+        old_effort = main._reasoning_effort_env
+        main._reasoning_effort_env = "low"
+        try:
+            with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+                provider.generate(role, "gpt-4o", "sender", [])
+        finally:
+            main._reasoning_effort_env = old_effort
+
+        self.assertEqual(captured.get("reasoning"), {"effort": "high"})
+
+
+class OrgChatReadToolTests(unittest.TestCase):
+    """Tests for the org_chat_read function."""
+
+    def test_returns_empty_when_no_org_workspace(self):
+        old = main._org_workspace
+        main._org_workspace = None
+        try:
+            result = json.loads(main.org_chat_read({}))
+        finally:
+            main._org_workspace = old
+        self.assertEqual(result["lines"], [])
+        self.assertIn("not available", result["note"])
+
+    def test_returns_empty_when_file_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = main.AgentWorkspaceStore(tmp)
+            old = main._org_workspace
+            main._org_workspace = store
+            try:
+                result = json.loads(main.org_chat_read({}))
+            finally:
+                main._org_workspace = old
+            self.assertEqual(result["lines"], [])
+
+    def test_returns_parsed_lines(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = main.AgentWorkspaceStore(tmp)
+            entry = {"turn": 1, "sender": "A", "receiver": "B", "prompt": "hi", "response": "hey"}
+            store.write("org", "org_chat.jsonl", json.dumps(entry) + "\n", append=False)
+            old = main._org_workspace
+            main._org_workspace = store
+            try:
+                result = json.loads(main.org_chat_read({}))
+            finally:
+                main._org_workspace = old
+            self.assertEqual(len(result["lines"]), 1)
+            self.assertEqual(result["lines"][0]["sender"], "A")
+            self.assertEqual(result["total"], 1)
+
+    def test_limit_respected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = main.AgentWorkspaceStore(tmp)
+            for i in range(5):
+                entry = {"turn": i, "sender": "A", "receiver": "B", "prompt": f"p{i}", "response": ""}
+                store.write("org", "org_chat.jsonl", json.dumps(entry) + "\n", append=True)
+            old = main._org_workspace
+            main._org_workspace = store
+            try:
+                result = json.loads(main.org_chat_read({}, limit=2))
+            finally:
+                main._org_workspace = old
+            self.assertEqual(len(result["lines"]), 2)
+            self.assertEqual(result["total"], 5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools.yaml
+++ b/tools.yaml
@@ -267,8 +267,8 @@
   system_tool: false
   grantable: true
   description: >
-    Read recent org chat history. Returns the last `limit` turns of inter-agent
-    conversation as a JSON array. Use this to catch up on what other agents discussed.
+    Read recent org chat history. Returns a JSON object with `lines` (array of turn objects) and `total` (total turns available) fields.
+    Use this to catch up on what other agents discussed.
   parameters:
     type: object
     properties:
@@ -278,7 +278,7 @@
         default: 20
     required: []
   code: |
-    return org_chat_read(employee_dict, limit=min(int(kwargs.get("limit", 20)), 100))
+    return org_chat_read(employee_dict, limit=min(int(limit if limit is not None else 20), 100))
 - name: agent.create_alarm
   required_capabilities: []
   owner_capability: agent

--- a/tools.yaml
+++ b/tools.yaml
@@ -261,6 +261,24 @@
       - path
   code: |
     return workspace_delete(employee_dict, agent_name, path)
+- name: org.chat_read
+  required_capabilities: []
+  owner_capability: basic
+  system_tool: false
+  grantable: true
+  description: >
+    Read recent org chat history. Returns the last `limit` turns of inter-agent
+    conversation as a JSON array. Use this to catch up on what other agents discussed.
+  parameters:
+    type: object
+    properties:
+      limit:
+        type: integer
+        description: Number of recent turns to return (default 20, max 100).
+        default: 20
+    required: []
+  code: |
+    return org_chat_read(employee_dict, limit=min(int(kwargs.get("limit", 20)), 100))
 - name: agent.create_alarm
   required_capabilities: []
   owner_capability: agent


### PR DESCRIPTION
Closes #61

## Summary

- **Org chat persistence**: tag all inter-agent messages `conversation_type="org_chat"` in SQLite; write transcript to `var/agents/org/org_chat.jsonl` after each turn
- **Prompt injection**: recent N org chat turns prepended to each agent's prompt (`ROBITS_ORG_CHAT_CONTEXT_LINES`, default 20)
- **`org.chat_read` tool**: grantable tool for agents to query org chat history directly
- **Per-agent org digests**: `ROBITS_ORG_DIGEST_INTERVAL` triggers `episodic/org_chat` digests per participant, reusing the personal memory pipeline
- **Identity digest in system prompt**: latest identity digest content surfaced in every agent's `agent_runtime_context` JSON block
- **Brevity guidance**: `BREVITY_GUIDANCE` constant appended to every role's system prompt at `interact()` time
- **Reasoning effort**: `ResponsesProvider` passes `reasoning={"effort": ...}` when `ROBITS_REASONING_EFFORT` or `role.reasoning_effort` is `low`/`medium`/`high`
- **New SQLite method**: `list_recent_message_ids_by_type(session_id, limit, conversation_type)`

## Test plan

- [x] All 180 tests pass (`uv run python -m unittest discover -s tests -v`)
- [x] `OrgChatContextTests` — format, JSONL write, step injection
- [x] `OrgDigestTests` — org_chat tagging, digest fires at interval, filtered ID list
- [x] `ReasoningEffortTests` — valid/invalid effort forwarding, role override of env
- [x] `OrgChatReadToolTests` — missing workspace, missing file, parse, limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)