### PR TITLE
Add async SQLite memory store adapter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openai
 PyYaml
 termcolor
+aiosqlite

--- a/robits/memory/__init__.py
+++ b/robits/memory/__init__.py
@@ -1,5 +1,11 @@
 """SQLite-backed memory storage for Robits."""
 
+from .async_sqlite import AsyncSQLiteMemoryStore
 from .sqlite import MemoryDigestSource, MemorySearchResult, SQLiteMemoryStore
 
-__all__ = ["MemoryDigestSource", "MemorySearchResult", "SQLiteMemoryStore"]
+__all__ = [
+    "AsyncSQLiteMemoryStore",
+    "MemoryDigestSource",
+    "MemorySearchResult",
+    "SQLiteMemoryStore",
+]

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -32,7 +32,7 @@ class AsyncSQLiteMemoryStore:
     def __init__(self, path, connection):
         self.path = Path(path)
         self.connection = connection
-        self._write_lock = asyncio.Lock()
+        self._db_lock = asyncio.Lock()
 
     @classmethod
     async def open(cls, path, *, busy_timeout_ms=5000, wal=True):
@@ -67,11 +67,13 @@ class AsyncSQLiteMemoryStore:
         await self.close()
 
     async def _rows(self, statement, params=()):
-        cursor = await self.connection.execute(statement, params)
-        try:
-            return await cursor.fetchall()
-        finally:
-            await cursor.close()
+        async with self._db_lock:
+            cursor = await self.connection.execute(statement, params)
+            try:
+                rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+            finally:
+                await cursor.close()
 
     async def _index(
         self,
@@ -110,7 +112,7 @@ class AsyncSQLiteMemoryStore:
 
     async def create_session(self, session_id, title=None, started_at=None, metadata=None):
         timestamp = started_at or _utc_now()
-        async with self._write_lock:
+        async with self._db_lock:
             await self.connection.execute(
                 """
                 INSERT OR IGNORE INTO sessions(session_id, title, started_at, metadata_json)
@@ -131,7 +133,7 @@ class AsyncSQLiteMemoryStore:
         metadata=None,
     ):
         timestamp = created_at or _utc_now()
-        async with self._write_lock:
+        async with self._db_lock:
             await self.connection.execute(
                 """
                 INSERT INTO agents(
@@ -171,7 +173,7 @@ class AsyncSQLiteMemoryStore:
         metadata=None,
     ):
         timestamp = created_at or _utc_now()
-        async with self._write_lock:
+        async with self._db_lock:
             cursor = await self.connection.execute(
                 """
                 INSERT INTO messages(
@@ -225,7 +227,7 @@ class AsyncSQLiteMemoryStore:
         metadata=None,
     ):
         timestamp = created_at or _utc_now()
-        async with self._write_lock:
+        async with self._db_lock:
             cursor = await self.connection.execute(
                 """
                 INSERT INTO thoughts(
@@ -273,7 +275,7 @@ class AsyncSQLiteMemoryStore:
         created_at=None,
     ):
         timestamp = created_at or _utc_now()
-        async with self._write_lock:
+        async with self._db_lock:
             cursor = await self.connection.execute(
                 """
                 INSERT INTO runtime_events(

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -23,10 +23,10 @@ def _json_dumps(value):
 class AsyncSQLiteMemoryStore:
     """Async SQLite access layer for concurrent Robits runtimes and observers.
 
-    This class intentionally starts as a small async boundary around the hot
-    event/message paths that the runtime and TUI need first. The synchronous
-    ``SQLiteMemoryStore`` remains the canonical schema owner while this async
-    layer grows method coverage.
+    The synchronous ``SQLiteMemoryStore`` remains the schema owner, and this
+    class mirrors its repository API for async callers. Hot-path methods are
+    implemented natively with ``aiosqlite`` while remaining methods delegate to
+    the synchronous store through ``asyncio.to_thread``.
     """
 
     def __init__(self, path, connection):
@@ -74,6 +74,16 @@ class AsyncSQLiteMemoryStore:
                 return [dict(row) for row in rows]
             finally:
                 await cursor.close()
+
+    async def _run_sync(self, method_name, *args, **kwargs):
+        def runner():
+            store = SQLiteMemoryStore(self.path)
+            try:
+                return getattr(store, method_name)(*args, **kwargs)
+            finally:
+                store.close()
+
+        return await asyncio.to_thread(runner)
 
     async def _index(
         self,
@@ -386,4 +396,330 @@ class AsyncSQLiteMemoryStore:
             LIMIT ?
             """,
             params + [limit],
+        )
+
+    async def ensure_schema(self):
+        return await self._run_sync("ensure_schema")
+
+    async def list_recent_message_ids(self, session_id, limit):
+        return await self._run_sync("list_recent_message_ids", session_id, limit)
+
+    async def list_recent_message_ids_by_type(self, session_id, limit, conversation_type):
+        return await self._run_sync(
+            "list_recent_message_ids_by_type",
+            session_id,
+            limit,
+            conversation_type,
+        )
+
+    async def end_session(self, session_id, ended_at=None):
+        return await self._run_sync("end_session", session_id, ended_at=ended_at)
+
+    async def add_contact(
+        self,
+        owner_agent_id,
+        contact_agent_id,
+        relationship_type,
+        notes=None,
+        created_at=None,
+        metadata=None,
+    ):
+        return await self._run_sync(
+            "add_contact",
+            owner_agent_id,
+            contact_agent_id,
+            relationship_type,
+            notes=notes,
+            created_at=created_at,
+            metadata=metadata,
+        )
+
+    async def append_todo(
+        self,
+        agent_id,
+        title,
+        session_id=None,
+        status="open",
+        content=None,
+        due_at=None,
+        created_at=None,
+        metadata=None,
+    ):
+        return await self._run_sync(
+            "append_todo",
+            agent_id,
+            title,
+            session_id=session_id,
+            status=status,
+            content=content,
+            due_at=due_at,
+            created_at=created_at,
+            metadata=metadata,
+        )
+
+    async def append_tool_call(
+        self,
+        tool_call_id,
+        agent_id,
+        tool_name,
+        arguments=None,
+        result_content=None,
+        status="requested",
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        return await self._run_sync(
+            "append_tool_call",
+            tool_call_id,
+            agent_id,
+            tool_name,
+            arguments=arguments,
+            result_content=result_content,
+            status=status,
+            session_id=session_id,
+            relationship_type=relationship_type,
+            conversation_type=conversation_type,
+            source=source,
+            created_at=created_at,
+            metadata=metadata,
+        )
+
+    async def list_todos(self, agent_id=None, session_id=None, status=None, limit=100):
+        return await self._run_sync(
+            "list_todos",
+            agent_id=agent_id,
+            session_id=session_id,
+            status=status,
+            limit=limit,
+        )
+
+    async def append_memory_entry(
+        self,
+        kind,
+        content,
+        agent_id=None,
+        session_id=None,
+        source_table=None,
+        source_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        return await self._run_sync(
+            "append_memory_entry",
+            kind,
+            content,
+            agent_id=agent_id,
+            session_id=session_id,
+            source_table=source_table,
+            source_id=source_id,
+            relationship_type=relationship_type,
+            conversation_type=conversation_type,
+            source=source,
+            created_at=created_at,
+            metadata=metadata,
+        )
+
+    async def append_memory_digest(
+        self,
+        content,
+        source_refs,
+        agent_id=None,
+        session_id=None,
+        digest_type="episodic",
+        generation=None,
+        version=1,
+        supersedes_digest_ids=None,
+        system_only=False,
+        accessibility=None,
+        prompt_version="memory-digest-v1",
+        source_start_at=None,
+        source_end_at=None,
+        relationship_type=None,
+        conversation_type=None,
+        source="digest",
+        created_at=None,
+        metadata=None,
+    ):
+        return await self._run_sync(
+            "append_memory_digest",
+            content,
+            source_refs,
+            agent_id=agent_id,
+            session_id=session_id,
+            digest_type=digest_type,
+            generation=generation,
+            version=version,
+            supersedes_digest_ids=supersedes_digest_ids,
+            system_only=system_only,
+            accessibility=accessibility,
+            prompt_version=prompt_version,
+            source_start_at=source_start_at,
+            source_end_at=source_end_at,
+            relationship_type=relationship_type,
+            conversation_type=conversation_type,
+            source=source,
+            created_at=created_at,
+            metadata=metadata,
+        )
+
+    async def seed_memory_digest(
+        self,
+        digest_type,
+        content,
+        agent_id=None,
+        session_id=None,
+        prompt_version="memory-digest-seed-v1",
+        source="system_seed",
+        created_at=None,
+        metadata=None,
+        system_only=False,
+        accessibility=None,
+        relationship_type=None,
+    ):
+        return await self._run_sync(
+            "seed_memory_digest",
+            digest_type,
+            content,
+            agent_id=agent_id,
+            session_id=session_id,
+            prompt_version=prompt_version,
+            source=source,
+            created_at=created_at,
+            metadata=metadata,
+            system_only=system_only,
+            accessibility=accessibility,
+            relationship_type=relationship_type,
+        )
+
+    async def seed_identity_and_goal_digests(
+        self,
+        agent_id,
+        identity_content,
+        long_term_goal_content,
+        short_term_goal_content=None,
+        session_id=None,
+        created_at=None,
+        metadata=None,
+        identity_relationship_type=None,
+    ):
+        return await self._run_sync(
+            "seed_identity_and_goal_digests",
+            agent_id,
+            identity_content,
+            long_term_goal_content,
+            short_term_goal_content=short_term_goal_content,
+            session_id=session_id,
+            created_at=created_at,
+            metadata=metadata,
+            identity_relationship_type=identity_relationship_type,
+        )
+
+    async def append_runtime_event_object(self, event):
+        return await self._run_sync("append_runtime_event_object", event)
+
+    async def get_memory_digest(self, digest_id):
+        return await self._run_sync("get_memory_digest", digest_id)
+
+    async def get_memory_digest_sources(self, digest_id):
+        return await self._run_sync("get_memory_digest_sources", digest_id)
+
+    async def expand_memory_digest_sources(
+        self,
+        digest_id,
+        recursive=False,
+        include_digest_records=True,
+        max_depth=None,
+    ):
+        return await self._run_sync(
+            "expand_memory_digest_sources",
+            digest_id,
+            recursive=recursive,
+            include_digest_records=include_digest_records,
+            max_depth=max_depth,
+        )
+
+    async def expand_memory_digest_source_tree(self, digest_id):
+        return await self._run_sync("expand_memory_digest_source_tree", digest_id)
+
+    async def list_memory_digests(
+        self,
+        agent_id=None,
+        session_id=None,
+        digest_type=None,
+        current_only=False,
+        accessible_only=False,
+        include_system_only=True,
+        limit=100,
+        relationship_type=None,
+    ):
+        return await self._run_sync(
+            "list_memory_digests",
+            agent_id=agent_id,
+            session_id=session_id,
+            digest_type=digest_type,
+            current_only=current_only,
+            accessible_only=accessible_only,
+            include_system_only=include_system_only,
+            limit=limit,
+            relationship_type=relationship_type,
+        )
+
+    async def list_agent_records(self, agent_id, limit=100):
+        return await self._run_sync("list_agent_records", agent_id, limit=limit)
+
+    async def search(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ):
+        return await self._run_sync(
+            "search",
+            query,
+            agent_id=agent_id,
+            session_id=session_id,
+            relationship_type=relationship_type,
+            conversation_type=conversation_type,
+            source=source,
+            start_at=start_at,
+            end_at=end_at,
+            limit=limit,
+        )
+
+    async def search_cascade(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ):
+        return await self._run_sync(
+            "search_cascade",
+            query,
+            agent_id=agent_id,
+            session_id=session_id,
+            relationship_type=relationship_type,
+            conversation_type=conversation_type,
+            source=source,
+            start_at=start_at,
+            end_at=end_at,
+            limit=limit,
         )

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import aiosqlite
+
+from .sqlite import SQLiteMemoryStore
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _json_dumps(value):
+    return json.dumps({} if value is None else value, sort_keys=True)
+
+
+class AsyncSQLiteMemoryStore:
+    """Async SQLite access layer for concurrent Robits runtimes and observers.
+
+    This class intentionally starts as a small async boundary around the hot
+    event/message paths that the runtime and TUI need first. The synchronous
+    ``SQLiteMemoryStore`` remains the canonical schema owner while this async
+    layer grows method coverage.
+    """
+
+    def __init__(self, path, connection):
+        self.path = Path(path)
+        self.connection = connection
+        self._write_lock = asyncio.Lock()
+
+    @classmethod
+    async def open(cls, path, *, busy_timeout_ms=5000, wal=True):
+        db_path = Path(path)
+        if db_path == Path(":memory:"):
+            raise ValueError(
+                "AsyncSQLiteMemoryStore requires a file-backed SQLite database; "
+                "':memory:' would create separate databases per connection."
+            )
+
+        # Keep schema creation and migration centralized in the synchronous store
+        # until this async layer fully owns schema management.
+        bootstrap = SQLiteMemoryStore(db_path)
+        bootstrap.close()
+
+        connection = await aiosqlite.connect(str(db_path))
+        connection.row_factory = sqlite3.Row
+        await connection.execute("PRAGMA foreign_keys = ON")
+        await connection.execute(f"PRAGMA busy_timeout = {int(busy_timeout_ms)}")
+        if wal:
+            await connection.execute("PRAGMA journal_mode = WAL")
+        await connection.commit()
+        return cls(db_path, connection)
+
+    async def close(self):
+        await self.connection.close()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_):
+        await self.close()
+
+    async def _rows(self, statement, params=()):
+        cursor = await self.connection.execute(statement, params)
+        try:
+            return await cursor.fetchall()
+        finally:
+            await cursor.close()
+
+    async def _index(
+        self,
+        kind,
+        record_id,
+        agent_id,
+        related_agent_id,
+        session_id,
+        source,
+        relationship_type,
+        conversation_type,
+        created_at,
+        content,
+    ):
+        await self.connection.execute(
+            """
+            INSERT INTO memory_fts(
+                kind, record_id, agent_id, related_agent_id, session_id,
+                source, relationship_type, conversation_type, created_at, content
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                kind,
+                str(record_id),
+                agent_id,
+                related_agent_id,
+                session_id,
+                source,
+                relationship_type,
+                conversation_type,
+                created_at,
+                content,
+            ),
+        )
+
+    async def create_session(self, session_id, title=None, started_at=None, metadata=None):
+        timestamp = started_at or _utc_now()
+        async with self._write_lock:
+            await self.connection.execute(
+                """
+                INSERT OR IGNORE INTO sessions(session_id, title, started_at, metadata_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (session_id, title, timestamp, _json_dumps(metadata)),
+            )
+            await self.connection.commit()
+        return session_id
+
+    async def upsert_agent(
+        self,
+        agent_id,
+        role,
+        display_name=None,
+        lifecycle_state="active",
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        async with self._write_lock:
+            await self.connection.execute(
+                """
+                INSERT INTO agents(
+                    agent_id, role, display_name, lifecycle_state, created_at, metadata_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(agent_id) DO UPDATE SET
+                    role = excluded.role,
+                    display_name = excluded.display_name,
+                    lifecycle_state = excluded.lifecycle_state,
+                    metadata_json = excluded.metadata_json
+                """,
+                (
+                    agent_id,
+                    role,
+                    display_name,
+                    lifecycle_state,
+                    timestamp,
+                    _json_dumps(metadata),
+                ),
+            )
+            await self.connection.commit()
+        return agent_id
+
+    async def append_message(
+        self,
+        session_id,
+        sender_agent_id,
+        receiver_agent_id,
+        content,
+        kind="message",
+        visibility="public",
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        async with self._write_lock:
+            cursor = await self.connection.execute(
+                """
+                INSERT INTO messages(
+                    session_id, sender_agent_id, receiver_agent_id, content, kind,
+                    visibility, relationship_type, conversation_type, source,
+                    created_at, metadata_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    sender_agent_id,
+                    receiver_agent_id,
+                    content,
+                    kind,
+                    visibility,
+                    relationship_type,
+                    conversation_type,
+                    source,
+                    timestamp,
+                    _json_dumps(metadata),
+                ),
+            )
+            record_id = cursor.lastrowid
+            await cursor.close()
+            await self._index(
+                "message",
+                record_id,
+                sender_agent_id,
+                receiver_agent_id,
+                session_id,
+                source,
+                relationship_type,
+                conversation_type,
+                timestamp,
+                content,
+            )
+            await self.connection.commit()
+        return record_id
+
+    async def append_thought(
+        self,
+        agent_id,
+        content,
+        session_id=None,
+        visibility="private",
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ):
+        timestamp = created_at or _utc_now()
+        async with self._write_lock:
+            cursor = await self.connection.execute(
+                """
+                INSERT INTO thoughts(
+                    session_id, agent_id, content, visibility, relationship_type,
+                    conversation_type, source, created_at, metadata_json
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    agent_id,
+                    content,
+                    visibility,
+                    relationship_type,
+                    conversation_type,
+                    source,
+                    timestamp,
+                    _json_dumps(metadata),
+                ),
+            )
+            record_id = cursor.lastrowid
+            await cursor.close()
+            await self._index(
+                "thought",
+                record_id,
+                agent_id,
+                None,
+                session_id,
+                source,
+                relationship_type,
+                conversation_type,
+                timestamp,
+                content,
+            )
+            await self.connection.commit()
+        return record_id
+
+    async def append_runtime_event(
+        self,
+        session_id,
+        event_type,
+        payload=None,
+        visibility="public",
+        sequence=None,
+        created_at=None,
+    ):
+        timestamp = created_at or _utc_now()
+        async with self._write_lock:
+            cursor = await self.connection.execute(
+                """
+                INSERT INTO runtime_events(
+                    session_id, sequence, event_type, visibility, payload_json, created_at
+                )
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    sequence,
+                    event_type,
+                    visibility,
+                    _json_dumps(payload),
+                    timestamp,
+                ),
+            )
+            record_id = cursor.lastrowid
+            await cursor.close()
+            await self.connection.commit()
+        return record_id
+
+    async def list_messages(
+        self,
+        session_id=None,
+        agent_id=None,
+        conversation_type=None,
+        visibility=None,
+        limit=100,
+    ):
+        clauses = []
+        params: list[Any] = []
+        if session_id is not None:
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if agent_id is not None:
+            clauses.append("(sender_agent_id = ? OR receiver_agent_id = ?)")
+            params.extend([agent_id, agent_id])
+        if conversation_type is not None:
+            clauses.append("conversation_type = ?")
+            params.append(conversation_type)
+        if visibility is not None:
+            clauses.append("visibility = ?")
+            params.append(visibility)
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return await self._rows(
+            f"""
+            SELECT * FROM messages
+            {where}
+            ORDER BY created_at, message_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )
+
+    async def list_thoughts(
+        self,
+        session_id=None,
+        agent_id=None,
+        conversation_type=None,
+        visibility=None,
+        limit=100,
+    ):
+        clauses = []
+        params: list[Any] = []
+        for column, value in (
+            ("session_id", session_id),
+            ("agent_id", agent_id),
+            ("conversation_type", conversation_type),
+            ("visibility", visibility),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return await self._rows(
+            f"""
+            SELECT * FROM thoughts
+            {where}
+            ORDER BY created_at, thought_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )
+
+    async def list_runtime_events(
+        self,
+        session_id=None,
+        event_type=None,
+        visibility=None,
+        limit=100,
+    ):
+        clauses = []
+        params: list[Any] = []
+        for column, value in (
+            ("session_id", session_id),
+            ("event_type", event_type),
+            ("visibility", visibility),
+        ):
+            if value is not None:
+                clauses.append(f"{column} = ?")
+                params.append(value)
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        return await self._rows(
+            f"""
+            SELECT * FROM runtime_events
+            {where}
+            ORDER BY COALESCE(sequence, event_id), event_id
+            LIMIT ?
+            """,
+            params + [limit],
+        )

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -94,7 +94,9 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(len(events), 10)
         self.assertEqual([event["sequence"] for event in events], list(range(10)))
-        self.assertGreaterEqual(max(observed_counts), 0)
+        # Reads see committed state only: counts must be non-decreasing
+        self.assertEqual(observed_counts, sorted(observed_counts))
+        self.assertLessEqual(max(observed_counts), 10)
 
     async def test_async_and_sync_stores_can_share_file_backed_database(self):
         store = await self.seed_store()

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import tempfile
 import unittest
 from pathlib import Path
@@ -139,6 +140,34 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIn("message", kinds)
         self.assertIn("thought", kinds)
+
+    async def test_async_store_exposes_sync_store_public_api_methods(self):
+        sync_public = {
+            name
+            for name, member in inspect.getmembers(SQLiteMemoryStore, inspect.isfunction)
+            if not name.startswith("_")
+        }
+        async_public = {
+            name
+            for name, member in inspect.getmembers(AsyncSQLiteMemoryStore, inspect.iscoroutinefunction)
+            if not name.startswith("_")
+        }
+        self.assertTrue(sync_public.issubset(async_public))
+
+    async def test_sync_parity_methods_delegate_through_async_store(self):
+        store = await self.seed_store()
+        await store.add_contact("SE", "HR", "coworker")
+
+        todo_id = await store.append_todo(
+            "SE",
+            "Capture drop-in parity tasks.",
+            session_id="session-1",
+        )
+
+        todos = await store.list_todos(agent_id="SE", session_id="session-1")
+        self.assertEqual(len(todos), 1)
+        self.assertEqual(todos[0]["todo_id"], todo_id)
+        self.assertEqual(todos[0]["title"], "Capture drop-in parity tasks.")
 
 
 if __name__ == "__main__":

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -1,0 +1,143 @@
+import asyncio
+import tempfile
+import unittest
+from pathlib import Path
+
+from robits.memory import AsyncSQLiteMemoryStore, SQLiteMemoryStore
+
+
+class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
+    async def build_store(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = await AsyncSQLiteMemoryStore.open(Path(temp_dir.name) / "memory.sqlite3")
+        self.addAsyncCleanup(store.close)
+        return store
+
+    async def seed_store(self):
+        store = await self.build_store()
+        await store.create_session("session-1", title="Planning")
+        await store.upsert_agent("CEO", "Human", "CEO")
+        await store.upsert_agent("SE", "SoftwareEngineer", "SE")
+        await store.upsert_agent("HR", "HR", "HR")
+        return store
+
+    async def test_async_store_bootstraps_schema_and_writes_messages(self):
+        store = await self.seed_store()
+
+        message_id = await store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Please design async storage.",
+            relationship_type="coworker",
+            conversation_type="org_chat",
+            source="chat",
+        )
+
+        messages = await store.list_messages(session_id="session-1", agent_id="SE")
+
+        self.assertEqual(messages[0]["message_id"], message_id)
+        self.assertEqual(messages[0]["content"], "Please design async storage.")
+        self.assertEqual(messages[0]["conversation_type"], "org_chat")
+
+    async def test_concurrent_async_appends_are_serialized_and_visible(self):
+        store = await self.seed_store()
+
+        async def append(index):
+            return await store.append_message(
+                "session-1",
+                "CEO" if index % 2 == 0 else "HR",
+                "SE",
+                f"Concurrent message {index}.",
+                conversation_type="org_chat",
+                source="test",
+            )
+
+        ids = await asyncio.gather(*(append(index) for index in range(20)))
+        messages = await store.list_messages(
+            session_id="session-1",
+            conversation_type="org_chat",
+            limit=25,
+        )
+
+        self.assertEqual(len(ids), 20)
+        self.assertEqual(len(set(ids)), 20)
+        self.assertEqual(len(messages), 20)
+        self.assertEqual(
+            {message["content"] for message in messages},
+            {f"Concurrent message {index}." for index in range(20)},
+        )
+
+    async def test_runtime_events_can_be_read_while_writes_continue(self):
+        store = await self.seed_store()
+
+        async def append_events():
+            for index in range(10):
+                await store.append_runtime_event(
+                    "session-1",
+                    "message.created",
+                    payload={"index": index},
+                    sequence=index,
+                )
+
+        async def read_events():
+            observed_counts = []
+            for _ in range(5):
+                rows = await store.list_runtime_events(session_id="session-1")
+                observed_counts.append(len(rows))
+                await asyncio.sleep(0)
+            return observed_counts
+
+        _, observed_counts = await asyncio.gather(append_events(), read_events())
+        events = await store.list_runtime_events(session_id="session-1", limit=20)
+
+        self.assertEqual(len(events), 10)
+        self.assertEqual([event["sequence"] for event in events], list(range(10)))
+        self.assertGreaterEqual(max(observed_counts), 0)
+
+    async def test_async_and_sync_stores_can_share_file_backed_database(self):
+        store = await self.seed_store()
+        await store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Async write visible to sync reader.",
+            conversation_type="org_chat",
+        )
+        await store.close()
+
+        sync_store = SQLiteMemoryStore(store.path)
+        self.addCleanup(sync_store.close)
+        messages = sync_store.list_messages(session_id="session-1")
+
+        self.assertEqual(messages[0]["content"], "Async write visible to sync reader.")
+
+    async def test_memory_fts_is_updated_for_async_messages_and_thoughts(self):
+        store = await self.seed_store()
+        await store.append_message(
+            "session-1",
+            "CEO",
+            "SE",
+            "Async sqlite message should be searchable.",
+            conversation_type="org_chat",
+        )
+        await store.append_thought(
+            "SE",
+            "Async sqlite thought should also be searchable.",
+            session_id="session-1",
+            conversation_type="agent_thought",
+        )
+        await store.close()
+
+        sync_store = SQLiteMemoryStore(store.path)
+        self.addCleanup(sync_store.close)
+        results = sync_store.search("searchable", session_id="session-1")
+        kinds = {result.kind for result in results}
+
+        self.assertIn("message", kinds)
+        self.assertIn("thought", kinds)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #68

## Summary

- Adds `AsyncSQLiteMemoryStore`, an `aiosqlite`-backed async persistence boundary for the hot runtime/TUI paths
- Keeps the existing synchronous `SQLiteMemoryStore` as the canonical schema owner while the async layer grows method coverage
- Enables WAL mode and a busy timeout for file-backed async SQLite access
- Adds async methods for sessions, agents, messages, thoughts, runtime events, and read-side filters useful for TUI replay
- Exports the async store from `robits.memory`
- Adds tests for concurrent async appends, runtime-event reads, sync/async DB sharing, and FTS indexing compatibility

## Scope note

This PR introduces the async adapter as a standalone class with partial method coverage — not yet a full drop-in for `SQLiteMemoryStore`. Full interface parity (so callers can swap the sync store for the async one transparently) is the next step and will be tracked separately.

## Test plan

```bash
uv run python -m unittest tests/test_async_memory_store.py -v
uv run python -m unittest discover -s tests -v
```

## Notes

This intentionally avoids a broad #69 schema migration in the same PR. The async layer preserves the existing `conversation_type` fields while preparing for first-class conversation scopes in a follow-up.