### PR TITLE
Add circadian phase foundation for agents

### DIFF
--- a/main.py
+++ b/main.py
@@ -2313,6 +2313,8 @@ class Session:
             canonical_sender = self._canonical_agent_id(sender)
             canonical_receiver = self._canonical_agent_id(receiver)
             try:
+                sender_phase = memory_store.get_agent_phase(canonical_sender)
+                receiver_phase = memory_store.get_agent_phase(canonical_receiver)
                 if prompt:
                     memory_store.append_message(
                         session_id=self.run_id,
@@ -2321,6 +2323,7 @@ class Session:
                         content=prompt,
                         kind="message",
                         channel_id=self._org_chat_channel_id,
+                        sender_phase=sender_phase,
                     )
                 if response:
                     memory_store.append_message(
@@ -2330,7 +2333,23 @@ class Session:
                         content=response,
                         kind="message",
                         channel_id=self._org_chat_channel_id,
+                        sender_phase=receiver_phase,
                     )
+                # Phase-shift: shift receiver toward sender's phase, weighted by social distance.
+                if self._org_chat_channel_id is not None and sender_phase is not None and receiver_phase is not None:
+                    try:
+                        row = memory_store.connection.execute(
+                            "SELECT social_distance FROM channels WHERE channel_id = ?",
+                            (self._org_chat_channel_id,),
+                        ).fetchone()
+                        if row is not None and row["social_distance"] is not None:
+                            from robits.memory.sqlite import compute_phase_shift
+                            shifted = compute_phase_shift(
+                                receiver_phase, sender_phase, float(row["social_distance"])
+                            )
+                            memory_store.set_agent_phase(canonical_receiver, shifted)
+                    except Exception:
+                        pass
             except Exception:
                 pass
             if (

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ from robits.memory.sqlite import (
     CHANNEL_ORG_CHAT,
     SOCIAL_PROFESSIONAL,
     SQLiteMemoryStore,
+    compute_phase_shift,
 )
 from robits.runtime.sandbox import SandboxMetadata
 from robits.runtime.tool_proposals import ToolProposalStore
@@ -2338,14 +2339,12 @@ class Session:
                 # Phase-shift: shift receiver toward sender's phase, weighted by social distance.
                 if self._org_chat_channel_id is not None and sender_phase is not None and receiver_phase is not None:
                     try:
-                        row = memory_store.connection.execute(
-                            "SELECT social_distance FROM channels WHERE channel_id = ?",
-                            (self._org_chat_channel_id,),
-                        ).fetchone()
-                        if row is not None and row["social_distance"] is not None:
-                            from robits.memory.sqlite import compute_phase_shift
+                        social_distance = memory_store.get_channel_social_distance(
+                            self._org_chat_channel_id
+                        )
+                        if social_distance is not None:
                             shifted = compute_phase_shift(
-                                receiver_phase, sender_phase, float(row["social_distance"])
+                                receiver_phase, sender_phase, social_distance
                             )
                             memory_store.set_agent_phase(canonical_receiver, shifted)
                     except Exception:

--- a/robits/memory/__init__.py
+++ b/robits/memory/__init__.py
@@ -16,6 +16,7 @@ from .sqlite import (
     SOCIAL_PROFESSIONAL,
     SOCIAL_SELF,
     SOCIAL_UNKNOWN,
+    compute_phase_shift,
     MemoryDigestSource,
     MemorySearchResult,
     SQLiteMemoryStore,
@@ -40,4 +41,5 @@ __all__ = [
     "MemoryDigestSource",
     "MemorySearchResult",
     "SQLiteMemoryStore",
+    "compute_phase_shift",
 ]

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -774,8 +774,12 @@ class AsyncSQLiteMemoryStore:
             limit=limit,
         )
 
-    async def get_agent_phase(self, agent_id) -> "float | None":
+    async def get_agent_phase(self, agent_id) -> float | None:
         return await self._run_sync("get_agent_phase", agent_id)
 
     async def set_agent_phase(self, agent_id, phase: float) -> None:
         return await self._run_sync("set_agent_phase", agent_id, phase)
+
+    async def get_channel_social_distance(self, channel_id) -> float | None:
+        """Return the social_distance for a channel, or None if not found or unset."""
+        return await self._run_sync("get_channel_social_distance", channel_id)

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -191,6 +191,7 @@ class AsyncSQLiteMemoryStore:
         source=None,
         created_at=None,
         metadata=None,
+        sender_phase=None,
     ):
         timestamp = created_at or _utc_now()
         async with self._db_lock:
