### PR TITLE
feat: improve tool use with trusted weather lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ as client-side function tools that work with any OpenAI-compatible endpoint:
 | Tool | Description | Capability required |
 |---|---|---|
 | `builtin.web_search` | Search the web via DuckDuckGo or `ROBITS_SEARCH_URL` | — |
+| `builtin.weather_lookup` | Look up a current US ZIP-code forecast via public no-key APIs | — |
 | `builtin.file_search` | Search text in an agent's private workspace files | — |
 | `builtin.shell_run` | Run a shell command in the agent's workspace directory | `shell` |
 | `builtin.tool_search` | Search the tool registry by name or description | — |
@@ -140,8 +141,9 @@ as client-side function tools that work with any OpenAI-compatible endpoint:
 | `builtin.computer_use` | Computer-use actions (not implemented) | `computer` |
 | `builtin.image_generation` | Generate images (not implemented) | — |
 
-All `builtin.*` tools are grantable. None are in the default tool grants; operators
-grant access explicitly via `tools.grant`.
+All `builtin.*` tools are grantable. `builtin.weather_lookup` is in the default
+tool grants so agents can satisfy common weather lookup requests; operators
+grant access to other built-ins explicitly via `tools.grant`.
 
 Example execution payload:
 

--- a/main.py
+++ b/main.py
@@ -220,6 +220,7 @@ class ToolRegistry:
                 "workspace_delete": workspace_delete,
                 "current_agent_context": current_agent_context,
                 "builtin_web_search": builtin_web_search,
+                "builtin_weather_lookup": builtin_weather_lookup,
                 "builtin_file_search": builtin_file_search,
                 "builtin_shell_run": builtin_shell_run,
                 "builtin_tool_search": builtin_tool_search,
@@ -1693,6 +1694,73 @@ def builtin_web_search(employee_dict, query, num_results=5):
     return json.dumps(results[:n], sort_keys=True)
 
 
