### PR TITLE
Tighten memory digestion and async store parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,13 @@ Relevant environment variables:
 - `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
 - `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.
 - `ROBITS_SEARCH_URL`: optional custom web search endpoint for `builtin.web_search`; falls back to the DuckDuckGo Instant Answers API.
-- `ROBITS_DIGEST_INTERVAL`: turns between automatic episodic digest creation; default `0` (disabled). When enabled, a raw transcript digest is created for every agent after each interval, making conversation history searchable via `memory.search`.
+- `ROBITS_DIGEST_INTERVAL`: turns between automatic episodic digest creation; default `0` (disabled).
+- `ROBITS_DIGEST_CONTEXT_CHARS`: accumulated meaningful prompt/response characters that trigger automatic episodic digestion; default `0` (disabled).
+- `ROBITS_DIGEST_ELAPSED_SECONDS`: elapsed seconds with meaningful activity that trigger automatic episodic digestion; default `0` (disabled).
+- `ROBITS_IDENTITY_DIGEST_INTERVAL`: turns between automatic identity checkpoint digests; default `0` (disabled).
+- `ROBITS_GOAL_DIGEST_INTERVAL`: turns between automatic short-term goal checkpoint digests; default `0` (disabled).
+
+Automatic digest triggers skip silent/passive turns and tool-only runtime artifacts, so model-facing prompt context and operational noise do not bloat stored transcript memory. When enabled, digests are created for every agent and are searchable via `memory.search`.
 
 ## Tools
 

--- a/main.py
+++ b/main.py
@@ -74,6 +74,10 @@ memory_max_depth = max(0, int(os.environ.get("ROBITS_MEMORY_MAX_DEPTH", "3")))
 memory_max_rows = max(1, int(os.environ.get("ROBITS_MEMORY_MAX_ROWS", "100")))
 memory_cache_threshold = max(512, int(os.environ.get("ROBITS_MEMORY_CACHE_THRESHOLD", "8192")))
 memory_digest_interval = max(0, int(os.environ.get("ROBITS_DIGEST_INTERVAL", "0")))
+memory_digest_context_chars = max(0, int(os.environ.get("ROBITS_DIGEST_CONTEXT_CHARS", "0")))
+memory_digest_elapsed_seconds = max(0, int(os.environ.get("ROBITS_DIGEST_ELAPSED_SECONDS", "0")))
+memory_identity_digest_interval = max(0, int(os.environ.get("ROBITS_IDENTITY_DIGEST_INTERVAL", "0")))
+memory_goal_digest_interval = max(0, int(os.environ.get("ROBITS_GOAL_DIGEST_INTERVAL", "0")))
 org_chat_context_lines = max(0, int(os.environ.get("ROBITS_ORG_CHAT_CONTEXT_LINES", "20")))
 org_digest_interval = max(0, int(os.environ.get("ROBITS_ORG_DIGEST_INTERVAL", "0")))
 _reasoning_effort_env = os.environ.get("ROBITS_REASONING_EFFORT", "").strip().lower() or None
@@ -2069,6 +2073,7 @@ class TranscriptEntry:
     response: str
     directed: bool = False
     system_events: list[str] = field(default_factory=list)
+    memory_recorded: bool = False
 
 
 @dataclass
@@ -2178,6 +2183,11 @@ class Session:
         self.event_stream = event_stream if event_stream is not None else RuntimeEventStream()
         self.transcript = []
         self.turns_completed = 0
+        self._last_digest_turn = 0
+        self._last_digest_at = time.monotonic()
+        self._meaningful_turns_completed = 0
+        self._last_identity_digest_meaningful_turn = 0
+        self._last_goal_digest_meaningful_turn = 0
         self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
         # Map role.name → participant dict key for FK-safe persistence.
         self._name_to_key = {getattr(p, "name", k): k for k, p in self.participants.items()}
@@ -2288,6 +2298,8 @@ class Session:
         return message, []
 
     def record_turn(self, sender, receiver, prompt, response, directed=False, system_events=None):
