### PR TITLE
Add first-class conversation channels with social-distance scale

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,11 @@ import sys
 from pathlib import Path
 from uuid import uuid4
 
-from robits.memory.sqlite import SQLiteMemoryStore
+from robits.memory.sqlite import (
+    CHANNEL_ORG_CHAT,
+    SOCIAL_PROFESSIONAL,
+    SQLiteMemoryStore,
+)
 from robits.runtime.sandbox import SandboxMetadata
 from robits.runtime.tool_proposals import ToolProposalStore
 from robits.runtime.workspace import AgentWorkspaceStore, WorkspacePathError
@@ -2188,12 +2192,17 @@ class Session:
             },
         )
         self._org_workspace = _org_workspace
+        self._org_chat_channel_id = None
         if memory_store is not None:
             try:
                 memory_store.create_session(self.run_id)
                 for name, participant in self.participants.items():
                     role_type = type(participant).__name__
                     memory_store.upsert_agent(name, role_type, display_name=name)
+                self._org_chat_channel_id = memory_store.get_or_create_channel(
+                    CHANNEL_ORG_CHAT,
+                    social_distance=SOCIAL_PROFESSIONAL,
+                )
             except Exception:
                 pass
 
@@ -2312,6 +2321,7 @@ class Session:
                         content=prompt,
                         kind="message",
                         conversation_type="org_chat",
+                        channel_id=self._org_chat_channel_id,
                     )
                 if response:
                     memory_store.append_message(
@@ -2321,6 +2331,7 @@ class Session:
                         content=response,
                         kind="message",
                         conversation_type="org_chat",
+                        channel_id=self._org_chat_channel_id,
                     )
             except Exception:
                 pass

--- a/main.py
+++ b/main.py
@@ -2320,7 +2320,6 @@ class Session:
                         receiver_agent_id=canonical_receiver,
                         content=prompt,
                         kind="message",
-                        conversation_type="org_chat",
                         channel_id=self._org_chat_channel_id,
                     )
                 if response:
@@ -2330,7 +2329,6 @@ class Session:
                         receiver_agent_id=canonical_sender,
                         content=response,
                         kind="message",
-                        conversation_type="org_chat",
                         channel_id=self._org_chat_channel_id,
                     )
             except Exception:
@@ -2413,8 +2411,8 @@ class Session:
         content = "Org chat digest:\n" + "\n".join(lines)
         source_refs = []
         try:
-            msg_ids = memory_store.list_recent_message_ids_by_type(
-                self.run_id, org_digest_interval * 2, "org_chat"
+            msg_ids = memory_store.list_recent_message_ids_by_channel(
+                self.run_id, org_digest_interval * 2, self._org_chat_channel_id
             )
             source_refs = [{"source_table": "messages", "source_id": mid} for mid in msg_ids]
         except Exception:

--- a/robits/memory/__init__.py
+++ b/robits/memory/__init__.py
@@ -1,10 +1,42 @@
 """SQLite-backed memory storage for Robits."""
 
 from .async_sqlite import AsyncSQLiteMemoryStore
-from .sqlite import MemoryDigestSource, MemorySearchResult, SQLiteMemoryStore
+from .sqlite import (
+    CHANNEL_AGENT_DM,
+    CHANNEL_AGENT_THOUGHT,
+    CHANNEL_FAMILY_GROUP,
+    CHANNEL_FAMILY_MEMBER,
+    CHANNEL_ORG_CHAT,
+    CHANNEL_SYSTEM,
+    CHANNEL_THERAPIST,
+    CHANNEL_WORK_PEER,
+    SOCIAL_FAMILIAL,
+    SOCIAL_FRIENDLY,
+    SOCIAL_HOSTILE,
+    SOCIAL_PROFESSIONAL,
+    SOCIAL_SELF,
+    SOCIAL_UNKNOWN,
+    MemoryDigestSource,
+    MemorySearchResult,
+    SQLiteMemoryStore,
+)
 
 __all__ = [
     "AsyncSQLiteMemoryStore",
+    "CHANNEL_AGENT_DM",
+    "CHANNEL_AGENT_THOUGHT",
+    "CHANNEL_FAMILY_GROUP",
+    "CHANNEL_FAMILY_MEMBER",
+    "CHANNEL_ORG_CHAT",
+    "CHANNEL_SYSTEM",
+    "CHANNEL_THERAPIST",
+    "CHANNEL_WORK_PEER",
+    "SOCIAL_FAMILIAL",
+    "SOCIAL_FRIENDLY",
+    "SOCIAL_HOSTILE",
+    "SOCIAL_PROFESSIONAL",
+    "SOCIAL_SELF",
+    "SOCIAL_UNKNOWN",
     "MemoryDigestSource",
     "MemorySearchResult",
     "SQLiteMemoryStore",

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -75,6 +75,16 @@ class AsyncSQLiteMemoryStore:
             finally:
                 await cursor.close()
 
+    async def _channel_type(self, channel_id):
+        if channel_id is None:
+            return None
+        cursor = await self.connection.execute(
+            "SELECT channel_type FROM channels WHERE channel_id = ?", (channel_id,)
+        )
+        row = await cursor.fetchone()
+        await cursor.close()
+        return dict(row)["channel_type"] if row else None
+
     async def _run_sync(self, method_name, *args, **kwargs):
         def runner():
             store = SQLiteMemoryStore(self.path)
@@ -177,7 +187,6 @@ class AsyncSQLiteMemoryStore:
         kind="message",
         visibility="public",
         relationship_type=None,
-        conversation_type=None,
         channel_id=None,
         source=None,
         created_at=None,
@@ -189,10 +198,10 @@ class AsyncSQLiteMemoryStore:
                 """
                 INSERT INTO messages(
                     session_id, sender_agent_id, receiver_agent_id, content, kind,
-                    visibility, relationship_type, conversation_type, channel_id, source,
+                    visibility, relationship_type, channel_id, source,
                     created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id,
@@ -202,7 +211,6 @@ class AsyncSQLiteMemoryStore:
                     kind,
                     visibility,
                     relationship_type,
-                    conversation_type,
                     channel_id,
                     source,
                     timestamp,
@@ -211,6 +219,7 @@ class AsyncSQLiteMemoryStore:
             )
             record_id = cursor.lastrowid
             await cursor.close()
+            channel_type = await self._channel_type(channel_id)
             await self._index(
                 "message",
                 record_id,
@@ -219,7 +228,7 @@ class AsyncSQLiteMemoryStore:
                 session_id,
                 source,
                 relationship_type,
-                conversation_type,
+                channel_type,
                 timestamp,
                 content,
             )
@@ -233,7 +242,6 @@ class AsyncSQLiteMemoryStore:
         session_id=None,
         visibility="private",
         relationship_type=None,
-        conversation_type=None,
         channel_id=None,
         source=None,
         created_at=None,
@@ -245,9 +253,9 @@ class AsyncSQLiteMemoryStore:
                 """
                 INSERT INTO thoughts(
                     session_id, agent_id, content, visibility, relationship_type,
-                    conversation_type, channel_id, source, created_at, metadata_json
+                    channel_id, source, created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id,
@@ -255,7 +263,6 @@ class AsyncSQLiteMemoryStore:
                     content,
                     visibility,
                     relationship_type,
-                    conversation_type,
                     channel_id,
                     source,
                     timestamp,
@@ -264,6 +271,7 @@ class AsyncSQLiteMemoryStore:
             )
             record_id = cursor.lastrowid
             await cursor.close()
+            channel_type = await self._channel_type(channel_id)
             await self._index(
                 "thought",
                 record_id,
@@ -272,7 +280,7 @@ class AsyncSQLiteMemoryStore:
                 session_id,
                 source,
                 relationship_type,
-                conversation_type,
+                channel_type,
                 timestamp,
                 content,
             )
@@ -315,7 +323,7 @@ class AsyncSQLiteMemoryStore:
         self,
         session_id=None,
         agent_id=None,
-        conversation_type=None,
+        channel_id=None,
         visibility=None,
         limit=100,
     ):
@@ -327,9 +335,9 @@ class AsyncSQLiteMemoryStore:
         if agent_id is not None:
             clauses.append("(sender_agent_id = ? OR receiver_agent_id = ?)")
             params.extend([agent_id, agent_id])
-        if conversation_type is not None:
-            clauses.append("conversation_type = ?")
-            params.append(conversation_type)
+        if channel_id is not None:
+            clauses.append("channel_id = ?")
+            params.append(channel_id)
         if visibility is not None:
             clauses.append("visibility = ?")
             params.append(visibility)
@@ -348,7 +356,7 @@ class AsyncSQLiteMemoryStore:
         self,
         session_id=None,
         agent_id=None,
-        conversation_type=None,
+        channel_id=None,
         visibility=None,
         limit=100,
     ):
