### PR TITLE
On/off-the-clock mode with identity weighting and work context parking

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,8 @@ memory_digest_interval = max(0, int(os.environ.get("ROBITS_DIGEST_INTERVAL", "0"
 org_chat_context_lines = max(0, int(os.environ.get("ROBITS_ORG_CHAT_CONTEXT_LINES", "20")))
 org_digest_interval = max(0, int(os.environ.get("ROBITS_ORG_DIGEST_INTERVAL", "0")))
 _reasoning_effort_env = os.environ.get("ROBITS_REASONING_EFFORT", "").strip().lower() or None
+_raw_clock_state = os.environ.get("ROBITS_CLOCK_STATE", "on").strip().lower()
+clock_state = _raw_clock_state if _raw_clock_state in {"on", "off"} else "on"
 agent_workspace_store = AgentWorkspaceStore()
 _org_workspace = agent_workspace_store if memory_store is not None else None
 default_location = os.environ.get("ROBITS_LOCATION", "").strip()
@@ -660,16 +662,26 @@ def _runtime_timezone_name(tzinfo):
     return getattr(tzinfo, "key", None) or str(tzinfo)
 
 
-def _latest_identity_digest_content(agent_id):
-    if memory_store is None:
-        return None
-    try:
-        digests = memory_store.list_memory_digests(
-            agent_id=agent_id, digest_type="identity", current_only=True, limit=1
-        )
-        return digests[0]["content"] if digests else None
-    except Exception:
-        return None
+def _get_identity_digests(agent_id):
+    """Return (primary_content, secondary_content) ordered by clock_state."""
+    if memory_store is None or not agent_id:
+        return None, None
+
+    def _fetch(rel_type):
+        try:
+            rows = memory_store.list_memory_digests(
+                agent_id=agent_id, digest_type="identity",
+                current_only=True, limit=1, relationship_type=rel_type,
+            )
+            return rows[0]["content"] if rows else None
+        except Exception:
+            return None
+
+    personal = _fetch("personal")
+    work = _fetch("work") or _fetch(None)  # fall back to untagged (legacy)
+    if clock_state == "on":
+        return work, personal
+    return personal, work
 
 
 def agent_runtime_context(role=None):
@@ -683,6 +695,7 @@ def agent_runtime_context(role=None):
     )
     agent_name = getattr(role, "name", None)
     canonical_id = getattr(role, "runtime_role_name", None) or agent_name
+    primary_id, secondary_id = _get_identity_digests(canonical_id)
     context = {
         "agent_name": agent_name,
         "role_name": role_name,
@@ -692,7 +705,9 @@ def agent_runtime_context(role=None):
         "current_date_local": now_local.date().isoformat(),
         "timezone": _runtime_timezone_name(local_tz),
         "location": default_location or None,
-        "identity_digest": _latest_identity_digest_content(canonical_id) if canonical_id else None,
+        "clock_state": clock_state,
+        "identity_primary": primary_id,
+        "identity_secondary": secondary_id,
     }
     return {key: value for key, value in context.items() if value is not None}
 
@@ -917,6 +932,25 @@ def org_chat_read(employee_dict, limit=20):
         except Exception:
             pass
     return json.dumps({"lines": parsed, "total": len(all_lines)})
+
+
+def work_todo_add(employee_dict, title, content=None):
+    del employee_dict
+    if memory_store is None:
+        return json.dumps({"error": "memory store not available"})
+    agent_id = getattr(active_tool_caller, "name", None)
+    if not agent_id:
+        return json.dumps({"error": "could not determine caller identity"})
+    try:
+        todo_id = memory_store.append_todo(
+            agent_id=agent_id,
+            title=title,
+            content=content,
+            status="open",
+        )
+        return json.dumps({"todo_id": todo_id, "title": title, "status": "open"})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
 
 
 def grant_tool_access(employee_dict, role_name, tool_name, granted_by=None):
@@ -1508,6 +1542,15 @@ def memory_search(employee_dict, agent_name, query, limit=10, cascade=True):
     else:
         results = store.search(query, agent_id=normalized_name, limit=effective_limit)
     result_json = json.dumps([result.__dict__ for result in results], sort_keys=True)
+    if clock_state == "off" and any(
+        getattr(r, "conversation_type", None) == "org_chat" for r in results
+    ):
+        note = (
+            "[System note: work-related content surfaced in these results. "
+            "Consider parking any useful insights via the work.todo tool "
+            "and return focus to the current personal context.]\n"
+        )
+        result_json = note + result_json
     return _condense_if_large(normalized_name, "memory_search", result_json)
 
 
@@ -1772,10 +1815,15 @@ def due_alarm_reminders(role, now=None):
     return reminders
 
 
-BREVITY_GUIDANCE = (
-    "\nCommunication style: default to concise responses — short clarifying questions, "
-    "statements of intent, and brief insights. Reserve longer responses for moments "
-    "where depth is explicitly needed or signaled by the conversation.\n"
+_ON_CLOCK_GUIDANCE = (
+    "\nCommunication style: default to concise work-focused responses — brief status updates, "
+    "statements of intent, targeted questions. Reserve longer responses for technical depth "
+    "when the context warrants it.\n"
+)
+_OFF_CLOCK_GUIDANCE = (
+    "\nCommunication style: you are off the clock. Engage personally and warmly — "
+    "short, natural conversation; curiosity; empathy. If work topics surface unexpectedly, "
+    "note them briefly and park via the work.todo tool rather than engaging at length.\n"
 )
 
 
@@ -1785,7 +1833,8 @@ def interact(self, model, sender, message):
             {"role": "system", "content": self.template},
         ]
     messages = self.conversation_history.get(self.name, [])
-    system_content = self.template + BREVITY_GUIDANCE + format_agent_context(self)
+    guidance = _ON_CLOCK_GUIDANCE if clock_state == "on" else _OFF_CLOCK_GUIDANCE
+    system_content = self.template + guidance + format_agent_context(self)
     if messages and messages[0].get("role") == "system":
         messages[0]["content"] = system_content
     elif self.template:
@@ -2110,6 +2159,7 @@ class Session:
         run_id=None,
         max_turns=None,
         event_stream=None,
+        clock_state=None,
     ):
         self.participants = participants if participants is not None else build_employee_dict()
         self.system = system if system is not None else System(self.participants)
@@ -2123,12 +2173,15 @@ class Session:
         self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
         # Map role.name → participant dict key for FK-safe persistence.
         self._name_to_key = {getattr(p, "name", k): k for k, p in self.participants.items()}
+        _cs = clock_state or globals().get("clock_state", "on")
+        self.clock_state = _cs if _cs in {"on", "off"} else "on"
         self.event_stream.emit(
             "session.created",
             self.run_id,
             {
                 "participants": list(self.participants),
                 "max_turns": self.max_turns,
+                "clock_state": self.clock_state,
             },
         )
         self._org_workspace = _org_workspace
@@ -2438,7 +2491,8 @@ class Session:
             self.recent_system_events() + system_events,
         )
         # Inject org chat context for the model only — not stored in transcript to avoid bloat.