@@ -199,9 +200,9 @@ class AsyncSQLiteMemoryStore:
                 INSERT INTO messages(
                     session_id, sender_agent_id, receiver_agent_id, content, kind,
                     visibility, relationship_type, channel_id, source,
-                    created_at, metadata_json
+                    created_at, metadata_json, sender_phase
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     session_id,
@@ -215,6 +216,7 @@ class AsyncSQLiteMemoryStore:
                     source,
                     timestamp,
                     _json_dumps(metadata),
+                    sender_phase,
                 ),
             )
             record_id = cursor.lastrowid
@@ -771,3 +773,9 @@ class AsyncSQLiteMemoryStore:
             participant=participant,
             limit=limit,
         )
+
+    async def get_agent_phase(self, agent_id) -> "float | None":
+        return await self._run_sync("get_agent_phase", agent_id)
+
+    async def set_agent_phase(self, agent_id, phase: float) -> None:
+        return await self._run_sync("set_agent_phase", agent_id, phase)

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -26,6 +26,21 @@ SOCIAL_UNKNOWN = 4.0
 SOCIAL_HOSTILE = 5.0
 
 
+SOCIAL_SELF = 0
+SOCIAL_FAMILIAL = 1
+SOCIAL_FRIENDLY = 2
+SOCIAL_PROFESSIONAL = 3
+SOCIAL_UNKNOWN = 4
+SOCIAL_HOSTILE = 5
+
+
+def compute_phase_shift(current_phase: float, event_phase: float, social_distance: float) -> float:
+    """Shift current_phase toward event_phase, weighted by closeness (inverse of social_distance+1)."""
+    weight = 1.0 / (social_distance + 1.0)
+    shifted = current_phase + weight * (event_phase - current_phase)
+    return max(0.0, min(1.0, shifted))
+
+
 def _utc_now():
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -301,6 +316,8 @@ class SQLiteMemoryStore:
         self.connection.execute(
             "CREATE INDEX IF NOT EXISTS idx_thoughts_channel ON thoughts(channel_id)"
         )
+        self._ensure_agent_phase_column()
+        self._ensure_message_sender_phase_column()
         self.connection.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_memory_digests_current
@@ -336,6 +353,45 @@ class SQLiteMemoryStore:
         for column, statement in migrations.items():
             if column not in columns:
                 self.connection.execute(statement)
+
+    def _ensure_agent_phase_column(self):
+        columns = {
+            row["name"]
+            for row in self.connection.execute("PRAGMA table_info(agents)").fetchall()
+        }
+        if "circadian_phase" not in columns:
+            self.connection.execute(
+                "ALTER TABLE agents ADD COLUMN circadian_phase REAL DEFAULT 0.5"
+            )
+
+    def _ensure_message_sender_phase_column(self):
+        columns = {
+            row["name"]
+            for row in self.connection.execute("PRAGMA table_info(messages)").fetchall()
+        }
+        if "sender_phase" not in columns:
+            self.connection.execute(
+                "ALTER TABLE messages ADD COLUMN sender_phase REAL"
+            )
+
+    def get_agent_phase(self, agent_id) -> "float | None":
+        """Return the current circadian phase for an agent, or None if not found."""
+        row = self.connection.execute(
+            "SELECT circadian_phase FROM agents WHERE agent_id = ?",
+            (agent_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return row["circadian_phase"]
+
+    def set_agent_phase(self, agent_id, phase: float) -> None:
+        """Update the circadian phase for an agent; clamps to [0.0, 1.0]."""
+        clamped = max(0.0, min(1.0, float(phase)))
+        self.connection.execute(
+            "UPDATE agents SET circadian_phase = ? WHERE agent_id = ?",
+            (clamped, agent_id),
+        )
+        self.connection.commit()
 
     def create_session(self, session_id, title=None, started_at=None, metadata=None):
         created_at = started_at or _utc_now()
@@ -556,6 +612,7 @@ class SQLiteMemoryStore:
         source=None,
         created_at=None,
         metadata=None,
+        sender_phase=None,
     ):
         timestamp = created_at or _utc_now()
         cursor = self.connection.execute(
@@ -563,9 +620,9 @@ class SQLiteMemoryStore:
             INSERT INTO messages(
                 session_id, sender_agent_id, receiver_agent_id, content, kind,
                 visibility, relationship_type, channel_id, source,
-                created_at, metadata_json
+                created_at, metadata_json, sender_phase
             )
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session_id,
@@ -579,6 +636,7 @@ class SQLiteMemoryStore:
                 source,
                 timestamp,
                 _json_dumps(metadata),
+                sender_phase,
             ),
         )
         record_id = cursor.lastrowid

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -26,17 +26,10 @@ SOCIAL_UNKNOWN = 4.0
 SOCIAL_HOSTILE = 5.0
 
 