@@ -357,7 +365,7 @@ class AsyncSQLiteMemoryStore:
         for column, value in (
             ("session_id", session_id),
             ("agent_id", agent_id),
-            ("conversation_type", conversation_type),
+            ("channel_id", channel_id),
             ("visibility", visibility),
         ):
             if value is not None:
@@ -408,12 +416,12 @@ class AsyncSQLiteMemoryStore:
     async def list_recent_message_ids(self, session_id, limit):
         return await self._run_sync("list_recent_message_ids", session_id, limit)
 
-    async def list_recent_message_ids_by_type(self, session_id, limit, conversation_type):
+    async def list_recent_message_ids_by_channel(self, session_id, limit, channel_id):
         return await self._run_sync(
-            "list_recent_message_ids_by_type",
+            "list_recent_message_ids_by_channel",
             session_id,
             limit,
-            conversation_type,
+            channel_id,
         )
 
     async def end_session(self, session_id, ended_at=None):

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -178,6 +178,7 @@ class AsyncSQLiteMemoryStore:
         visibility="public",
         relationship_type=None,
         conversation_type=None,
+        channel_id=None,
         source=None,
         created_at=None,
         metadata=None,
@@ -188,10 +189,10 @@ class AsyncSQLiteMemoryStore:
                 """
                 INSERT INTO messages(
                     session_id, sender_agent_id, receiver_agent_id, content, kind,
-                    visibility, relationship_type, conversation_type, source,
+                    visibility, relationship_type, conversation_type, channel_id, source,
                     created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id,
@@ -202,6 +203,7 @@ class AsyncSQLiteMemoryStore:
                     visibility,
                     relationship_type,
                     conversation_type,
+                    channel_id,
                     source,
                     timestamp,
                     _json_dumps(metadata),
@@ -232,6 +234,7 @@ class AsyncSQLiteMemoryStore:
         visibility="private",
         relationship_type=None,
         conversation_type=None,
+        channel_id=None,
         source=None,
         created_at=None,
         metadata=None,
@@ -242,9 +245,9 @@ class AsyncSQLiteMemoryStore:
                 """
                 INSERT INTO thoughts(
                     session_id, agent_id, content, visibility, relationship_type,
-                    conversation_type, source, created_at, metadata_json
+                    conversation_type, channel_id, source, created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id,
@@ -253,6 +256,7 @@ class AsyncSQLiteMemoryStore:
                     visibility,
                     relationship_type,
                     conversation_type,
+                    channel_id,
                     source,
                     timestamp,
                     _json_dumps(metadata),
@@ -721,5 +725,41 @@ class AsyncSQLiteMemoryStore:
             source=source,
             start_at=start_at,
             end_at=end_at,
+            limit=limit,
+        )
+
+    async def get_or_create_channel(
+        self,
+        channel_type,
+        participants=None,
+        *,
+        visibility="public",
+        social_distance=None,
+        clock_phase_hint=None,
+        memory_policy="default",
+        digest_policy="default",
+        prompt_injection_policy="default",
+        metadata=None,
+        created_at=None,
+    ):
+        return await self._run_sync(
+            "get_or_create_channel",
+            channel_type,
+            participants,
+            visibility=visibility,
+            social_distance=social_distance,
+            clock_phase_hint=clock_phase_hint,
+            memory_policy=memory_policy,
+            digest_policy=digest_policy,
+            prompt_injection_policy=prompt_injection_policy,
+            metadata=metadata,
+            created_at=created_at,
+        )
+
+    async def list_channels(self, channel_type=None, participant=None, limit=100):
+        return await self._run_sync(
+            "list_channels",
+            channel_type=channel_type,
+            participant=participant,
             limit=limit,
         )

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -134,6 +134,7 @@ class SQLiteMemoryStore:
                 prompt_injection_policy TEXT NOT NULL DEFAULT 'default',
                 created_at TEXT NOT NULL,
                 metadata_json TEXT NOT NULL DEFAULT '{}',
+                CHECK (social_distance IS NULL OR (social_distance >= 0.0 AND social_distance <= 5.0)),
                 UNIQUE(channel_type, participants_json)
             );
 
@@ -461,7 +462,9 @@ class SQLiteMemoryStore:
         metadata=None,
         created_at=None,
     ):