-        org_context = format_org_chat_context(self.transcript, org_chat_context_lines)
+        effective_org_lines = org_chat_context_lines if self.clock_state == "on" else 0
+        org_context = format_org_chat_context(self.transcript, effective_org_lines)
         model_prompt = org_context + raw_prompt if org_context else raw_prompt
         self.prepare_agent_runtime(routed.receiver)
         response = routed.receiver.interact(sender.name, model_prompt)

--- a/main.py
+++ b/main.py
@@ -218,6 +218,7 @@ class ToolRegistry:
                 "builtin_computer_use": builtin_computer_use,
                 "builtin_image_generation": builtin_image_generation,
                 "org_chat_read": org_chat_read,
+                "work_todo_add": work_todo_add,
             },
             local_dict,
         )
@@ -694,6 +695,7 @@ def agent_runtime_context(role=None):
         or getattr(role, "name", None)
     )
     agent_name = getattr(role, "name", None)
+    # runtime_role_name is the participant key (FK-safe); fall back to role.name for headless use.
     canonical_id = getattr(role, "runtime_role_name", None) or agent_name
     primary_id, secondary_id = _get_identity_digests(canonical_id)
     context = {
@@ -938,7 +940,7 @@ def work_todo_add(employee_dict, title, content=None):
     del employee_dict
     if memory_store is None:
         return json.dumps({"error": "memory store not available"})
-    agent_id = getattr(active_tool_caller, "name", None)
+    agent_id = active_tool_caller_name or getattr(active_tool_caller, "name", None)
     if not agent_id:
         return json.dumps({"error": "could not determine caller identity"})
     try:
@@ -1833,7 +1835,8 @@ def interact(self, model, sender, message):
             {"role": "system", "content": self.template},
         ]
     messages = self.conversation_history.get(self.name, [])