-SOCIAL_SELF = 0
-SOCIAL_FAMILIAL = 1
-SOCIAL_FRIENDLY = 2
-SOCIAL_PROFESSIONAL = 3
-SOCIAL_UNKNOWN = 4
-SOCIAL_HOSTILE = 5
-
-
 def compute_phase_shift(current_phase: float, event_phase: float, social_distance: float) -> float:
     """Shift current_phase toward event_phase, weighted by closeness (inverse of social_distance+1)."""
-    weight = 1.0 / (social_distance + 1.0)
+    effective_distance = max(0.0, social_distance)
+    weight = 1.0 / (effective_distance + 1.0)
     shifted = current_phase + weight * (event_phase - current_phase)
     return max(0.0, min(1.0, shifted))
 
@@ -377,7 +370,7 @@ class SQLiteMemoryStore:
     def get_agent_phase(self, agent_id) -> "float | None":
         """Return the current circadian phase for an agent, or None if not found."""
         row = self.connection.execute(
-            "SELECT circadian_phase FROM agents WHERE agent_id = ?",
+            "SELECT COALESCE(circadian_phase, 0.5) AS circadian_phase FROM agents WHERE agent_id = ?",
             (agent_id,),
         ).fetchone()
         if row is None:

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -158,6 +158,7 @@ class SQLiteMemoryStore:
                 source TEXT,
                 created_at TEXT NOT NULL,
                 metadata_json TEXT NOT NULL DEFAULT '{}',
+                sender_phase REAL,
                 FOREIGN KEY (session_id) REFERENCES sessions(session_id),
                 FOREIGN KEY (sender_agent_id) REFERENCES agents(agent_id),
                 FOREIGN KEY (receiver_agent_id) REFERENCES agents(agent_id),
@@ -367,7 +368,7 @@ class SQLiteMemoryStore:
                 "ALTER TABLE messages ADD COLUMN sender_phase REAL"
             )
 
-    def get_agent_phase(self, agent_id) -> "float | None":
+    def get_agent_phase(self, agent_id) -> float | None:
         """Return the current circadian phase for an agent, or None if not found."""
         row = self.connection.execute(
             "SELECT COALESCE(circadian_phase, 0.5) AS circadian_phase FROM agents WHERE agent_id = ?",
@@ -385,6 +386,16 @@ class SQLiteMemoryStore:
             (clamped, agent_id),
         )
         self.connection.commit()
