### PR TITLE
feat: grant web search by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ as client-side function tools that work with any OpenAI-compatible endpoint:
 | `builtin.computer_use` | Computer-use actions (not implemented) | `computer` |
 | `builtin.image_generation` | Generate images (not implemented) | — |
 
-All `builtin.*` tools are grantable. None are in the default tool grants; operators
-grant access explicitly via `tools.grant`.
+All `builtin.*` tools are grantable. `builtin.web_search` is in the default tool
+grants so agents can satisfy ordinary public lookup requests; operators grant
+access to other built-ins explicitly via `tools.grant`.
 
 Example execution payload:
 

--- a/main.py
+++ b/main.py
@@ -1889,7 +1889,13 @@ Only say that you created, changed, or called a tool after the runtime has retur
         self.lifecycle_state = "active"
         self.lifecycle_events = []
         self.capabilities = set()
-        self.allowed_tools = {"agent.*", "memory.search", "memory.list_digests", "memory.expand_digest"}
+        self.allowed_tools = {
+            "agent.*",
+            "builtin.web_search",
+            "memory.search",
+            "memory.list_digests",
+            "memory.expand_digest",
+        }
         self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
         self.runtime_event_stream = None

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -665,6 +665,7 @@ class RuntimeTests(unittest.TestCase):
 
         tool_names = {tool["name"] for tool in fake_client.responses.create.calls[0]["tools"]}
         self.assertIn("tools__propose", tool_names)
+        self.assertIn("builtin__web_search", tool_names)
         self.assertNotIn("org__create_role", tool_names)
 
     def test_disallowed_tool_call_is_rejected_at_runtime(self):


### PR DESCRIPTION
## Summary

- Default-grant `builtin.web_search` to regular roles alongside existing agent and memory tools.
- Update the Responses-provider exposure test so default web search is visible to model tool selection.
- Document that other built-ins still require explicit operator grants.

## Why

Local Ollama testing showed the team could not progress from a public lookup request unless a useful lookup tool was already exposed. This PR keeps the change narrow: safe public web search becomes generally available, while shell/MCP/computer-use tools remain explicitly gated.

## Validation

```sh
source /home/marques/src/robits/.venv/bin/activate && python3 -m unittest -v tests.test_runtime.RuntimeTests.test_responses_provider_exposes_only_role_allowed_tools tests.test_runtime.BuiltinToolTests.test_tool_search_finds_tools_by_name_fragment
```