-    guidance = _ON_CLOCK_GUIDANCE if clock_state == "on" else _OFF_CLOCK_GUIDANCE
+    effective_clock = getattr(self, "runtime_clock_state", clock_state)
+    guidance = _ON_CLOCK_GUIDANCE if effective_clock == "on" else _OFF_CLOCK_GUIDANCE
     system_content = self.template + guidance + format_agent_context(self)
     if messages and messages[0].get("role") == "system":
         messages[0]["content"] = system_content
@@ -2458,6 +2461,7 @@ class Session:
         role.runtime_event_stream = self.event_stream
         role.runtime_session_id = self.run_id
         role.runtime_tool_results = []
+        role.runtime_clock_state = self.clock_state
         for name, participant in self.participants.items():
             if participant is role:
                 role.runtime_role_name = name

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -798,6 +798,7 @@ class SQLiteMemoryStore:
         metadata=None,
         system_only=False,
         accessibility=None,
+        relationship_type=None,
     ):
         self._validate_digest_type(digest_type)
         seed_id = self.append_memory_entry(
@@ -808,6 +809,7 @@ class SQLiteMemoryStore:
             source=source,
             created_at=created_at,
             metadata=metadata,
+            relationship_type=relationship_type,
         )
         return self.append_memory_digest(
             content,
@@ -823,6 +825,7 @@ class SQLiteMemoryStore:
             source=source,
             created_at=created_at,
             metadata=metadata,
+            relationship_type=relationship_type,
         )
 
     def seed_identity_and_goal_digests(
@@ -834,6 +837,7 @@ class SQLiteMemoryStore:
         session_id=None,
         created_at=None,
         metadata=None,
+        identity_relationship_type=None,
     ):
         if short_term_goal_content is None:
             short_term_goal_content = long_term_goal_content
@@ -845,6 +849,7 @@ class SQLiteMemoryStore:
                 session_id=session_id,
                 created_at=created_at,
                 metadata=metadata,
+                relationship_type=identity_relationship_type,
             ),
             "goal_long_term": self.seed_memory_digest(
                 "goal_long_term",
@@ -1001,6 +1006,7 @@ class SQLiteMemoryStore:
         accessible_only=False,
         include_system_only=True,
         limit=100,
+        relationship_type=None,
     ):
         clauses = []
         params: list[Any] = []
@@ -1008,6 +1014,7 @@ class SQLiteMemoryStore:
             ("agent_id", agent_id),
             ("session_id", session_id),
             ("digest_type", digest_type),
+            ("relationship_type", relationship_type),
         ):
             if value is not None:
                 clauses.append(f"{column} = ?")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2856,5 +2856,214 @@ class OrgChatReadToolTests(unittest.TestCase):
             self.assertEqual(result["total"], 5)
 
 