+
+    def get_channel_social_distance(self, channel_id) -> float | None:
+        """Return the social_distance for a channel, or None if not found or unset."""
+        row = self.connection.execute(
+            "SELECT social_distance FROM channels WHERE channel_id = ?",
+            (channel_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return row["social_distance"]
 
     def create_session(self, session_id, title=None, started_at=None, metadata=None):
         created_at = started_at or _utc_now()

--- a/tests/test_circadian.py
+++ b/tests/test_circadian.py
@@ -1,0 +1,241 @@
+"""Tests for circadian phase foundation (issue #73)."""
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import main
+from robits.memory import SQLiteMemoryStore, compute_phase_shift
+
+
+def _make_store():
+    """Return a file-backed SQLiteMemoryStore with a temporary directory."""
+    temp_dir = tempfile.TemporaryDirectory()
+    store = SQLiteMemoryStore(Path(temp_dir.name) / "memory.sqlite3")
+    return store, temp_dir
+
+
+class CircadianSchemaTests(unittest.TestCase):
+    def setUp(self):
+        self.store, self.temp_dir = _make_store()
+
+    def tearDown(self):
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def _agent_columns(self):
+        return {
+            row["name"]
+            for row in self.store.connection.execute("PRAGMA table_info(agents)").fetchall()
+        }
+
+    def _message_columns(self):
+        return {
+            row["name"]
+            for row in self.store.connection.execute("PRAGMA table_info(messages)").fetchall()
+        }
+
+    def test_agents_have_circadian_phase_column(self):
+        self.assertIn("circadian_phase", self._agent_columns())
+
+    def test_messages_have_sender_phase_column(self):
+        self.assertIn("sender_phase", self._message_columns())
+
+
+class AgentPhaseTests(unittest.TestCase):
+    def setUp(self):
+        self.store, self.temp_dir = _make_store()
+        self.store.create_session("s1")
+        self.store.upsert_agent("alice", "Human", "Alice")
+
+    def tearDown(self):
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def test_get_set_agent_phase_round_trip(self):
+        self.store.set_agent_phase("alice", 0.75)
+        self.assertAlmostEqual(self.store.get_agent_phase("alice"), 0.75)
+
+    def test_set_agent_phase_clamps_above_one(self):
+        self.store.set_agent_phase("alice", 1.5)
+        self.assertAlmostEqual(self.store.get_agent_phase("alice"), 1.0)
+
+    def test_set_agent_phase_clamps_below_zero(self):
+        self.store.set_agent_phase("alice", -0.3)
+        self.assertAlmostEqual(self.store.get_agent_phase("alice"), 0.0)
+
+    def test_get_agent_phase_returns_none_for_missing_agent(self):
+        self.assertIsNone(self.store.get_agent_phase("does_not_exist"))
+
+    def test_new_agent_has_default_phase_of_0_5(self):
+        phase = self.store.get_agent_phase("alice")
+        self.assertAlmostEqual(phase, 0.5)
+
+
+class ComputePhaseShiftTests(unittest.TestCase):
+    def test_compute_phase_shift_moves_toward_event(self):
+        # Self contact (distance=0) should fully shift to event_phase.
+        result = compute_phase_shift(0.0, 1.0, 0.0)
+        self.assertAlmostEqual(result, 1.0)
+
+    def test_compute_phase_shift_self_contact_has_full_weight(self):
+        # weight = 1/(0+1) = 1.0 => result = current + 1.0*(event - current) = event
+        result = compute_phase_shift(0.2, 0.8, 0.0)
+        self.assertAlmostEqual(result, 0.8)
+
+    def test_compute_phase_shift_hostile_has_minimal_weight(self):
+        # social_distance=5 => weight = 1/6
+        current, event = 0.0, 0.6
+        expected = 0.0 + (1.0 / 6.0) * (0.6 - 0.0)
+        result = compute_phase_shift(current, event, 5.0)
+        self.assertAlmostEqual(result, expected, places=10)
+
+    def test_compute_phase_shift_clamps_to_unit_interval_high(self):
+        result = compute_phase_shift(0.99, 1.0, 0.0)
+        self.assertLessEqual(result, 1.0)
+
+    def test_compute_phase_shift_clamps_to_unit_interval_low(self):
+        result = compute_phase_shift(0.01, 0.0, 0.0)
+        self.assertGreaterEqual(result, 0.0)
+
+    def test_compute_phase_shift_partial_weight(self):
+        # social_distance=1 => weight = 0.5
+        result = compute_phase_shift(0.0, 1.0, 1.0)
+        self.assertAlmostEqual(result, 0.5)
+
+
+class PhaseMigrationTests(unittest.TestCase):
+    def test_phase_migration_on_legacy_db(self):
+        """A legacy DB without circadian_phase column gets it added on open."""
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        db_path = Path(temp_dir.name) / "legacy.sqlite3"
+
+        # Build a database that looks like the old schema (no circadian_phase).
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """
+            CREATE TABLE agents (
+                agent_id TEXT PRIMARY KEY,
+                role TEXT NOT NULL,
+                display_name TEXT,
+                lifecycle_state TEXT NOT NULL DEFAULT 'active',
+                created_at TEXT NOT NULL,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            CREATE TABLE sessions (
+                session_id TEXT PRIMARY KEY,
+                title TEXT,
+                started_at TEXT NOT NULL,
+                ended_at TEXT,
+                metadata_json TEXT NOT NULL DEFAULT '{}'
+            );
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        # Opening the store should run the migration.
+        store = SQLiteMemoryStore(db_path)
+        self.addCleanup(store.close)
+
+        columns = {
+            row["name"]
+            for row in store.connection.execute("PRAGMA table_info(agents)").fetchall()
+        }
+        self.assertIn("circadian_phase", columns)
+
+        # Verify the column has the correct default (NULL for existing rows,
+        # 0.5 for new inserts via DEFAULT).
+        store.upsert_agent("bot", "Bot", "Bot")
+        phase = store.get_agent_phase("bot")
+        self.assertAlmostEqual(phase, 0.5)
+
+
+class RecordTurnSenderPhaseTests(unittest.TestCase):
+    """Integration: record_turn stamps sender_phase on messages."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db_path = Path(self.temp_dir.name) / "memory.sqlite3"
+        self.store = SQLiteMemoryStore(db_path)
+        self.original_store = main.memory_store
+        self.original_digest_interval = main.memory_digest_interval
+        self.original_org_digest_interval = main.org_digest_interval
+        main.memory_store = self.store
+        main.memory_digest_interval = 0
+        main.org_digest_interval = 0
+
+    def tearDown(self):
+        main.memory_store = self.original_store
+        main.memory_digest_interval = self.original_digest_interval
+        main.org_digest_interval = self.original_org_digest_interval
+        self.store.close()
+        self.temp_dir.cleanup()
+
+    def _make_session(self):
+        participants = {
+            "A": SimpleNamespace(
+                name="A",
+                lifecycle_state="active",
+                interact=lambda *a, **kw: "hello",
+                update_group_conversations=lambda m: None,
+                runtime_tool_results=[],
+            ),
+            "B": SimpleNamespace(
+                name="B",
+                lifecycle_state="active",
+                interact=lambda *a, **kw: "world",
+                update_group_conversations=lambda m: None,
+                runtime_tool_results=[],
+            ),
+        }
+        system = SimpleNamespace(interact=lambda *a, **kw: None)
+        scheduler = main.RoundRobinScheduler(list(participants))
+        return main.Session(
+            participants=participants,
+            system=system,
+            scheduler=scheduler,
+        )
+
+    def test_record_turn_stamps_sender_phase_on_messages(self):
+        session = self._make_session()
+        # Set known phases for agents.
+        self.store.set_agent_phase("A", 0.3)
+        self.store.set_agent_phase("B", 0.7)
+
+        session.record_turn("A", "B", "hello prompt", "world response")
+
+        rows = self.store.connection.execute(
+            "SELECT sender_agent_id, sender_phase FROM messages WHERE session_id = ?",
+            (session.run_id,),
+        ).fetchall()
+        phase_by_sender = {row["sender_agent_id"]: row["sender_phase"] for row in rows}
+
+        # Prompt: sender=A, sender_phase should be A's phase (0.3)
+        self.assertAlmostEqual(phase_by_sender["A"], 0.3)
+        # Response: sender=B, sender_phase should be B's phase (0.7)
+        self.assertAlmostEqual(phase_by_sender["B"], 0.7)
+
+    def test_record_turn_shifts_receiver_phase_when_channel_set(self):
+        session = self._make_session()
+        # Set known phases.
+        self.store.set_agent_phase("A", 0.2)
+        self.store.set_agent_phase("B", 0.8)
+
+        from robits.memory.sqlite import CHANNEL_AGENT_DM
+        ch_id = self.store.get_or_create_channel(
+            CHANNEL_AGENT_DM, participants=["A", "B"], social_distance=1.0
+        )
+        session._org_chat_channel_id = ch_id
+        session.record_turn("A", "B", "hello", "world")
+
+        # Receiver is B; sender is A with phase 0.2. social_distance=1 => weight=0.5
+        # shifted = 0.8 + 0.5*(0.2 - 0.8) = 0.8 - 0.3 = 0.5
+        shifted = self.store.get_agent_phase("B")
+        self.assertAlmostEqual(shifted, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_circadian.py
+++ b/tests/test_circadian.py
@@ -104,6 +104,11 @@ class ComputePhaseShiftTests(unittest.TestCase):
         result = compute_phase_shift(0.0, 1.0, 1.0)
         self.assertAlmostEqual(result, 0.5)
 
+    def test_compute_phase_shift_negative_social_distance_treated_as_zero(self):
+        # negative distance is clamped to 0 => weight = 1.0, so result == event_phase
+        result = compute_phase_shift(0.2, 0.8, -1.0)
+        self.assertAlmostEqual(result, 0.8)
+
 
 class PhaseMigrationTests(unittest.TestCase):
     def test_phase_migration_on_legacy_db(self):


### PR DESCRIPTION
Closes #73

## Summary

- Add `circadian_phase REAL DEFAULT 0.5` column to `agents` via `_ensure_agent_phase_column()` migration
- Add `sender_phase REAL` column to `messages` via `_ensure_message_sender_phase_column()` migration
- Add `get_agent_phase(agent_id)` and `set_agent_phase(agent_id, phase)` (clamps [0, 1])
- Add `compute_phase_shift(current_phase, event_phase, social_distance) -> float` utility
- Wire `record_turn()` in `Session` to stamp `sender_phase` on messages and shift receiver phase via `compute_phase_shift` weighted by channel's `social_distance`
- 14 new tests in `tests/test_circadian.py` covering schema, round-trip, clamping, math, legacy DB migration, and `record_turn` integration

## Test plan

- [ ] `uv run python -m unittest discover -s tests -v` — all 222+ tests pass
- [ ] `compute_phase_shift(0.5, 1.0, SOCIAL_PROFESSIONAL)` returns ~0.6 (weight = 1/4)
- [ ] `set_agent_phase` clamps values outside [0, 1]
- [ ] Legacy DB (no `circadian_phase` or `sender_phase` columns) is migrated on open

🤖 Generated with [Claude Code](https://claude.com/claude-code)