+        meaningful_response = bool(str(response or "").strip())
+        system_events = system_events or []
         entry = TranscriptEntry(
             turn=self.turns_completed + 1,
             sender=sender,
@@ -2295,10 +2307,13 @@ class Session:
             prompt=prompt,
             response=response,
             directed=directed,
-            system_events=system_events or [],
+            system_events=system_events,
+            memory_recorded=meaningful_response,
         )
         self.transcript.append(entry)
         self.turns_completed += 1
+        if meaningful_response:
+            self._meaningful_turns_completed += 1
         self.event_stream.emit(
             "message.recorded",
             self.run_id,
@@ -2316,7 +2331,7 @@ class Session:
             try:
                 sender_phase = memory_store.get_agent_phase(canonical_sender)
                 receiver_phase = memory_store.get_agent_phase(canonical_receiver)
-                if prompt:
+                if meaningful_response and prompt:
                     memory_store.append_message(
                         session_id=self.run_id,
                         sender_agent_id=canonical_sender,
@@ -2326,7 +2341,7 @@ class Session:
                         channel_id=self._org_chat_channel_id,
                         sender_phase=sender_phase,
                     )
-                if response:
+                if meaningful_response and response:
                     memory_store.append_message(
                         session_id=self.run_id,
                         sender_agent_id=canonical_receiver,
@@ -2351,22 +2366,65 @@ class Session:
                         pass
             except Exception:
                 pass
-            if (
-                memory_digest_interval > 0
-                and self.turns_completed % memory_digest_interval == 0
-            ):
-                self._auto_digest()
+            digest_reasons = self._auto_digest_reasons()
+            if digest_reasons:
+                self._auto_digest(digest_reasons)
             if (
                 org_digest_interval > 0
                 and self.turns_completed % org_digest_interval == 0
             ):
                 self._auto_org_digest()
+            if (
+                memory_identity_digest_interval > 0
+                and meaningful_response
+                and self._meaningful_turns_completed - self._last_identity_digest_meaningful_turn
+                >= memory_identity_digest_interval
+            ):
+                self._auto_state_digest("identity")
+                self._last_identity_digest_meaningful_turn = self._meaningful_turns_completed
+            if (
+                memory_goal_digest_interval > 0
+                and meaningful_response
+                and self._meaningful_turns_completed - self._last_goal_digest_meaningful_turn
+                >= memory_goal_digest_interval
+            ):
+                self._auto_state_digest("goal_short_term")
+                self._last_goal_digest_meaningful_turn = self._meaningful_turns_completed
         self._write_org_chat_jsonl(entry)
         return entry
 
-    def _auto_digest(self):
-        """Create a raw transcript digest covering the last memory_digest_interval turns."""
-        window = self.transcript[-memory_digest_interval:]
+    def _auto_digest_reasons(self):
+        reasons = []
+        meaningful_window = [
+            e for e in self.transcript[self._last_digest_turn:]
+            if e.memory_recorded
+        ]
+        if not meaningful_window:
+            return reasons
+        if (
+            memory_digest_interval > 0
+            and self.turns_completed - self._last_digest_turn >= memory_digest_interval
+        ):
+            reasons.append("turn_interval")
+        if memory_digest_context_chars > 0:
+            chars = sum(len(e.prompt or "") + len(e.response or "") for e in meaningful_window)
+            if chars >= memory_digest_context_chars:
+                reasons.append("context_chars")
+        if memory_digest_elapsed_seconds > 0:
+            elapsed = time.monotonic() - self._last_digest_at
+            if elapsed >= memory_digest_elapsed_seconds:
+                reasons.append("elapsed_seconds")
+        return reasons
+
+    def _auto_digest(self, reasons=None):
+        """Create a raw transcript digest covering meaningful turns since the last digest."""
+        if memory_digest_interval > 0 and not reasons:
+            window = [e for e in self.transcript[-memory_digest_interval:] if e.memory_recorded]
+        else:
+            window = [
+                e for e in self.transcript[self._last_digest_turn:]
+                if e.memory_recorded
+            ]
         lines = []
         for e in window:
             if e.prompt:
@@ -2379,7 +2437,7 @@ class Session:
         source_refs = []
         try:
             msg_ids = memory_store.list_recent_message_ids(
-                self.run_id, memory_digest_interval * 2
+                self.run_id, max(2, len(window) * 2)
             )
             source_refs = [
                 {"source_table": "messages", "source_id": mid}
@@ -2399,9 +2457,50 @@ class Session:
                     digest_type="episodic",
                     accessibility="agent",
                     system_only=False,
+                    metadata={"trigger_reasons": list(reasons or ["turn_interval"])},
                 )
+            self._last_digest_turn = self.turns_completed
+            self._last_digest_at = time.monotonic()
         except Exception:
             pass
+
+    def _auto_state_digest(self, digest_type):
+        if memory_store is None:
+            return
+        source_refs = []
+        try:
+            msg_ids = memory_store.list_recent_message_ids(
+                self.run_id,
+                max(2, memory_digest_interval * 2 or 10),
+            )
+            source_refs = [{"source_table": "messages", "source_id": mid} for mid in msg_ids]
+        except Exception:
+            return
+        if not source_refs:
+            return
+        label = "identity" if digest_type == "identity" else "short-term goal"
+        window = [e for e in self.transcript if e.memory_recorded][-10:]
+        content_lines = [
+            f"[turn {e.turn}] {e.sender}->{e.receiver}: {e.response[:300]}"
+            for e in window
+            if e.response
+        ]
+        if not content_lines:
+            return
+        for agent_id in list(self.participants):
+            try:
+                memory_store.append_memory_digest(
+                    content=f"Automatic {label} checkpoint:\n" + "\n".join(content_lines),
+                    source_refs=source_refs,
+                    agent_id=agent_id,
+                    session_id=self.run_id,
+                    digest_type=digest_type,
+                    accessibility="agent",
+                    system_only=False,
+                    metadata={"trigger_reasons": [f"{digest_type}_interval"]},
+                )
+            except Exception:
+                pass
 
     def _write_org_chat_jsonl(self, entry):
         if self._org_workspace is None:
@@ -2425,7 +2524,10 @@ class Session:
         lines = [
             f"[turn {e.turn}] {e.sender}->{e.receiver}: {e.prompt[:300]} | {e.response[:300]}"
             for e in window
+            if e.memory_recorded
         ]
+        if not lines:
+            return
         content = "Org chat digest:\n" + "\n".join(lines)
         source_refs = []
         try:

--- a/robits/memory/__init__.py
+++ b/robits/memory/__init__.py
@@ -1,6 +1,7 @@
 """SQLite-backed memory storage for Robits."""
 
 from .async_sqlite import AsyncSQLiteMemoryStore
+from .protocols import AsyncMemoryStoreProtocol, MemoryStoreProtocol
 from .sqlite import (
     CHANNEL_AGENT_DM,
     CHANNEL_AGENT_THOUGHT,
@@ -24,6 +25,7 @@ from .sqlite import (
 
 __all__ = [
     "AsyncSQLiteMemoryStore",
+    "AsyncMemoryStoreProtocol",
     "CHANNEL_AGENT_DM",
     "CHANNEL_AGENT_THOUGHT",
     "CHANNEL_FAMILY_GROUP",
@@ -40,6 +42,7 @@ __all__ = [
     "SOCIAL_UNKNOWN",
     "MemoryDigestSource",
     "MemorySearchResult",
+    "MemoryStoreProtocol",
     "SQLiteMemoryStore",
     "compute_phase_shift",
 ]

--- a/robits/memory/protocols.py
+++ b/robits/memory/protocols.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class MemoryStoreProtocol(Protocol):
+    """Synchronous memory store interface used by the runtime."""
+
+    def close(self): ...
+    def ensure_schema(self): ...
+    def create_session(self, session_id, title=None, started_at=None, metadata=None): ...
+    def end_session(self, session_id, ended_at=None): ...
+    def upsert_agent(
+        self,
+        agent_id,
+        role,
+        display_name=None,
+        lifecycle_state="active",
+        created_at=None,
+        metadata=None,
+    ): ...
+    def add_contact(
+        self,
+        owner_agent_id,
+        contact_agent_id,
+        relationship_type,
+        notes=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    def get_or_create_channel(
+        self,
+        channel_type,
+        participants=None,
+        *,
+        visibility="public",
+        social_distance=None,
+        clock_phase_hint=None,
+        memory_policy="default",
+        digest_policy="default",
+        prompt_injection_policy="default",
+        metadata=None,
+        created_at=None,
+    ): ...
+    def list_channels(self, channel_type=None, participant=None, limit=100): ...
+    def get_agent_phase(self, agent_id) -> float | None: ...
+    def set_agent_phase(self, agent_id, phase: float) -> None: ...
+    def get_channel_social_distance(self, channel_id) -> float | None: ...
+    def append_message(
+        self,
+        session_id,
+        sender_agent_id,
+        receiver_agent_id,
+        content,
+        kind="message",
+        visibility="public",
+        relationship_type=None,
+        channel_id=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+        sender_phase=None,
+    ): ...
+    def append_thought(
+        self,
+        agent_id,
+        content,
+        session_id=None,
+        visibility="private",
+        relationship_type=None,
+        channel_id=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    def append_todo(
+        self,
+        agent_id,
+        title,
+        session_id=None,
+        status="open",
+        content=None,
+        due_at=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    def append_tool_call(
+        self,
+        tool_call_id,
+        agent_id,
+        tool_name,
+        arguments=None,
+        result_content=None,
+        status="requested",
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    def append_memory_entry(
+        self,
+        kind,
+        content,
+        agent_id=None,
+        session_id=None,
+        source_table=None,
+        source_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    def append_memory_digest(
+        self,
+        content,
+        source_refs,
+        agent_id=None,
+        session_id=None,
+        digest_type="episodic",
+        generation=None,
+        version=1,
+        supersedes_digest_ids=None,
+        system_only=False,
+        accessibility=None,
+        prompt_version="memory-digest-v1",
+        source_start_at=None,
+        source_end_at=None,
+        relationship_type=None,
+        conversation_type=None,
+        source="digest",
+        created_at=None,
+        metadata=None,
+    ): ...
+    def append_runtime_event(
+        self,
+        session_id,
+        event_type,
+        payload=None,
+        visibility="public",
+        sequence=None,
+        created_at=None,
+    ): ...
+    def append_runtime_event_object(self, event): ...
+    def seed_memory_digest(
+        self,
+        digest_type,
+        content,
+        agent_id=None,
+        session_id=None,
+        prompt_version="memory-digest-seed-v1",
+        source="system_seed",
+        created_at=None,
+        metadata=None,
+        system_only=False,
+        accessibility=None,
+        relationship_type=None,
+    ): ...
+    def seed_identity_and_goal_digests(
+        self,
+        agent_id,
+        identity_content,
+        long_term_goal_content,
+        short_term_goal_content=None,
+        session_id=None,
+        created_at=None,
+        metadata=None,
+        identity_relationship_type=None,
+    ): ...
+    def list_recent_message_ids(self, session_id, limit): ...
+    def list_recent_message_ids_by_channel(self, session_id, limit, channel_id): ...
+    def list_todos(self, agent_id=None, session_id=None, status=None, limit=100): ...
+    def list_runtime_events(self, session_id=None, event_type=None, visibility=None, limit=100): ...
+    def get_memory_digest(self, digest_id): ...
+    def get_memory_digest_sources(self, digest_id): ...
+    def expand_memory_digest_sources(
+        self,
+        digest_id,
+        recursive=False,
+        include_digest_records=True,
+        max_depth=None,
+    ): ...
+    def expand_memory_digest_source_tree(self, digest_id): ...
+    def list_memory_digests(
+        self,
+        agent_id=None,
+        session_id=None,
+        digest_type=None,
+        current_only=False,
+        accessible_only=False,
+        include_system_only=True,
+        limit=100,
+        relationship_type=None,
+    ): ...
+    def list_messages(self, session_id=None, agent_id=None, limit=100): ...
+    def list_agent_records(self, agent_id, limit=100): ...
+    def search(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ): ...
+    def search_cascade(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ): ...
+
+
+@runtime_checkable
+class AsyncMemoryStoreProtocol(Protocol):
+    """Async equivalent of MemoryStoreProtocol.
+
+    Implementations should accept the same arguments as the sync store and
+    return awaitable equivalents.
+    """
+
+    async def close(self): ...
+    async def ensure_schema(self): ...
+    async def create_session(self, session_id, title=None, started_at=None, metadata=None): ...
+    async def end_session(self, session_id, ended_at=None): ...
+    async def upsert_agent(
+        self,
+        agent_id,
+        role,
+        display_name=None,
+        lifecycle_state="active",
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def add_contact(
+        self,
+        owner_agent_id,
+        contact_agent_id,
+        relationship_type,
+        notes=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def get_or_create_channel(
+        self,
+        channel_type,
+        participants=None,
+        *,
+        visibility="public",
+        social_distance=None,
+        clock_phase_hint=None,
+        memory_policy="default",
+        digest_policy="default",
+        prompt_injection_policy="default",
+        metadata=None,
+        created_at=None,
+    ): ...
+    async def list_channels(self, channel_type=None, participant=None, limit=100): ...
+    async def get_agent_phase(self, agent_id) -> float | None: ...
+    async def set_agent_phase(self, agent_id, phase: float) -> None: ...
+    async def get_channel_social_distance(self, channel_id) -> float | None: ...
+    async def append_message(
+        self,
+        session_id,
+        sender_agent_id,
+        receiver_agent_id,
+        content,
+        kind="message",
+        visibility="public",
+        relationship_type=None,
+        channel_id=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+        sender_phase=None,
+    ): ...
+    async def append_thought(
+        self,
+        agent_id,
+        content,
+        session_id=None,
+        visibility="private",
+        relationship_type=None,
+        channel_id=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def append_todo(
+        self,
+        agent_id,
+        title,
+        session_id=None,
+        status="open",
+        content=None,
+        due_at=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def append_tool_call(
+        self,
+        tool_call_id,
+        agent_id,
+        tool_name,
+        arguments=None,
+        result_content=None,
+        status="requested",
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def append_memory_entry(
+        self,
+        kind,
+        content,
+        agent_id=None,
+        session_id=None,
+        source_table=None,
+        source_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def append_memory_digest(
+        self,
+        content,
+        source_refs,
+        agent_id=None,
+        session_id=None,
+        digest_type="episodic",
+        generation=None,
+        version=1,
+        supersedes_digest_ids=None,
+        system_only=False,
+        accessibility=None,
+        prompt_version="memory-digest-v1",
+        source_start_at=None,
+        source_end_at=None,
+        relationship_type=None,
+        conversation_type=None,
+        source="digest",
+        created_at=None,
+        metadata=None,
+    ): ...
+    async def append_runtime_event(
+        self,
+        session_id,
+        event_type,
+        payload=None,
+        visibility="public",
+        sequence=None,
+        created_at=None,
+    ): ...
+    async def append_runtime_event_object(self, event): ...
+    async def seed_memory_digest(
+        self,
+        digest_type,
+        content,
+        agent_id=None,
+        session_id=None,
+        prompt_version="memory-digest-seed-v1",
+        source="system_seed",
+        created_at=None,
+        metadata=None,
+        system_only=False,
+        accessibility=None,
+        relationship_type=None,
+    ): ...
+    async def seed_identity_and_goal_digests(
+        self,
+        agent_id,
+        identity_content,
+        long_term_goal_content,
+        short_term_goal_content=None,
+        session_id=None,
+        created_at=None,
+        metadata=None,
+        identity_relationship_type=None,
+    ): ...
+    async def list_recent_message_ids(self, session_id, limit): ...
+    async def list_recent_message_ids_by_channel(self, session_id, limit, channel_id): ...
+    async def list_todos(self, agent_id=None, session_id=None, status=None, limit=100): ...
+    async def list_runtime_events(self, session_id=None, event_type=None, visibility=None, limit=100): ...
+    async def get_memory_digest(self, digest_id): ...
+    async def get_memory_digest_sources(self, digest_id): ...
+    async def expand_memory_digest_sources(
+        self,
+        digest_id,
+        recursive=False,
+        include_digest_records=True,
+        max_depth=None,
+    ): ...
+    async def expand_memory_digest_source_tree(self, digest_id): ...
+    async def list_memory_digests(
+        self,
+        agent_id=None,
+        session_id=None,
+        digest_type=None,
+        current_only=False,
+        accessible_only=False,
+        include_system_only=True,
+        limit=100,
+        relationship_type=None,
+    ): ...
+    async def list_messages(self, session_id=None, agent_id=None, limit=100): ...
+    async def list_agent_records(self, agent_id, limit=100): ...
+    async def search(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ): ...
+    async def search_cascade(
+        self,
+        query,
+        agent_id=None,
+        session_id=None,
+        relationship_type=None,
+        conversation_type=None,
+        source=None,
+        start_at=None,
+        end_at=None,
+        limit=20,
+    ): ...

--- a/tests/test_async_memory_store.py
+++ b/tests/test_async_memory_store.py
@@ -4,7 +4,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from robits.memory import AsyncSQLiteMemoryStore, SQLiteMemoryStore
+from robits.memory import (
+    AsyncMemoryStoreProtocol,
+    AsyncSQLiteMemoryStore,
+    MemoryStoreProtocol,
+    SQLiteMemoryStore,
+)
 
 
 class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
@@ -154,6 +159,81 @@ class AsyncSQLiteMemoryStoreTests(unittest.IsolatedAsyncioTestCase):
             if not name.startswith("_")
         }
         self.assertTrue(sync_public.issubset(async_public))
+
+    async def test_async_store_public_api_accepts_sync_store_parameters(self):
+        for name, sync_member in inspect.getmembers(SQLiteMemoryStore, inspect.isfunction):
+            if name.startswith("_"):
+                continue
+            async_member = getattr(AsyncSQLiteMemoryStore, name)
+            sync_params = inspect.signature(sync_member).parameters
+            async_params = inspect.signature(async_member).parameters
+            has_var_kwargs = any(
+                param.kind == inspect.Parameter.VAR_KEYWORD
+                for param in async_params.values()
+            )
+            missing = [
+                param_name for param_name in sync_params
+                if param_name != "self" and param_name not in async_params
+            ]
+            self.assertFalse(
+                missing and not has_var_kwargs,
+                f"{name} missing parameters: {missing}",
+            )
+            required_extra = [
+                param_name for param_name, param in async_params.items()
+                if (
+                    param_name not in sync_params
+                    and param_name != "self"
+                    and param.default is inspect.Parameter.empty
+                    and param.kind
+                    in {
+                        inspect.Parameter.POSITIONAL_ONLY,
+                        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                        inspect.Parameter.KEYWORD_ONLY,
+                    }
+                )
+            ]
+            self.assertFalse(
+                required_extra,
+                f"{name} has required extra parameters: {required_extra}",
+            )
+
+    async def test_memory_store_protocols_match_concrete_stores(self):
+        store = await self.seed_store()
+        sync_store = SQLiteMemoryStore(store.path)
+        self.addCleanup(sync_store.close)
+
+        self.assertIsInstance(sync_store, MemoryStoreProtocol)
+        self.assertIsInstance(store, AsyncMemoryStoreProtocol)
+
+    async def test_protocols_spell_out_key_memory_method_signatures(self):
+        key_methods = {
+            "append_message",
+            "append_thought",
+            "append_todo",
+            "append_tool_call",
+            "append_memory_entry",
+            "append_memory_digest",
+            "append_runtime_event",
+            "seed_memory_digest",
+            "seed_identity_and_goal_digests",
+            "list_memory_digests",
+            "search",
+            "search_cascade",
+        }
+        for protocol in (MemoryStoreProtocol, AsyncMemoryStoreProtocol):
+            for name in key_methods:
+                params = inspect.signature(getattr(protocol, name)).parameters.values()
+                wildcard_params = {
+                    param.kind
+                    for param in params
+                    if param.kind
+                    in {
+                        inspect.Parameter.VAR_POSITIONAL,
+                        inspect.Parameter.VAR_KEYWORD,
+                    }
+                }
+                self.assertFalse(wildcard_params, f"{protocol.__name__}.{name} uses wildcards")
 
     async def test_async_channel_create_and_list(self):
         from robits.memory.sqlite import CHANNEL_AGENT_DM, SOCIAL_FRIENDLY

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2381,13 +2381,25 @@ class SessionMemoryCaptureTests(unittest.TestCase):
 
         self.original_store = main.memory_store
         self.original_digest_interval = main.memory_digest_interval
+        self.original_digest_context_chars = main.memory_digest_context_chars
+        self.original_digest_elapsed_seconds = main.memory_digest_elapsed_seconds
+        self.original_identity_digest_interval = main.memory_identity_digest_interval
+        self.original_goal_digest_interval = main.memory_goal_digest_interval
         main.memory_store = self.store
         main.memory_digest_interval = 0
+        main.memory_digest_context_chars = 0
+        main.memory_digest_elapsed_seconds = 0
+        main.memory_identity_digest_interval = 0
+        main.memory_goal_digest_interval = 0
         self.addCleanup(self._restore)
 
     def _restore(self):
         main.memory_store = self.original_store
         main.memory_digest_interval = self.original_digest_interval
+        main.memory_digest_context_chars = self.original_digest_context_chars
+        main.memory_digest_elapsed_seconds = self.original_digest_elapsed_seconds
+        main.memory_identity_digest_interval = self.original_identity_digest_interval
+        main.memory_goal_digest_interval = self.original_goal_digest_interval
 
     def _make_session(self):
         # "SE" key with name="SoftwareEngineer" exercises key≠name FK resolution.
@@ -2447,6 +2459,15 @@ class SessionMemoryCaptureTests(unittest.TestCase):
         ).fetchone()
         self.assertEqual(rows["n"], 0)
 
+    def test_passive_turn_prompt_not_persisted_as_memory_message(self):
+        session = self._make_session()
+        session.record_turn("A", "SE", "already expressed prompt", "")
+        rows = self.store.connection.execute(
+            "SELECT COUNT(*) AS n FROM messages WHERE session_id = ?", (session.run_id,)
+        ).fetchone()
+        self.assertEqual(rows["n"], 0)
+        self.assertFalse(session.transcript[-1].memory_recorded)
+
     def test_thought_is_persisted(self):
         session = self._make_session()
         session.record_thought("A", "my private thought")
@@ -2484,6 +2505,68 @@ class SessionMemoryCaptureTests(unittest.TestCase):
             "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
         ).fetchall()
         self.assertEqual(len(rows), 0)
+
+    def test_auto_digest_fires_on_context_char_threshold(self):
+        main.memory_digest_context_chars = 20
+        session = self._make_session()
+        session.record_turn("A", "SE", "short", "this response is long enough")
+        rows = self.store.connection.execute(
+            "SELECT metadata_json FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertGreater(len(rows), 0)
+        self.assertIn("context_chars", rows[0]["metadata_json"])
+
+    def test_auto_digest_fires_on_elapsed_activity_threshold(self):
+        main.memory_digest_elapsed_seconds = 1
+        session = self._make_session()
+        session._last_digest_at -= 2
+        session.record_turn("A", "SE", "elapsed prompt", "elapsed response")
+        rows = self.store.connection.execute(
+            "SELECT metadata_json FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertGreater(len(rows), 0)
+        self.assertIn("elapsed_seconds", rows[0]["metadata_json"])
+
+    def test_passive_turn_does_not_trigger_auto_digest(self):
+        main.memory_digest_context_chars = 1
+        session = self._make_session()
+        session.record_turn("A", "SE", "large but passive prompt", "")
+        rows = self.store.connection.execute(
+            "SELECT digest_id FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertEqual(len(rows), 0)
+
+    def test_identity_and_goal_interval_digests_fire(self):
+        main.memory_identity_digest_interval = 1
+        main.memory_goal_digest_interval = 1
+        session = self._make_session()
+        session.record_turn("A", "SE", "identity prompt", "goal response")
+        rows = self.store.connection.execute(
+            "SELECT digest_type FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        digest_types = {row["digest_type"] for row in rows}
+        self.assertIn("identity", digest_types)
+        self.assertIn("goal_short_term", digest_types)
+
+    def test_passive_turn_does_not_advance_identity_or_goal_checkpoint_intervals(self):
+        main.memory_identity_digest_interval = 2
+        main.memory_goal_digest_interval = 2
+        session = self._make_session()
+        session.record_turn("A", "SE", "first meaningful prompt", "first response")
+        session.record_turn("A", "SE", "passive prompt", "")
+        rows = self.store.connection.execute(
+            "SELECT digest_type FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        self.assertNotIn("identity", {row["digest_type"] for row in rows})
+        self.assertNotIn("goal_short_term", {row["digest_type"] for row in rows})
+
+        session.record_turn("A", "SE", "second meaningful prompt", "second response")
+        rows = self.store.connection.execute(
+            "SELECT digest_type FROM memory_digests WHERE session_id = ?", (session.run_id,)
+        ).fetchall()
+        digest_types = {row["digest_type"] for row in rows}
+        self.assertIn("identity", digest_types)
+        self.assertIn("goal_short_term", digest_types)
 
     def test_mismatched_key_name_uses_participant_key_for_messages(self):
         """SE key with role.name='SoftwareEngineer' must persist under key 'SE'."""


### PR DESCRIPTION
## Summary

- avoid storing silent/passive turns as memory messages, so wait/tool-only turns do not bloat transcript memory
- add additional automatic digest triggers for accumulated context characters, elapsed meaningful activity, identity checkpoints, and short-term goal checkpoints
- record digest trigger reasons in digest metadata and document the new environment knobs
- add sync/async memory store Protocols and strengthen AsyncSQLiteMemoryStore parity tests to catch missing or incompatible public method parameters

## Issue Coverage

- Closes #65
- Closes #72
- Advances #45 by broadening live-session automatic digestion and keeping operational/passive artifacts out of message memory. The larger future work around richer re-digestion policy can remain separately scoped if needed.

## Validation

- `PYTHONPATH=/tmp/robits-deps python3 -m py_compile main.py robits/memory/async_sqlite.py robits/memory/sqlite.py robits/memory/protocols.py tests/test_async_memory_store.py tests/test_runtime.py`
- `PYTHONPATH=/tmp/robits-deps timeout 60 python3 -m unittest -v tests.test_runtime.SessionMemoryCaptureTests tests.test_runtime.OrgChatReadToolFixTests tests.test_runtime.OrgDigestTests`
- `PYTHONPATH=/tmp/robits-deps timeout 60 python3 -m unittest -v tests.test_async_memory_store` (run outside sandbox because `aiosqlite` worker threads hang under the sandbox)
- `PYTHONPATH=/tmp/robits-deps OPENAI_BASE_URL=http://127.0.0.1:11434/v1 OPENAI_API_KEY=ollama ROBITS_MODEL=granite4.1:3b ROBITS_PROVIDER_API=chat_completions timeout 90 python3 main.py --prompt "Ops, reply with one short sentence." --turns 1`
- `git diff --check`

Note: full `python3 -m unittest` hit a 120s timeout in this environment without progress output, so validation focused on the changed areas plus an Ollama smoke.