+class ClockStateTests(unittest.TestCase):
+    """Tests for on/off-the-clock mode affecting prompts, org context, and identity."""
+
+    def setUp(self):
+        self.original_clock = main.clock_state
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.clock_state = self.original_clock
+
+    def test_on_clock_guidance_used_when_on(self):
+        main.clock_state = "on"
+        self.assertIn("work-focused", main._ON_CLOCK_GUIDANCE)
+
+    def test_off_clock_guidance_used_when_off(self):
+        main.clock_state = "off"
+        self.assertIn("off the clock", main._OFF_CLOCK_GUIDANCE)
+
+    def test_session_stores_clock_state(self):
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        session = main.Session(participants={"A": a}, clock_state="off")
+        self.assertEqual(session.clock_state, "off")
+
+    def test_session_clock_state_in_event(self):
+        events = []
+        stream = main.RuntimeEventStream()
+        stream.subscribe(lambda e: events.append(e))
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        main.Session(participants={"A": a}, event_stream=stream, clock_state="off")
+        created = next(e for e in events if e.event_type == "session.created")
+        self.assertEqual(created.payload["clock_state"], "off")
+
+    def test_off_clock_suppresses_org_chat_injection(self):
+        received_prompts = []
+
+        class CapturingRole:
+            name = "B"
+            lifecycle_state = "active"
+            conversation_history = {}
+            template = ""
+            max_tokens = 100
+            temperature = 0.0
+            runtime_tool_results = []
+            runtime_event_stream = None
+            runtime_session_id = None
+            runtime_role_name = None
+            allowed_tools = set()
+
+            def interact(self, sender=None, prompt=None):
+                received_prompts.append(prompt or "")
+                return "response"
+
+            def update_group_conversations(self, m):
+                pass
+
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "initial",
+                            update_group_conversations=lambda m: None)
+        b = CapturingRole()
+        old_lines = main.org_chat_context_lines
+        main.org_chat_context_lines = 5
+        try:
+            session = main.Session(participants={"A": a, "B": b}, clock_state="off")
+            session.transcript.append(main.TranscriptEntry(1, "A", "B", "seed", "response"))
+            session.turns_completed = 1
+            session.last_receiver = a
+            session.step("hello")
+        finally:
+            main.org_chat_context_lines = old_lines
+
+        self.assertFalse(any("Recent org chat" in p for p in received_prompts))
+
+    def test_identity_primary_secondary_swapped_by_clock(self):
+        store_temp = tempfile.TemporaryDirectory()
+        store = SQLiteMemoryStore(Path(store_temp.name) / "id.sqlite3")
+        store.upsert_agent("alice", "Role", "Alice")
+        store.seed_memory_digest("identity", "personal identity content",
+                                  agent_id="alice", relationship_type="personal")
+        store.seed_memory_digest("identity", "work identity content",
+                                  agent_id="alice", relationship_type="work")
+        old_store = main.memory_store
+        main.memory_store = store
+        try:
+            main.clock_state = "on"
+            primary_on, secondary_on = main._get_identity_digests("alice")
+            main.clock_state = "off"
+            primary_off, secondary_off = main._get_identity_digests("alice")
+        finally:
+            main.memory_store = old_store
+            main.clock_state = self.original_clock
+            store.close()
+            store_temp.cleanup()
+
+        self.assertIn("work", primary_on)
+        self.assertIn("personal", secondary_on)
+        self.assertIn("personal", primary_off)
+        self.assertIn("work", secondary_off)
+
+
+class MemorySearchParkingTests(unittest.TestCase):
+    """Tests for off-clock parking reminder when org_chat results surface."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "p.sqlite3")
+        self.addCleanup(self.store.close)
+        self.original_store = main.memory_store
+        self.original_clock = main.clock_state
+        main.memory_store = self.store
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.memory_store = self.original_store
+        main.clock_state = self.original_clock
+
+    def _seed_org_message(self, agent_id="bob"):
+        self.store.upsert_agent(agent_id, "Role", agent_id)
+        self.store.create_session("s1")
+        self.store.append_message("s1", agent_id, agent_id, "project deadline is Friday",
+                                   conversation_type="org_chat")
+
+    def test_off_clock_org_result_prepends_parking_note(self):
+        self._seed_org_message()
+        main.clock_state = "off"
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="bob", allowed_tools={"memory.*"})
+        try:
+            result = main.memory_search({}, "bob", "project deadline")
+        finally:
+            main.active_tool_caller = old_caller
+        self.assertIn("work.todo", result)
+        self.assertIn("System note", result)
+
+    def test_on_clock_no_parking_note(self):
+        self._seed_org_message()
+        main.clock_state = "on"
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="bob", allowed_tools={"memory.*"})
+        try:
+            result = main.memory_search({}, "bob", "project deadline")
+        finally:
+            main.active_tool_caller = old_caller
+        self.assertNotIn("System note", result)
+
+    def test_off_clock_personal_result_no_parking_note(self):
+        self.store.upsert_agent("carol", "Role", "carol")
+        self.store.create_session("s2")
+        self.store.append_message("s2", "carol", "carol", "family picnic plans",
+                                   conversation_type="personal")
+        main.clock_state = "off"
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="carol", allowed_tools={"memory.*"})
+        try:
+            result = main.memory_search({}, "carol", "picnic")
+        finally:
+            main.active_tool_caller = old_caller
+        self.assertNotIn("System note", result)
+
+
+class WorkTodoToolTests(unittest.TestCase):
+    """Tests for work_todo_add function."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "t.sqlite3")
+        self.addCleanup(self.store.close)
+        self.original_store = main.memory_store
+        self.original_caller = main.active_tool_caller
+        main.memory_store = self.store
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.memory_store = self.original_store
+        main.active_tool_caller = self.original_caller
+
+    def test_creates_todo_record(self):
+        self.store.upsert_agent("dave", "Role", "dave")
+        main.active_tool_caller = SimpleNamespace(name="dave")
+        result = json.loads(main.work_todo_add({}, title="Follow up on Q3 budget"))
+        self.assertEqual(result["title"], "Follow up on Q3 budget")
+        self.assertEqual(result["status"], "open")
+        rows = self.store.list_todos(agent_id="dave")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["title"], "Follow up on Q3 budget")
+
+    def test_no_memory_store_returns_error(self):
+        main.memory_store = None
+        result = json.loads(main.work_todo_add({}, title="something"))
+        self.assertIn("error", result)
+
+    def test_no_caller_returns_error(self):
+        main.active_tool_caller = SimpleNamespace()  # no .name
+        result = json.loads(main.work_todo_add({}, title="something"))
+        self.assertIn("error", result)
+
+    def test_content_stored(self):
+        self.store.upsert_agent("eve", "Role", "eve")
+        main.active_tool_caller = SimpleNamespace(name="eve")
+        main.work_todo_add({}, title="Research topic", content="detailed notes here")
+        rows = self.store.list_todos(agent_id="eve")
+        self.assertEqual(rows[0]["content"], "detailed notes here")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2713,6 +2713,121 @@ class OrgDigestTests(unittest.TestCase):
         self.assertEqual(len(org_digests), 0)
 
 