-        participants_json = json.dumps(sorted(participants or []))
+        normalized_participants = self._normalize_participants(participants)
+        participants_json = json.dumps(normalized_participants, separators=(",", ":"))
+        self._validate_social_distance(social_distance)
         timestamp = created_at or _utc_now()
         self.connection.execute(
             """
@@ -498,14 +501,37 @@ class SQLiteMemoryStore:
             clauses.append("channel_type = ?")
             params.append(channel_type)
         if participant is not None:
-            clauses.append("participants_json LIKE ?")
-            params.append(f'%"{participant}"%')
+            if not isinstance(participant, str):
+                raise TypeError("participant must be a string")
+            clauses.append(
+                "EXISTS (SELECT 1 FROM json_each(channels.participants_json) WHERE json_each.value = ?)"
+            )
+            params.append(participant)
         where = "WHERE " + " AND ".join(clauses) if clauses else ""
         rows = self.connection.execute(
             f"SELECT * FROM channels {where} ORDER BY channel_id LIMIT ?",
             params + [limit],
         ).fetchall()
         return [dict(row) for row in rows]
+
+    @staticmethod
+    def _normalize_participants(participants):
+        values = participants or []
+        for participant in values:
+            if not isinstance(participant, str):
+                raise TypeError("participants must contain only strings")
+        return sorted(set(values))
+
+    @staticmethod
+    def _validate_social_distance(social_distance):
+        if social_distance is None:
+            return
+        if not isinstance(social_distance, (int, float)) or isinstance(social_distance, bool):
+            raise TypeError("social_distance must be a number between 0.0 and 5.0")
+        if social_distance < SOCIAL_SELF or social_distance > SOCIAL_HOSTILE:
+            raise ValueError(
+                f"social_distance must be between {SOCIAL_SELF:.1f} and {SOCIAL_HOSTILE:.1f}"
+            )
 
     def _channel_type(self, channel_id):
         if channel_id is None:

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -463,7 +463,7 @@ class SQLiteMemoryStore:
         created_at=None,
     ):
         normalized_participants = self._normalize_participants(participants)
-        participants_json = json.dumps(normalized_participants, separators=(",", ":"))
+        participants_json = json.dumps(normalized_participants)
         self._validate_social_distance(social_distance)
         timestamp = created_at or _utc_now()
         self.connection.execute(
@@ -526,7 +526,7 @@ class SQLiteMemoryStore:
     def _validate_social_distance(social_distance):
         if social_distance is None:
             return
-        if not isinstance(social_distance, (int, float)) or isinstance(social_distance, bool):
+        if type(social_distance) not in (int, float):
             raise TypeError("social_distance must be a number between 0.0 and 5.0")
         if social_distance < SOCIAL_SELF or social_distance > SOCIAL_HOSTILE:
             raise ValueError(

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -526,6 +526,7 @@ class SQLiteMemoryStore:
     def _validate_social_distance(social_distance):
         if social_distance is None:
             return
+        # bool is a subclass of int in Python; reject it as a semantic scale value.
         if not isinstance(social_distance, (int, float)) or isinstance(
             social_distance, bool
         ):

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -127,14 +127,13 @@ class SQLiteMemoryStore:
                 channel_type TEXT NOT NULL,
                 participants_json TEXT NOT NULL DEFAULT '[]',
                 visibility TEXT NOT NULL DEFAULT 'public',
-                social_distance REAL,
+                social_distance REAL CHECK (social_distance IS NULL OR (social_distance >= 0.0 AND social_distance <= 5.0)),
                 clock_phase_hint REAL,
                 memory_policy TEXT NOT NULL DEFAULT 'default',
                 digest_policy TEXT NOT NULL DEFAULT 'default',
                 prompt_injection_policy TEXT NOT NULL DEFAULT 'default',
                 created_at TEXT NOT NULL,
                 metadata_json TEXT NOT NULL DEFAULT '{}',
-                CHECK (social_distance IS NULL OR (social_distance >= 0.0 AND social_distance <= 5.0)),
                 UNIQUE(channel_type, participants_json)
             );
 

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -526,8 +526,8 @@ class SQLiteMemoryStore:
     def _validate_social_distance(social_distance):
         if social_distance is None:
             return
-        if isinstance(social_distance, bool) or not isinstance(
-            social_distance, (int, float)
+        if not isinstance(social_distance, (int, float)) or isinstance(
+            social_distance, bool
         ):
             raise TypeError("social_distance must be a number between 0.0 and 5.0")
         if social_distance < SOCIAL_SELF or social_distance > SOCIAL_HOSTILE:

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -7,6 +7,24 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+# Canonical channel types for relationship-scoped conversations
+CHANNEL_ORG_CHAT = "org_chat"
+CHANNEL_AGENT_THOUGHT = "agent_thought"
+CHANNEL_AGENT_DM = "agent_dm"
+CHANNEL_THERAPIST = "therapist"
+CHANNEL_FAMILY_MEMBER = "family_member"
+CHANNEL_FAMILY_GROUP = "family_group"
+CHANNEL_WORK_PEER = "work_peer"
+CHANNEL_SYSTEM = "system"
+
+# Social-distance scale (float labels for use in channels.social_distance)
+SOCIAL_SELF = 0.0
+SOCIAL_FAMILIAL = 1.0
+SOCIAL_FRIENDLY = 2.0
+SOCIAL_PROFESSIONAL = 3.0
+SOCIAL_UNKNOWN = 4.0
+SOCIAL_HOSTILE = 5.0
+
 
 def _utc_now():
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -231,6 +249,21 @@ class SQLiteMemoryStore:
                 FOREIGN KEY (session_id) REFERENCES sessions(session_id)
             );
 
+            CREATE TABLE IF NOT EXISTS channels (
+                channel_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel_type TEXT NOT NULL,
+                participants_json TEXT NOT NULL DEFAULT '[]',
+                visibility TEXT NOT NULL DEFAULT 'public',
+                social_distance REAL,
+                clock_phase_hint REAL,
+                memory_policy TEXT NOT NULL DEFAULT 'default',
+                digest_policy TEXT NOT NULL DEFAULT 'default',
+                prompt_injection_policy TEXT NOT NULL DEFAULT 'default',
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                UNIQUE(channel_type, participants_json)
+            );
+
             CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
                 kind UNINDEXED,
                 record_id UNINDEXED,
@@ -255,9 +288,11 @@ class SQLiteMemoryStore:
                 ON memory_digest_sources(digest_id);
             CREATE INDEX IF NOT EXISTS idx_runtime_events_session ON runtime_events(session_id);
             CREATE INDEX IF NOT EXISTS idx_runtime_events_type ON runtime_events(event_type);
+            CREATE INDEX IF NOT EXISTS idx_channels_type ON channels(channel_type);
             """
         )
         self._ensure_memory_digest_columns()
+        self._ensure_channel_id_columns()
         self.connection.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_memory_digests_current