+def _fetch_json_url(url, headers=None, timeout=15):
+    import urllib.request
+    req = urllib.request.Request(url, headers=headers or {"User-Agent": "robits/1.0"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode())
+
+
+def builtin_weather_lookup(employee_dict, zipcode, country="US", date=None):
+    del employee_dict, date
+    zipcode = str(zipcode or "").strip()
+    country = str(country or "US").strip().lower()
+    if not zipcode:
+        return "Error: ZIP/postal code must be provided."
+    if country not in {"us", "usa"}:
+        return "Error: builtin.weather_lookup currently supports US ZIP codes only."
+    try:
+        import urllib.parse
+        zip_url = f"https://api.zippopotam.us/us/{urllib.parse.quote(zipcode)}"
+        zip_data = _fetch_json_url(zip_url)
+        places = zip_data.get("places") or []
+        if not places:
+            return f"Error: No location found for ZIP code {zipcode}."
+        place = places[0]
+        latitude = float(place["latitude"])
+        longitude = float(place["longitude"])
+        location = ", ".join(
+            part
+            for part in [
+                place.get("place name"),
+                place.get("state abbreviation") or place.get("state"),
+            ]
+            if part
+        )
+        nws_headers = {
+            "Accept": "application/geo+json",
+            "User-Agent": "robits/1.0 (weather lookup; contact unavailable)",
+        }
+        points = _fetch_json_url(
+            f"https://api.weather.gov/points/{latitude:.4f},{longitude:.4f}",
+            headers=nws_headers,
+        )
+        forecast_url = (points.get("properties") or {}).get("forecast")
+        if not forecast_url:
+            return f"Error: Weather.gov did not provide a forecast URL for ZIP code {zipcode}."
+        forecast = _fetch_json_url(forecast_url, headers=nws_headers)
+        periods = (forecast.get("properties") or {}).get("periods") or []
+        if not periods:
+            return f"Error: Weather.gov returned no forecast periods for ZIP code {zipcode}."
+        period = periods[0]
+        result = {
+            "zipcode": zipcode,
+            "location": location,
+            "source": "weather.gov",
+            "period": period.get("name"),
+            "start_time": period.get("startTime"),
+            "temperature": period.get("temperature"),
+            "temperature_unit": period.get("temperatureUnit"),
+            "wind_speed": period.get("windSpeed"),
+            "wind_direction": period.get("windDirection"),
+            "short_forecast": period.get("shortForecast"),
+            "detailed_forecast": period.get("detailedForecast"),
+        }
+        return json.dumps(result, sort_keys=True)
+    except Exception as exc:
+        return f"Error: Weather lookup failed: {exc}"
+
+
 def builtin_file_search(employee_dict, agent_name, query, path="", max_results=10):
     del employee_dict
     if not isinstance(query, str) or not query.strip():
@@ -1889,7 +1957,13 @@ Only say that you created, changed, or called a tool after the runtime has retur
         self.lifecycle_state = "active"
         self.lifecycle_events = []
         self.capabilities = set()
-        self.allowed_tools = {"agent.*", "memory.search", "memory.list_digests", "memory.expand_digest"}
+        self.allowed_tools = {
+            "agent.*",
+            "builtin.weather_lookup",
+            "memory.search",
+            "memory.list_digests",
+            "memory.expand_digest",
+        }
         self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
         self.runtime_event_stream = None

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -41,6 +41,20 @@ class FakeCreate:
         return self.responses.pop(0)
 
 
+class FakeHTTPResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
 class RecordingStream:
     def __init__(self):
         self.content = ""
@@ -665,6 +679,7 @@ class RuntimeTests(unittest.TestCase):
 
         tool_names = {tool["name"] for tool in fake_client.responses.create.calls[0]["tools"]}
         self.assertIn("tools__propose", tool_names)
+        self.assertIn("builtin__weather_lookup", tool_names)
         self.assertNotIn("org__create_role", tool_names)
 
     def test_disallowed_tool_call_is_rejected_at_runtime(self):
@@ -2036,6 +2051,61 @@ class BuiltinToolTests(unittest.TestCase):
             main.builtin_search_url = original
         self.assertTrue(result.startswith("Error:"))
 
+    # ── builtin.weather_lookup ───────────────────────────────────────────────
+
+    def test_weather_lookup_validates_zipcode(self):
+        result = main.builtin_weather_lookup({}, "")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_weather_lookup_returns_current_forecast(self):
+        def fake_urlopen(request, timeout=15):
+            url = request.full_url
+            if url == "https://api.zippopotam.us/us/08234":
+                return FakeHTTPResponse(
+                    {
+                        "places": [
+                            {
+                                "place name": "Egg Harbor Township",
+                                "state abbreviation": "NJ",
+                                "latitude": "39.3965",
+                                "longitude": "-74.5699",
+                            }
+                        ]
+                    }
+                )
+            if url == "https://api.weather.gov/points/39.3965,-74.5699":
+                return FakeHTTPResponse({"properties": {"forecast": "https://api.weather.gov/gridpoints/PHI/48,37/forecast"}})
+            if url == "https://api.weather.gov/gridpoints/PHI/48,37/forecast":
+                return FakeHTTPResponse(
+                    {
+                        "properties": {
+                            "periods": [
+                                {
+                                    "name": "Tonight",
+                                    "startTime": "2026-05-09T18:00:00-04:00",
+                                    "temperature": 55,
+                                    "temperatureUnit": "F",
+                                    "windSpeed": "5 mph",
+                                    "windDirection": "E",
+                                    "shortForecast": "Mostly Clear",
+                                    "detailedForecast": "Mostly clear, with a low around 55.",
+                                }
+                            ]
+                        }
+                    }
+                )
+            raise AssertionError(f"Unexpected URL: {url}")
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            result_json = main.builtin_weather_lookup({}, "08234")
+
+        result = json.loads(result_json)
+        self.assertEqual(result["zipcode"], "08234")
+        self.assertEqual(result["location"], "Egg Harbor Township, NJ")
+        self.assertEqual(result["source"], "weather.gov")
+        self.assertEqual(result["temperature"], 55)
+        self.assertEqual(result["short_forecast"], "Mostly Clear")
+
     # ── builtin.file_search ──────────────────────────────────────────────────
 
     def test_file_search_finds_text_in_workspace_file(self):
@@ -2141,6 +2211,7 @@ class BuiltinToolTests(unittest.TestCase):
             sorted(builtin_names),
             sorted([
                 "builtin.web_search",
+                "builtin.weather_lookup",
                 "builtin.file_search",
                 "builtin.shell_run",
                 "builtin.tool_search",

--- a/tools.yaml
+++ b/tools.yaml
@@ -727,6 +727,31 @@
       - query
   code: |
     return builtin_web_search(employee_dict, query, num_results=num_results if num_results is not None else 5)
+- name: builtin.weather_lookup
+  grantable: true
+  owner_capability: agent
+  description: Look up a current US ZIP-code forecast using public no-key weather APIs.
+  parameters:
+    type: object
+    properties:
+      zipcode:
+        type: string
+        description: US ZIP code, for example "08234".
+      country:
+        type: string
+        description: Country code; currently only US is supported.
+      date:
+        type: string
+        description: Optional requested date in YYYY-MM-DD form. The current forecast period is returned.
+    required:
+      - zipcode
+  code: |
+    return builtin_weather_lookup(
+        employee_dict,
+        zipcode,
+        country=country if country is not None else "US",
+        date=date,
+    )
 - name: builtin.file_search
   grantable: true
   owner_capability: agent


### PR DESCRIPTION
## Summary

- Add a trusted `builtin.weather_lookup` tool backed by public no-key ZIP/location and Weather.gov forecast APIs.
- Default-grant that safe lookup tool so agents can select it when a weather need appears.
- Cover the tool with unit tests for validation, YAML registration, and Responses-provider exposure.

## Why

This is framed as a tool-use behavior improvement, not just a weather feature. The local Ollama runs showed three stages:

1. With no relevant tool exposed, the team repeated capability denials.
2. With only generic web search exposed, SE selected a tool but DuckDuckGo Instant Answers returned no useful result for ZIP `08234`.
3. With a trusted weather lookup tool available, SE selected `builtin.weather_lookup({"zipcode":"08234"})`, the runtime returned verified Weather.gov data, and the team reported the forecast.

The branch keeps executable tool creation trusted and repo-owned: agents cannot define arbitrary executable code from chat, but a concrete unmet need can become a trusted registered tool that the team can then discover, call, and use in the conversation.

## Validation

```sh
source /home/marques/src/robits/.venv/bin/activate && python3 -m py_compile main.py tests/test_runtime.py
source /home/marques/src/robits/.venv/bin/activate && python3 -m unittest -v tests.test_runtime.RuntimeTests.test_responses_provider_exposes_only_role_allowed_tools tests.test_runtime.RuntimeTests.test_disallowed_tool_call_is_rejected_at_runtime tests.test_runtime.BuiltinToolTests.test_weather_lookup_validates_zipcode tests.test_runtime.BuiltinToolTests.test_weather_lookup_returns_current_forecast tests.test_runtime.BuiltinToolTests.test_builtin_tools_load_from_yaml_without_error
source /home/marques/src/robits/.venv/bin/activate && OPENAI_BASE_URL=http://127.0.0.1:11434/v1/ OPENAI_API_KEY=ollama OPENAI_MODEL=granite4.1:3b timeout 240 python3 main.py --prompt "SE, CEO asks: tell me today's weather for ZIP 08234. Use the weather lookup tool if available." --turns 3
```