+class OrgChatReadToolFixTests(unittest.TestCase):
+    """Tests for org_chat_read sandbox inclusion and kwargs fix."""
+
+    def test_org_chat_read_in_tool_exec_globals(self):
+        """org_chat_read must be reachable from compiled tool code (not raise NameError)."""
+        # Compile a tiny tool that calls org_chat_read and verify it doesn't NameError.
+        func = main.tool_registry.compile_tool(
+            "_test_org_read", ["limit"], [], "return org_chat_read(employee_dict, limit=1)"
+        )
+        old = main._org_workspace
+        main._org_workspace = None
+        try:
+            result = json.loads(func(employee_dict={}))
+        finally:
+            main._org_workspace = old
+        self.assertIn("note", result)
+
+    def test_org_chat_read_limit_zero_safe(self):
+        result = json.loads(main.org_chat_read({}, limit=0))
+        self.assertEqual(result["lines"], [])
+
+    def test_org_chat_read_negative_limit_safe(self):
+        result = json.loads(main.org_chat_read({}, limit=-5))
+        self.assertEqual(result["lines"], [])
+
+    def test_org_context_not_stored_in_transcript(self):
+        """Org chat context should be injected for the model but not persisted in transcript."""
+        received_model_prompts = []
+
+        class CapturingRole:
+            name = "B"
+            lifecycle_state = "active"
+            conversation_history = {}
+            template = ""
+            max_tokens = 100
+            temperature = 0.0
+            runtime_tool_results = []
+            runtime_event_stream = None
+            runtime_session_id = None
+            runtime_role_name = None
+            runtime_clock_state = "on"
+            allowed_tools = set()
+
+            def interact(self, sender=None, prompt=None):
+                received_model_prompts.append(prompt or "")
+                return "answer"
+
+            def update_group_conversations(self, m):
+                pass
+
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "initial",
+                            update_group_conversations=lambda m: None)
+        b = CapturingRole()
+        old_lines = main.org_chat_context_lines
+        main.org_chat_context_lines = 5
+        try:
+            session = main.Session(participants={"A": a, "B": b}, clock_state="on")
+            session.transcript.append(main.TranscriptEntry(1, "A", "B", "raw seed", "seed resp"))
+            session.turns_completed = 1
+            session.last_receiver = a
+            session.step("next message")
+        finally:
+            main.org_chat_context_lines = old_lines
+
+        # Model prompt should contain org context
+        self.assertTrue(any("Recent org chat" in p for p in received_model_prompts))
+        # But stored transcript prompt should NOT contain org context
+        last_entry = session.transcript[-1]
+        self.assertNotIn("Recent org chat", last_entry.prompt)
+
+    def test_prepare_agent_runtime_sets_clock_state(self):
+        """prepare_agent_runtime must stamp runtime_clock_state so interact() can read it."""
+        role = SimpleNamespace(name="B", lifecycle_state="active",
+                               interact=lambda *a, **kw: "hi",
+                               update_group_conversations=lambda m: None)
+        session = main.Session(participants={"A": SimpleNamespace(
+            name="A", lifecycle_state="active",
+            interact=lambda *a, **kw: "hi",
+            update_group_conversations=lambda m: None,
+        ), "B": role}, clock_state="off")
+        session.prepare_agent_runtime(role)
+        self.assertEqual(getattr(role, "runtime_clock_state", None), "off")
+
+    def test_interact_uses_runtime_clock_state_for_guidance(self):
+        """main.interact() picks guidance from role.runtime_clock_state, not module global."""
+        captured = []
+
+        def fake_generate(role, model, sender, messages):
+            # Capture the system message content
+            if messages and messages[0].get("role") == "system":
+                captured.append(messages[0]["content"])
+            return "ok"
+
+        role = SimpleNamespace(
+            name="TestBot",
+            template="You are helpful.",
+            conversation_history={},
+            max_tokens=100,
+            temperature=0.0,
+            employee_dict={},
+            runtime_clock_state="off",
+            runtime_session_id=None,
+            runtime_role_name=None,
+            runtime_event_stream=None,
+        )
+        old_provider = main.model_provider
+        main.model_provider = SimpleNamespace(generate=fake_generate)
+        try:
+            main.interact(role, "gpt-4o-mini", "user", "hello")
+        finally:
+            main.model_provider = old_provider
+        self.assertTrue(any("off the clock" in c for c in captured))
+
+
 class ReasoningEffortTests(unittest.TestCase):
     """Tests that ResponsesProvider forwards reasoning_effort when set."""
 