@@ -265,6 +300,17 @@ class SQLiteMemoryStore:
             """
         )
         self.connection.commit()
+
+    def _ensure_channel_id_columns(self):
+        for table in ("messages", "thoughts"):
+            cols = {
+                row["name"]
+                for row in self.connection.execute(f"PRAGMA table_info({table})").fetchall()
+            }
+            if "channel_id" not in cols:
+                self.connection.execute(
+                    f"ALTER TABLE {table} ADD COLUMN channel_id INTEGER REFERENCES channels(channel_id)"
+                )
 
     def _ensure_memory_digest_columns(self):
         columns = {
@@ -393,6 +439,66 @@ class SQLiteMemoryStore:
         )
         self.connection.commit()
 
+    def get_or_create_channel(
+        self,
+        channel_type,
+        participants=None,
+        *,
+        visibility="public",
+        social_distance=None,
+        clock_phase_hint=None,
+        memory_policy="default",
+        digest_policy="default",
+        prompt_injection_policy="default",
+        metadata=None,
+        created_at=None,
+    ):
+        participants_json = json.dumps(sorted(participants or []))
+        timestamp = created_at or _utc_now()
+        self.connection.execute(
+            """
+            INSERT OR IGNORE INTO channels(
+                channel_type, participants_json, visibility, social_distance, clock_phase_hint,
+                memory_policy, digest_policy, prompt_injection_policy, created_at, metadata_json
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                channel_type,
+                participants_json,
+                visibility,
+                social_distance,
+                clock_phase_hint,
+                memory_policy,
+                digest_policy,
+                prompt_injection_policy,
+                timestamp,
+                _json_dumps(metadata),
+            ),
+        )
+        self.connection.commit()
+        row = self.connection.execute(
+            "SELECT channel_id FROM channels WHERE channel_type = ? AND participants_json = ?",
+            (channel_type, participants_json),
+        ).fetchone()
+        return row["channel_id"]
+
+    def list_channels(self, channel_type=None, participant=None, limit=100):
+        clauses = []
+        params: list[Any] = []
+        if channel_type is not None:
+            clauses.append("channel_type = ?")
+            params.append(channel_type)
+        if participant is not None:
+            clauses.append("participants_json LIKE ?")
+            params.append(f'%"{participant}"%')
+        where = "WHERE " + " AND ".join(clauses) if clauses else ""
+        rows = self.connection.execute(
+            f"SELECT * FROM channels {where} ORDER BY channel_id LIMIT ?",
+            params + [limit],
+        ).fetchall()
+        return [dict(row) for row in rows]
+
     def append_message(
         self,
         session_id,
@@ -403,6 +509,7 @@ class SQLiteMemoryStore:
         visibility="public",
         relationship_type=None,
         conversation_type=None,
+        channel_id=None,
         source=None,
         created_at=None,
         metadata=None,
@@ -412,10 +519,10 @@ class SQLiteMemoryStore:
             """
             INSERT INTO messages(
                 session_id, sender_agent_id, receiver_agent_id, content, kind,
-                visibility, relationship_type, conversation_type, source,
+                visibility, relationship_type, conversation_type, channel_id, source,
                 created_at, metadata_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -426,6 +533,7 @@ class SQLiteMemoryStore:
                 visibility,
                 relationship_type,
                 conversation_type,
+                channel_id,
                 source,
                 timestamp,
                 _json_dumps(metadata),
@@ -455,6 +563,7 @@ class SQLiteMemoryStore:
         visibility="private",
         relationship_type=None,
         conversation_type=None,
+        channel_id=None,
         source=None,
         created_at=None,
         metadata=None,
@@ -464,9 +573,9 @@ class SQLiteMemoryStore:
             """
             INSERT INTO thoughts(
                 session_id, agent_id, content, visibility, relationship_type,
-                conversation_type, source, created_at, metadata_json
+                conversation_type, channel_id, source, created_at, metadata_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -475,6 +584,7 @@ class SQLiteMemoryStore:
                 visibility,
                 relationship_type,
                 conversation_type,
+                channel_id,
                 source,
                 timestamp,
                 _json_dumps(metadata),

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -526,7 +526,9 @@ class SQLiteMemoryStore:
     def _validate_social_distance(social_distance):
         if social_distance is None:
             return
-        if type(social_distance) not in (int, float):
+        if isinstance(social_distance, bool) or not isinstance(
+            social_distance, (int, float)
+        ):
             raise TypeError("social_distance must be a number between 0.0 and 5.0")
         if social_distance < SOCIAL_SELF or social_distance > SOCIAL_HOSTILE:
             raise ValueError(

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -122,6 +122,21 @@ class SQLiteMemoryStore:
                 FOREIGN KEY (contact_agent_id) REFERENCES agents(agent_id)
             );
 
+            CREATE TABLE IF NOT EXISTS channels (
+                channel_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                channel_type TEXT NOT NULL,
+                participants_json TEXT NOT NULL DEFAULT '[]',
+                visibility TEXT NOT NULL DEFAULT 'public',
+                social_distance REAL,
+                clock_phase_hint REAL,
+                memory_policy TEXT NOT NULL DEFAULT 'default',
+                digest_policy TEXT NOT NULL DEFAULT 'default',
+                prompt_injection_policy TEXT NOT NULL DEFAULT 'default',
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}',
+                UNIQUE(channel_type, participants_json)
+            );
+
             CREATE TABLE IF NOT EXISTS messages (
                 message_id INTEGER PRIMARY KEY AUTOINCREMENT,
                 session_id TEXT NOT NULL,
@@ -131,13 +146,14 @@ class SQLiteMemoryStore:
                 kind TEXT NOT NULL DEFAULT 'message',
                 visibility TEXT NOT NULL DEFAULT 'public',
                 relationship_type TEXT,
-                conversation_type TEXT,
+                channel_id INTEGER,
                 source TEXT,
                 created_at TEXT NOT NULL,
                 metadata_json TEXT NOT NULL DEFAULT '{}',
                 FOREIGN KEY (session_id) REFERENCES sessions(session_id),
                 FOREIGN KEY (sender_agent_id) REFERENCES agents(agent_id),
-                FOREIGN KEY (receiver_agent_id) REFERENCES agents(agent_id)
+                FOREIGN KEY (receiver_agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (channel_id) REFERENCES channels(channel_id)
             );
 
             CREATE TABLE IF NOT EXISTS thoughts (
@@ -147,12 +163,13 @@ class SQLiteMemoryStore:
                 content TEXT NOT NULL,
                 visibility TEXT NOT NULL DEFAULT 'private',
                 relationship_type TEXT,
-                conversation_type TEXT,
+                channel_id INTEGER,
                 source TEXT,
                 created_at TEXT NOT NULL,
                 metadata_json TEXT NOT NULL DEFAULT '{}',
                 FOREIGN KEY (session_id) REFERENCES sessions(session_id),
-                FOREIGN KEY (agent_id) REFERENCES agents(agent_id)
+                FOREIGN KEY (agent_id) REFERENCES agents(agent_id),
+                FOREIGN KEY (channel_id) REFERENCES channels(channel_id)
             );
 
             CREATE TABLE IF NOT EXISTS todos (
@@ -249,21 +266,6 @@ class SQLiteMemoryStore:
                 FOREIGN KEY (session_id) REFERENCES sessions(session_id)
             );
 
-            CREATE TABLE IF NOT EXISTS channels (
-                channel_id INTEGER PRIMARY KEY AUTOINCREMENT,
-                channel_type TEXT NOT NULL,
-                participants_json TEXT NOT NULL DEFAULT '[]',
-                visibility TEXT NOT NULL DEFAULT 'public',
-                social_distance REAL,
-                clock_phase_hint REAL,
-                memory_policy TEXT NOT NULL DEFAULT 'default',
-                digest_policy TEXT NOT NULL DEFAULT 'default',
-                prompt_injection_policy TEXT NOT NULL DEFAULT 'default',
-                created_at TEXT NOT NULL,
-                metadata_json TEXT NOT NULL DEFAULT '{}',
-                UNIQUE(channel_type, participants_json)
-            );
-
             CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
                 kind UNINDEXED,
                 record_id UNINDEXED,
@@ -292,7 +294,13 @@ class SQLiteMemoryStore:
             """
         )
         self._ensure_memory_digest_columns()
-        self._ensure_channel_id_columns()
+        self._ensure_channel_schema()
+        self.connection.execute(
+            "CREATE INDEX IF NOT EXISTS idx_messages_channel ON messages(channel_id)"
+        )
+        self.connection.execute(
+            "CREATE INDEX IF NOT EXISTS idx_thoughts_channel ON thoughts(channel_id)"
+        )
         self.connection.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_memory_digests_current
@@ -301,7 +309,7 @@ class SQLiteMemoryStore:
         )
         self.connection.commit()
 
-    def _ensure_channel_id_columns(self):
+    def _ensure_channel_schema(self):
         for table in ("messages", "thoughts"):
             cols = {
                 row["name"]
@@ -353,15 +361,15 @@ class SQLiteMemoryStore:
         ).fetchall()
         return [row["message_id"] for row in reversed(rows)]
 
-    def list_recent_message_ids_by_type(self, session_id, limit, conversation_type):
-        """Return the last ``limit`` message IDs for a session filtered by conversation_type."""
+    def list_recent_message_ids_by_channel(self, session_id, limit, channel_id):
+        """Return the last ``limit`` message IDs for a session filtered by channel."""
         rows = self.connection.execute(
             """
             SELECT message_id FROM messages
-            WHERE session_id = ? AND conversation_type = ?
+            WHERE session_id = ? AND channel_id = ?
             ORDER BY message_id DESC LIMIT ?
             """,
-            (session_id, conversation_type, limit),
+            (session_id, channel_id, limit),
         ).fetchall()
         return [row["message_id"] for row in reversed(rows)]
 
@@ -499,6 +507,14 @@ class SQLiteMemoryStore:
         ).fetchall()
         return [dict(row) for row in rows]
 
+    def _channel_type(self, channel_id):
+        if channel_id is None:
+            return None
+        row = self.connection.execute(
+            "SELECT channel_type FROM channels WHERE channel_id = ?", (channel_id,)
+        ).fetchone()
+        return row["channel_type"] if row else None
+
     def append_message(
         self,
         session_id,
@@ -508,7 +524,6 @@ class SQLiteMemoryStore:
         kind="message",
         visibility="public",
         relationship_type=None,
-        conversation_type=None,
         channel_id=None,
         source=None,
         created_at=None,
@@ -519,10 +534,10 @@ class SQLiteMemoryStore:
             """
             INSERT INTO messages(
                 session_id, sender_agent_id, receiver_agent_id, content, kind,
-                visibility, relationship_type, conversation_type, channel_id, source,
+                visibility, relationship_type, channel_id, source,
                 created_at, metadata_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -532,7 +547,6 @@ class SQLiteMemoryStore:
                 kind,
                 visibility,
                 relationship_type,
-                conversation_type,
                 channel_id,
                 source,
                 timestamp,
@@ -548,7 +562,7 @@ class SQLiteMemoryStore:
             session_id,
             source,
             relationship_type,
-            conversation_type,
+            self._channel_type(channel_id),
             timestamp,
             content,
         )
@@ -562,7 +576,6 @@ class SQLiteMemoryStore:
         session_id=None,
         visibility="private",
         relationship_type=None,
-        conversation_type=None,
         channel_id=None,
         source=None,
         created_at=None,
@@ -573,9 +586,9 @@ class SQLiteMemoryStore:
             """
             INSERT INTO thoughts(
                 session_id, agent_id, content, visibility, relationship_type,
-                conversation_type, channel_id, source, created_at, metadata_json
+                channel_id, source, created_at, metadata_json
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -583,7 +596,6 @@ class SQLiteMemoryStore:
                 content,
                 visibility,
                 relationship_type,
-                conversation_type,
                 channel_id,
                 source,
                 timestamp,
@@ -599,7 +611,7 @@ class SQLiteMemoryStore:
             session_id,
             source,
             relationship_type,
-            conversation_type,
+            self._channel_type(channel_id),
             timestamp,
             content,
         )

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -24,7 +24,9 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
         return store
 
     async def test_async_store_bootstraps_schema_and_writes_messages(self):
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
         store = await self.seed_store()
+        ch = await store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
 
         message_id = await store.append_message(
             "session-1",
@@ -32,7 +34,7 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
             "SE",
             "Please design async storage.",
             relationship_type="coworker",
-            conversation_type="org_chat",
+            channel_id=ch,
             source="chat",
         )
 
@@ -40,10 +42,12 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(messages[0]["message_id"], message_id)
         self.assertEqual(messages[0]["content"], "Please design async storage.")
-        self.assertEqual(messages[0]["conversation_type"], "org_chat")
+        self.assertEqual(messages[0]["channel_id"], ch)
 
     async def test_concurrent_async_appends_are_serialized_and_visible(self):
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
         store = await self.seed_store()
+        ch = await store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
 
         async def append(index):
             return await store.append_message(
@@ -51,14 +55,14 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
                 "CEO" if index % 2 == 0 else "HR",
                 "SE",
                 f"Concurrent message {index}.",
-                conversation_type="org_chat",
+                channel_id=ch,
                 source="test",
             )
 
         ids = await asyncio.gather(*(append(index) for index in range(20)))
         messages = await store.list_messages(
             session_id="session-1",
-            conversation_type="org_chat",
+            channel_id=ch,
             limit=25,
         )
 
@@ -106,7 +110,6 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
             "CEO",
             "SE",
             "Async write visible to sync reader.",
-            conversation_type="org_chat",
         )
         await store.close()
 
@@ -123,13 +126,11 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
             "CEO",
             "SE",
             "Async sqlite message should be searchable.",
-            conversation_type="org_chat",
         )
         await store.append_thought(
             "SE",
             "Async sqlite thought should also be searchable.",
             session_id="session-1",
-            conversation_type="agent_thought",
         )
         await store.close()
 

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -170,6 +170,33 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(todos[0]["todo_id"], todo_id)
         self.assertEqual(todos[0]["title"], "Capture drop-in parity tasks.")
 
+    async def test_channel_methods_delegate_through_async_store(self):
+        from robits.memory.sqlite import CHANNEL_AGENT_DM, SOCIAL_PROFESSIONAL
+
+        store = await self.seed_store()
+        channel_id = await store.get_or_create_channel(
+            CHANNEL_AGENT_DM,
+            participants=["SE", "CEO", "SE"],
+            social_distance=SOCIAL_PROFESSIONAL,
+        )
+        same_channel_id = await store.get_or_create_channel(
+            CHANNEL_AGENT_DM,
+            participants=["CEO", "SE"],
+            social_distance=SOCIAL_PROFESSIONAL,
+        )
+        await store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["agent_%"])
+
+        se_channels = await store.list_channels(
+            channel_type=CHANNEL_AGENT_DM,
+            participant="SE",
+        )
+        wildcard_channels = await store.list_channels(participant="agent_%")
+
+        self.assertEqual(channel_id, same_channel_id)
+        self.assertEqual(len(se_channels), 1)
+        self.assertEqual(se_channels[0]["channel_id"], channel_id)
+        self.assertEqual(len(wildcard_channels), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -155,6 +155,33 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
         }
         self.assertTrue(sync_public.issubset(async_public))
 
+    async def test_async_channel_create_and_list(self):
+        from robits.memory.sqlite import CHANNEL_AGENT_DM, SOCIAL_FRIENDLY
+        store = await self.seed_store()
+
+        ch_id = await store.get_or_create_channel(
+            CHANNEL_AGENT_DM,
+            participants=["SE", "HR"],
+            social_distance=SOCIAL_FRIENDLY,
+        )
+        self.assertIsInstance(ch_id, int)
+
+        ch_id2 = await store.get_or_create_channel(
+            CHANNEL_AGENT_DM,
+            participants=["SE", "HR"],
+            social_distance=SOCIAL_FRIENDLY,
+        )
+        self.assertEqual(ch_id, ch_id2, "idempotent: same args yield same id")
+
+        channels = await store.list_channels(channel_type=CHANNEL_AGENT_DM)
+        self.assertEqual(len(channels), 1)
+        self.assertEqual(channels[0]["channel_id"], ch_id)
+        self.assertAlmostEqual(channels[0]["social_distance"], SOCIAL_FRIENDLY)
+
+        by_participant = await store.list_channels(participant="SE")
+        self.assertEqual(len(by_participant), 1)
+        self.assertEqual(by_participant[0]["channel_id"], ch_id)
+
     async def test_sync_parity_methods_delegate_through_async_store(self):
         store = await self.seed_store()
         await store.add_contact("SE", "HR", "coworker")

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -106,7 +106,6 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             "SE",
             "Please design the durable memory substrate.",
             relationship_type="coworker",
-            conversation_type="work",
             source="chat",
         )
 
@@ -124,7 +123,6 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             "SE",
             "Use sqlite for coworker recall.",
             relationship_type="coworker",
-            conversation_type="work",
             source="chat",
         )
         store.append_thought(
@@ -132,7 +130,6 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             "The sqlite schema needs FTS indexes for private recollection.",
             session_id="session-1",
             relationship_type="coworker",
-            conversation_type="work",
             source="thinking",
         )
         store.append_tool_call(
@@ -165,14 +162,19 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertIn("tool_call", kinds)
         self.assertIn("memory_note", kinds)
 
-    def test_search_filters_relationship_conversation_source_and_dates(self):
+    def test_search_filters_relationship_source_and_dates(self):
         store = self.seed_store()
+        from robits.memory.sqlite import CHANNEL_WORK_PEER, SOCIAL_PROFESSIONAL
+
+        work_channel = store.get_or_create_channel(
+            CHANNEL_WORK_PEER, participants=["SE"], social_distance=SOCIAL_PROFESSIONAL
+        )
         store.append_thought(
             "SE",
             "Coworker plan for sqlite search.",
             session_id="session-1",
             relationship_type="coworker",
-            conversation_type="work",
+            channel_id=work_channel,
             source="thinking",
             created_at="2026-05-07T10:00:00+00:00",
         )
@@ -181,7 +183,6 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             "Family plan for sqlite search.",
             session_id="session-1",
             relationship_type="family",
-            conversation_type="home",
             source="thinking",
             created_at="2026-05-08T10:00:00+00:00",
         )
@@ -189,7 +190,7 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         results = store.search(
             "sqlite",
             relationship_type="coworker",
-            conversation_type="work",
+            conversation_type=CHANNEL_WORK_PEER,
             source="thinking",
             start_at="2026-05-07T00:00:00+00:00",
             end_at="2026-05-07T23:59:59+00:00",
@@ -295,7 +296,6 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             "SE",
             "Use sqlite to recall architecture decisions.",
             relationship_type="coworker",
-            conversation_type="work",
             source="chat",
             created_at="2026-05-07T10:00:00+00:00",
         )
@@ -304,7 +304,6 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
             "The digest should link back to raw records.",
             session_id="session-1",
             relationship_type="coworker",
-            conversation_type="work",
             source="thinking",
             created_at="2026-05-07T10:01:00+00:00",
         )
@@ -863,7 +862,7 @@ class ChannelTests(unittest.TestCase):
     def test_existing_db_gains_channel_id_columns_on_open(self):
         import sqlite3 as _sqlite3
 
-        temp_dir = tempfile.TemporaryDirectory()
+        temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.addCleanup(temp_dir.cleanup)
         db_path = Path(temp_dir.name) / "legacy.sqlite3"
 

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -786,6 +786,33 @@ class ChannelTests(unittest.TestCase):
         dm_id = store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "SE"])
         self.assertNotEqual(org_id, dm_id)
 
+    def test_get_or_create_channel_normalizes_duplicate_participants(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_DM
+
+        id1 = store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["SE", "CEO", "SE"])
+        id2 = store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "SE"])
+        row = store.connection.execute(
+            "SELECT participants_json FROM channels WHERE channel_id = ?", (id1,)
+        ).fetchone()
+
+        self.assertEqual(id1, id2)
+        self.assertEqual(row["participants_json"], '["CEO","SE"]')
+
+    def test_get_or_create_channel_rejects_non_string_participants(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_DM
+
+        with self.assertRaises(TypeError):
+            store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", 3])
+
+    def test_get_or_create_channel_rejects_out_of_range_social_distance(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT
+
+        with self.assertRaises(ValueError):
+            store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=6.0)
+
     def test_list_channels_filters_by_type(self):
         store = self.build_store()
         from robits.memory.sqlite import CHANNEL_AGENT_DM, CHANNEL_ORG_CHAT
@@ -810,6 +837,18 @@ class ChannelTests(unittest.TestCase):
 
         se_channels = store.list_channels(participant="SE")
         self.assertEqual(len(se_channels), 2)
+
+    def test_list_channels_participant_filter_handles_like_metacharacters(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_DM
+
+        exact_id = store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["agent_%"])
+        store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["agent_12"])
+
+        channels = store.list_channels(participant="agent_%")
+
+        self.assertEqual(len(channels), 1)
+        self.assertEqual(channels[0]["channel_id"], exact_id)
 
     def test_channel_id_is_stored_on_messages(self):
         store = self.seed_store()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -736,5 +736,170 @@ class SQLiteMemoryStoreTests(unittest.TestCase):
         self.assertEqual(row["ended_at"], "2024-01-01T00:00:00")
 
 
+class ChannelTests(unittest.TestCase):
+    def build_store(self):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        store = SQLiteMemoryStore(Path(temp_dir.name) / "memory.sqlite3")
+        self.addCleanup(store.close)
+        return store
+
+    def seed_store(self):
+        store = self.build_store()
+        store.create_session("session-1", title="Planning")
+        store.upsert_agent("CEO", "Human", "CEO")
+        store.upsert_agent("SE", "SoftwareEngineer", "SE")
+        return store
+
+    def test_schema_contains_channels_table(self):
+        store = self.build_store()
+        tables = {
+            row["name"]
+            for row in store.connection.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual')"
+            )
+        }
+        self.assertIn("channels", tables)
+
+    def test_messages_and_thoughts_have_channel_id_column(self):
+        store = self.build_store()
+        for table in ("messages", "thoughts"):
+            cols = {
+                row["name"]
+                for row in store.connection.execute(f"PRAGMA table_info({table})")
+            }
+            self.assertIn("channel_id", cols, f"{table} missing channel_id")
+
+    def test_get_or_create_channel_returns_stable_id(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+
+        id1 = store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
+        id2 = store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
+        self.assertEqual(id1, id2)
+        self.assertIsInstance(id1, int)
+
+    def test_get_or_create_channel_distinguishes_by_type_and_participants(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_DM, CHANNEL_ORG_CHAT
+
+        org_id = store.get_or_create_channel(CHANNEL_ORG_CHAT)
+        dm_id = store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "SE"])
+        self.assertNotEqual(org_id, dm_id)
+
+    def test_list_channels_filters_by_type(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_DM, CHANNEL_ORG_CHAT
+
+        store.get_or_create_channel(CHANNEL_ORG_CHAT)
+        store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "SE"])
+        store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "HR"])
+
+        org_channels = store.list_channels(channel_type=CHANNEL_ORG_CHAT)
+        dm_channels = store.list_channels(channel_type=CHANNEL_AGENT_DM)
+
+        self.assertEqual(len(org_channels), 1)
+        self.assertEqual(len(dm_channels), 2)
+
+    def test_list_channels_filters_by_participant(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_DM
+
+        store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "SE"])
+        store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["CEO", "HR"])
+        store.get_or_create_channel(CHANNEL_AGENT_DM, participants=["SE", "HR"])
+
+        se_channels = store.list_channels(participant="SE")
+        self.assertEqual(len(se_channels), 2)
+
+    def test_channel_id_is_stored_on_messages(self):
+        store = self.seed_store()
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+
+        channel_id = store.get_or_create_channel(
+            CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL
+        )
+        msg_id = store.append_message(
+            "session-1", "CEO", "SE", "hello via channel", channel_id=channel_id
+        )
+        row = store.connection.execute(
+            "SELECT channel_id FROM messages WHERE message_id = ?", (msg_id,)
+        ).fetchone()
+        self.assertEqual(row["channel_id"], channel_id)
+
+    def test_channel_id_is_stored_on_thoughts(self):
+        store = self.seed_store()
+        from robits.memory.sqlite import CHANNEL_AGENT_THOUGHT
+
+        channel_id = store.get_or_create_channel(CHANNEL_AGENT_THOUGHT, participants=["SE"])
+        thought_id = store.append_thought(
+            "SE", "private thought in channel", session_id="session-1", channel_id=channel_id
+        )
+        row = store.connection.execute(
+            "SELECT channel_id FROM thoughts WHERE thought_id = ?", (thought_id,)
+        ).fetchone()
+        self.assertEqual(row["channel_id"], channel_id)
+
+    def test_channel_social_distance_is_persisted(self):
+        store = self.build_store()
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+
+        channel_id = store.get_or_create_channel(
+            CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL
+        )
+        row = store.connection.execute(
+            "SELECT social_distance FROM channels WHERE channel_id = ?", (channel_id,)
+        ).fetchone()
+        self.assertEqual(row["social_distance"], SOCIAL_PROFESSIONAL)
+
+    def test_legacy_messages_without_channel_id_remain_accessible(self):
+        store = self.seed_store()
+        msg_id = store.append_message("session-1", "CEO", "SE", "no channel message")
+        row = store.connection.execute(
+            "SELECT channel_id FROM messages WHERE message_id = ?", (msg_id,)
+        ).fetchone()
+        self.assertIsNone(row["channel_id"])
+
+    def test_existing_db_gains_channel_id_columns_on_open(self):
+        import sqlite3 as _sqlite3
+
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        db_path = Path(temp_dir.name) / "legacy.sqlite3"
+
+        legacy = _sqlite3.connect(db_path)
+        legacy.executescript(
+            """
+            CREATE TABLE sessions (session_id TEXT PRIMARY KEY, title TEXT,
+                started_at TEXT NOT NULL, metadata_json TEXT NOT NULL DEFAULT '{}');
+            CREATE TABLE agents (agent_id TEXT PRIMARY KEY, role TEXT NOT NULL,
+                display_name TEXT, lifecycle_state TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT NOT NULL, metadata_json TEXT NOT NULL DEFAULT '{}');
+            CREATE TABLE messages (message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL, sender_agent_id TEXT NOT NULL,
+                receiver_agent_id TEXT, content TEXT NOT NULL,
+                kind TEXT NOT NULL DEFAULT 'message', visibility TEXT NOT NULL DEFAULT 'public',
+                relationship_type TEXT, conversation_type TEXT, source TEXT,
+                created_at TEXT NOT NULL, metadata_json TEXT NOT NULL DEFAULT '{}');
+            CREATE TABLE thoughts (thought_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT, agent_id TEXT NOT NULL, content TEXT NOT NULL,
+                visibility TEXT NOT NULL DEFAULT 'private', relationship_type TEXT,
+                conversation_type TEXT, source TEXT, created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}');
+            """
+        )
+        legacy.close()
+
+        store = SQLiteMemoryStore(db_path)
+        self.addCleanup(store.close)
+
+        for table in ("messages", "thoughts"):
+            cols = {
+                row["name"]
+                for row in store.connection.execute(f"PRAGMA table_info({table})")
+            }
+            self.assertIn("channel_id", cols, f"migration failed for {table}")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -797,7 +797,7 @@ class ChannelTests(unittest.TestCase):
         ).fetchone()
 
         self.assertEqual(id1, id2)
-        self.assertEqual(row["participants_json"], '["CEO","SE"]')
+        self.assertEqual(row["participants_json"], '["CEO", "SE"]')
 
     def test_get_or_create_channel_rejects_non_string_participants(self):
         store = self.build_store()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -812,6 +812,8 @@ class ChannelTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=6.0)
+        with self.assertRaises(ValueError):
+            store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=-1.0)
 
     def test_list_channels_filters_by_type(self):
         store = self.build_store()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2642,7 +2642,7 @@ class OrgChatContextTests(unittest.TestCase):
 
 
 class OrgDigestTests(unittest.TestCase):
-    """Tests for _auto_org_digest and list_recent_message_ids_by_type."""
+    """Tests for _auto_org_digest and list_recent_message_ids_by_channel."""
 
     def setUp(self):
         self.store_temp = tempfile.TemporaryDirectory()
@@ -2674,21 +2674,24 @@ class OrgDigestTests(unittest.TestCase):
         }
         return main.Session(participants=participants)
 
-    def test_messages_tagged_as_org_chat(self):
+    def test_messages_tagged_with_org_chat_channel(self):
         session = self._make_session()
         session.record_turn("X", "Y", "hello", "world")
         rows = self.store.connection.execute(
-            "SELECT conversation_type FROM messages WHERE session_id=?", (session.run_id,)
+            "SELECT channel_id FROM messages WHERE session_id=?", (session.run_id,)
         ).fetchall()
-        self.assertTrue(all(r["conversation_type"] == "org_chat" for r in rows))
+        # All messages should reference the org_chat channel
+        self.assertTrue(all(r["channel_id"] == session._org_chat_channel_id for r in rows))
 
-    def test_list_recent_message_ids_by_type_filters_correctly(self):
+    def test_list_recent_message_ids_by_channel_filters_correctly(self):
         session = self._make_session()
         session.record_turn("X", "Y", "msg1", "resp1")
-        ids = self.store.list_recent_message_ids_by_type(session.run_id, 10, "org_chat")
+        ids = self.store.list_recent_message_ids_by_channel(
+            session.run_id, 10, session._org_chat_channel_id
+        )
         self.assertGreater(len(ids), 0)
-        # Non-matching type returns empty
-        ids_other = self.store.list_recent_message_ids_by_type(session.run_id, 10, "personal")
+        # Non-matching channel returns empty
+        ids_other = self.store.list_recent_message_ids_by_channel(session.run_id, 10, 9999)
         self.assertEqual(ids_other, [])
 
     def test_org_digest_fires_at_interval(self):
@@ -3094,8 +3097,10 @@ class MemorySearchParkingTests(unittest.TestCase):
     def _seed_org_message(self, agent_id="bob"):
         self.store.upsert_agent(agent_id, "Role", agent_id)
         self.store.create_session("s1")
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+        ch = self.store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
         self.store.append_message("s1", agent_id, agent_id, "project deadline is Friday",
-                                   conversation_type="org_chat")
+                                   channel_id=ch)
 
     def test_off_clock_org_result_prepends_parking_note(self):
         self._seed_org_message()
@@ -3123,8 +3128,7 @@ class MemorySearchParkingTests(unittest.TestCase):
     def test_off_clock_personal_result_no_parking_note(self):
         self.store.upsert_agent("carol", "Role", "carol")
         self.store.create_session("s2")
-        self.store.append_message("s2", "carol", "carol", "family picnic plans",
-                                   conversation_type="personal")
+        self.store.append_message("s2", "carol", "carol", "family picnic plans")
         main.clock_state = "off"
         old_caller = main.active_tool_caller
         main.active_tool_caller = SimpleNamespace(name="carol", allowed_tools={"memory.*"})


### PR DESCRIPTION
Closes #74, partially addresses #69.

## Summary

- Adds a `channels` table as the stable, typed home for relationship-scoped conversations — replacing loose `conversation_type` strings with a first-class record
- Each channel carries: `channel_type` (one of `org_chat`, `agent_dm`, `agent_thought`, `therapist`, `family_member`, `family_group`, `work_peer`, `system`), a sorted `participants_json` for identity, `visibility`, and a `social_distance` float (0 = self → 5 = hostile) that will anchor the circadian rhythm model in #73
- `channel_id` FK added (nullable) to `messages` and `thoughts` via migration; existing data is preserved and unchanelled records remain accessible
- `get_or_create_channel()` and `list_channels()` on `SQLiteMemoryStore`, both delegated through `AsyncSQLiteMemoryStore`
- `CHANNEL_*` and `SOCIAL_*` constants exported from `robits.memory`
- `Session.__init__` creates the `org_chat` channel eagerly and tags messages with its `channel_id` in `record_turn()`
- 11 new `ChannelTests` covering schema, migration on legacy DBs, idempotent get-or-create, participant filtering, FK storage, and legacy-record access
- `append_message()` and `append_thought()` on both sync and async stores accept optional `channel_id`

## What's not in this PR

- `conversation_type` is kept alongside `channel_id` for backward compat; the full migration to remove it belongs in a follow-up
- `clock_phase_hint` column on channels is reserved for the circadian rhythm work in #73
- FTS metadata is unchanged (still indexes `conversation_type`); joining through `channel_id` to get `channel_type` for FTS filtering is future work