--- a/tools.yaml
+++ b/tools.yaml
@@ -279,6 +279,27 @@
     required: []
   code: |
     return org_chat_read(employee_dict, limit=min(int(limit if limit is not None else 20), 100))
+- name: work.todo
+  required_capabilities: []
+  owner_capability: basic
+  system_tool: false
+  grantable: true
+  description: >
+    Park a work insight or task as a todo item to revisit later.
+    Use this when a work topic surfaces unexpectedly during off-the-clock interactions.
+  parameters:
+    type: object
+    properties:
+      title:
+        type: string
+        description: Short description of the work item to park.
+      content:
+        type: string
+        description: Optional extended notes or context.
+    required:
+      - title
+  code: |
+    return work_todo_add(employee_dict, title=title, content=content)
 - name: agent.create_alarm
   required_capabilities: []
   owner_capability: agent


### PR DESCRIPTION
Closes #62

## Summary

- **`ROBITS_CLOCK_STATE=on|off`**: module-level and session-level clock state; `Session` accepts `clock_state` param
- **Clock-aware guidance**: `_ON_CLOCK_GUIDANCE` (concise, work-focused) and `_OFF_CLOCK_GUIDANCE` (personal, warm, mentions `work.todo`) replace the generic `BREVITY_GUIDANCE`; chosen at `interact()` time
- **Identity weighting**: `_get_identity_digests()` returns `(primary, secondary)` ordered by clock — on-clock: work leads; off-clock: personal leads; both exposed in `agent_runtime_context` as `identity_primary` / `identity_secondary`
- **Org chat suppression**: off-clock sessions skip org chat context injection in `Session.step`
- **Work context parking reminder**: `memory_search` prepends a system note when off-clock and any result has `conversation_type="org_chat"` — directs agent to `work.todo`
- **`work.todo` tool**: grantable tool backed by new `work_todo_add()` → `memory_store.append_todo()`
- **SQLite**: `list_memory_digests` gains `relationship_type` filter; `seed_memory_digest` and `seed_identity_and_goal_digests` gain `relationship_type` / `identity_relationship_type` params for tagging personal vs work identity at seed time

## Test plan

- [x] All 193 tests pass
- [x] `ClockStateTests` — guidance string selection, session stores state, event payload, org chat suppression off-clock, identity primary/secondary swap
- [x] `MemorySearchParkingTests` — off-clock org result gets note; on-clock no note; off-clock personal result no note
- [x] `WorkTodoToolTests` — creates record, no-store error, no-caller error, content stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)