### PR TITLE
feat: channel-scoped memory tagging and search filtering

### DIFF
--- a/robits/core/context.py
+++ b/robits/core/context.py
@@ -57,12 +57,10 @@ def agent_runtime_context(role=None):
         or getattr(role, "runtime_role_name", None)
         or getattr(role, "name", None)
     )
-    agent_name = getattr(role, "name", None)
-    canonical_id = getattr(role, "runtime_role_name", None) or agent_name
+    canonical_id = role_name
     primary_id, secondary_id = _get_identity_digests(canonical_id)
     context = {
-        "agent_name": agent_name,
-        "role_name": role_name,
+        "agent_name": role_name,
         "session_id": getattr(role, "runtime_session_id", None),
         "current_datetime_utc": now_utc.isoformat(timespec="seconds"),
         "current_datetime_local": now_local.isoformat(timespec="seconds"),

--- a/robits/core/context.py
+++ b/robits/core/context.py
@@ -86,16 +86,17 @@ def format_agent_context(role=None):
 
 
 def format_org_chat_context(transcript, limit):
-    """Format the most recent `limit` transcript entries as a readable org-chat snippet."""
+    """Format the most recent `limit` non-directed transcript entries as an org-chat snippet."""
     if not transcript or limit == 0:
         return ""
-    recent = transcript[-limit:]
+    public = [e for e in transcript if not getattr(e, "directed", False)]
+    recent = public[-limit:]
     lines = []
     for e in recent:
         lines.append(f"[Turn {e.turn}] {e.sender} -> {e.receiver}: {e.prompt[:400]}")
         if e.response:
             lines.append(f"  -> {e.response[:400]}")
-    return "\nRecent org chat:\n" + "\n".join(lines) + "\n"
+    return "\nRecent org chat:\n" + "\n".join(lines) + "\n" if lines else ""
 
 
 def current_agent_context(employee_dict):

--- a/robits/core/lifecycle.py
+++ b/robits/core/lifecycle.py
@@ -83,7 +83,8 @@ def _caller_can_act_for_agent(agent_name):
     caller = _m.active_tool_caller
     if caller is None:
         return False
-    if _m.active_tool_caller_name == agent_name or getattr(caller, "name", None) == agent_name:
+    caller_name = _m.active_tool_caller_name or getattr(caller, "name", None)
+    if caller_name == agent_name:
         return True
     capabilities = getattr(caller, "capabilities", set())
     return bool({"operator", "hr"} & capabilities)

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -67,6 +67,7 @@ class Role:
         turn_action_template = """
 On your turn, choose one useful action. You do not need to reply to every message.
 Only say that you created, changed, or called a tool after the runtime has returned a verified tool result. Without a verified result, describe the work as a request, proposal, or plan instead of a completed fact.
+When thinking, recalling past events, or forming memories, use your tools rather than relying on assumed knowledge.
 """
         self.template = template + group_template_additions + turn_action_template
         self.employee_dict = employee_dict

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -8,7 +8,14 @@ from uuid import uuid4
 from robits.core.config import _config as _m
 from termcolor import colored
 
-from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL, compute_phase_shift
+from robits.memory.sqlite import (
+    CHANNEL_AGENT_DM,
+    CHANNEL_AGENT_THOUGHT,
+    CHANNEL_ORG_CHAT,
+    SOCIAL_FAMILIAL,
+    SOCIAL_PROFESSIONAL,
+    compute_phase_shift,
+)
 from robits.core.roles import System, build_employee_dict, parse_tool_instruction, parse_agent_action
 from robits.core.context import (
     format_org_chat_context,
@@ -181,6 +188,8 @@ class Session:
 
         self._org_workspace = _m._org_workspace
         self._org_chat_channel_id = None
+        self._thought_channel_ids: dict = {}
+        self._dm_channel_ids: dict = {}
         if _m.memory_store is not None:
             try:
                 _m.memory_store.create_session(self.run_id)
@@ -193,6 +202,41 @@ class Session:
                 )
             except Exception:
                 pass
+
+    def _get_thought_channel_id(self, agent_name):
+        """Return the agent_thought channel ID for agent_name, creating it if needed."""
+        if _m.memory_store is None:
+            return None
+        if agent_name not in self._thought_channel_ids:
+            try:
+                cid = _m.memory_store.get_or_create_channel(
+                    CHANNEL_AGENT_THOUGHT,
+                    participants=[agent_name],
+                    visibility="private",
+                    social_distance=0.0,
+                )
+                self._thought_channel_ids[agent_name] = cid
+            except Exception:
+                return None
+        return self._thought_channel_ids.get(agent_name)
+
+    def _get_dm_channel_id(self, agent_a, agent_b):
+        """Return the agent_dm channel ID for a pair of agents, creating it if needed."""
+        if _m.memory_store is None:
+            return None
+        key = frozenset((agent_a, agent_b))
+        if key not in self._dm_channel_ids:
+            try:
+                cid = _m.memory_store.get_or_create_channel(
+                    CHANNEL_AGENT_DM,
+                    participants=sorted([agent_a, agent_b]),
+                    visibility="private",
+                    social_distance=SOCIAL_FAMILIAL,
+                )
+                self._dm_channel_ids[key] = cid
+            except Exception:
+                return None
+        return self._dm_channel_ids.get(key)
 
     def _clear_wait_state_file(self, role):
         """Remove the persisted wait-state file for role if agent_workspace_store is available."""
@@ -367,6 +411,11 @@ class Session:
         if _m.memory_store is not None:
             canonical_sender = self._canonical_agent_id(sender)
             canonical_receiver = self._canonical_agent_id(receiver)
+            msg_channel_id = (
+                self._get_dm_channel_id(canonical_sender, canonical_receiver)
+                if directed
+                else self._org_chat_channel_id
+            )
             try:
                 sender_phase = _m.memory_store.get_agent_phase(canonical_sender)
                 receiver_phase = _m.memory_store.get_agent_phase(canonical_receiver)
@@ -377,7 +426,7 @@ class Session:
                         receiver_agent_id=canonical_receiver,
                         content=prompt,
                         kind="message",
-                        channel_id=self._org_chat_channel_id,
+                        channel_id=msg_channel_id,
                         sender_phase=sender_phase,
                     )
                 if meaningful_response and response:
@@ -387,13 +436,13 @@ class Session:
                         receiver_agent_id=canonical_sender,
                         content=response,
                         kind="message",
-                        channel_id=self._org_chat_channel_id,
+                        channel_id=msg_channel_id,
                         sender_phase=receiver_phase,
                     )
-                if self._org_chat_channel_id is not None and sender_phase is not None and receiver_phase is not None:
+                if msg_channel_id is not None and sender_phase is not None and receiver_phase is not None:
                     try:
                         social_distance = _m.memory_store.get_channel_social_distance(
-                            self._org_chat_channel_id
+                            msg_channel_id
                         )
                         if social_distance is not None:
                             shifted = compute_phase_shift(
@@ -599,12 +648,14 @@ class Session:
     def record_thought(self, agent_name, content, visibility="private"):
         """Persist a private thought to memory and emit a thought.recorded event."""
         if _m.memory_store is not None:
+            canonical = self._canonical_agent_id(agent_name)
             try:
                 _m.memory_store.append_thought(
-                    agent_id=self._canonical_agent_id(agent_name),
+                    agent_id=canonical,
                     content=content,
                     session_id=self.run_id,
                     visibility=visibility,
+                    channel_id=self._get_thought_channel_id(canonical),
                 )
             except Exception:
                 pass

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -416,6 +416,7 @@ class Session:
                 if directed
                 else self._org_chat_channel_id
             )
+            msg_visibility = "private" if directed else "public"
             try:
                 sender_phase = _m.memory_store.get_agent_phase(canonical_sender)
                 receiver_phase = _m.memory_store.get_agent_phase(canonical_receiver)
@@ -426,6 +427,7 @@ class Session:
                         receiver_agent_id=canonical_receiver,
                         content=prompt,
                         kind="message",
+                        visibility=msg_visibility,
                         channel_id=msg_channel_id,
                         sender_phase=sender_phase,
                     )
@@ -436,6 +438,7 @@ class Session:
                         receiver_agent_id=canonical_sender,
                         content=response,
                         kind="message",
+                        visibility=msg_visibility,
                         channel_id=msg_channel_id,
                         sender_phase=receiver_phase,
                     )
@@ -592,8 +595,8 @@ class Session:
                 pass
 
     def _write_org_chat_jsonl(self, entry):
-        """Append a transcript entry as a JSONL line to the org workspace chat log."""
-        if self._org_workspace is None:
+        """Append a non-directed transcript entry as a JSONL line to the org workspace chat log."""
+        if self._org_workspace is None or getattr(entry, "directed", False):
             return
         line = json.dumps({
             "turn": entry.turn,

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -423,7 +423,10 @@ def _condense_if_large(agent_name, tool_label, result_json):
     return json.dumps(condensed, sort_keys=True)
 
 
-def memory_search(employee_dict, agent_name, query, limit=10, cascade=True):
+_WORK_CHANNEL_TYPES = {"org_chat", "work_peer", "system"}
+
+
+def memory_search(employee_dict, agent_name, query, limit=10, cascade=True, channel_type=None):
     """Search an agent's memory store and return matching results, condensing large payloads."""
     del employee_dict
     store, error = _require_memory_store()
@@ -438,13 +441,16 @@ def memory_search(employee_dict, agent_name, query, limit=10, cascade=True):
     if not isinstance(query, str) or not query.strip():
         return "Error: Memory query must be a non-empty string."
     effective_limit = max(1, min(int(limit or 10), _m.memory_max_rows))
+    search_kwargs = dict(agent_id=normalized_name, limit=effective_limit)
+    if channel_type is not None:
+        search_kwargs["conversation_type"] = channel_type
     if cascade:
-        results = store.search_cascade(query, agent_id=normalized_name, limit=effective_limit)
+        results = store.search_cascade(query, **search_kwargs)
     else:
-        results = store.search(query, agent_id=normalized_name, limit=effective_limit)
+        results = store.search(query, **search_kwargs)
     result_json = json.dumps([result.__dict__ for result in results], sort_keys=True)
     if _m.clock_state == "off" and any(
-        getattr(r, "conversation_type", None) == "org_chat" for r in results
+        getattr(r, "conversation_type", None) in _WORK_CHANNEL_TYPES for r in results
     ):
         note = (
             "[System note: work-related content surfaced in these results. "

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -423,7 +423,7 @@ def _condense_if_large(agent_name, tool_label, result_json):
     return json.dumps(condensed, sort_keys=True)
 
 
-_WORK_CHANNEL_TYPES = {"org_chat", "work_peer", "system"}
+_WORK_CHANNEL_TYPES = {"org_chat", "work_peer"}
 
 
 def memory_search(employee_dict, agent_name, query, limit=10, cascade=True, channel_type=None):

--- a/run_local.py
+++ b/run_local.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Seed a memory DB with personal + work context, then run a short session.
+
+Usage:
+  OPENAI_BASE_URL=http://127.0.0.1:11434/v1/ OPENAI_API_KEY=ollama \
+  OPENAI_MODEL=granite4.1:3b ROBITS_PROVIDER_API=chat \
+  ROBITS_MEMORY_DB=/tmp/robits_local.db python3 run_local.py \
+  --prompt "SE, have you had any personal or work experience with Python or cooking?"
+"""
+import os
+import sys
+
+DB_PATH = os.environ.get("ROBITS_MEMORY_DB", "/tmp/robits_local.db")
+
+def seed_memory(db_path):
+    from robits.memory.sqlite import (
+        SQLiteMemoryStore,
+        CHANNEL_AGENT_THOUGHT, CHANNEL_ORG_CHAT,
+        SOCIAL_PROFESSIONAL,
+    )
+    store = SQLiteMemoryStore(db_path)
+    store.create_session("seed-session")
+    store.upsert_agent("SE", "SoftwareEngineer", "SE")
+    store.upsert_agent("CEO", "Human", "CEO")
+
+    org_ch = store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
+    thought_ch = store.get_or_create_channel(
+        CHANNEL_AGENT_THOUGHT, participants=["SE"],
+        visibility="private", social_distance=0.0,
+    )
+
+    # Work memories — org_chat channel
+    store.append_message("seed-session", "CEO", "SE",
+        "SE, can you refactor the auth module to use Python async/await?",
+        channel_id=org_ch)
+    store.append_message("seed-session", "SE", "CEO",
+        "Sure, I'll migrate it to asyncio. I've done this pattern several times — "
+        "Python async has become second nature to me after years of backend work.",
+        channel_id=org_ch)
+    store.append_message("seed-session", "CEO", "SE",
+        "What's your take on the new SQLite FTS5 integration?",
+        channel_id=org_ch)
+    store.append_message("seed-session", "SE", "CEO",
+        "I find it elegant. The cascade-search approach is something I proposed "
+        "based on prior experience building search pipelines in Python.",
+        channel_id=org_ch)
+
+    # Personal memories — agent_thought channel
+    store.append_thought("SE",
+        "I really enjoy cooking on weekends — especially Italian food. "
+        "Last Saturday I made a proper carbonara from scratch; took about an hour.",
+        session_id="seed-session", channel_id=thought_ch, visibility="private")
+    store.append_thought("SE",
+        "Been meaning to pick up sourdough baking. I've been reading about "
+        "fermentation science — there's a surprising amount of chemistry involved.",
+        session_id="seed-session", channel_id=thought_ch, visibility="private")
+    store.append_thought("SE",
+        "Python was actually my first serious language — started with it in college "
+        "writing small data scripts. Feels personal, not just a work tool.",
+        session_id="seed-session", channel_id=thought_ch, visibility="private")
+
+    store.close()
+    print(f"[run_local] Memory seeded at {db_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    seed_memory(DB_PATH)
+    # Delegate to main.py's entry point
+    import main
+    main.main(argv=sys.argv[1:])

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1610,8 +1610,7 @@ class RuntimeTests(unittest.TestCase):
 
         context = json.loads(response)
 
-        self.assertEqual(context["agent_name"], "SoftwareEngineer")
-        self.assertEqual(context["role_name"], "SE")
+        self.assertEqual(context["agent_name"], "SE")
         self.assertEqual(context["location"], "Philadelphia, PA")
         self.assertEqual(context["timezone"], "America/New_York")
         self.assertIn("current_datetime_local", context)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3275,7 +3275,9 @@ class ChannelScopedMemoryTests(unittest.TestCase):
         self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "ch.sqlite3")
         self.addCleanup(self.store.close)
         self.original_store = main.memory_store
+        self.original_clock = main.clock_state
         main.memory_store = self.store
+        main.clock_state = "on"
         self.addCleanup(self._restore)
         self.store.create_session("s1")
         self.store.upsert_agent("A", "Role", "A")
@@ -3283,6 +3285,7 @@ class ChannelScopedMemoryTests(unittest.TestCase):
 
     def _restore(self):
         main.memory_store = self.original_store
+        main.clock_state = self.original_clock
 
     def _make_session(self, participants=None):
         if participants is None:
@@ -3326,12 +3329,22 @@ class ChannelScopedMemoryTests(unittest.TestCase):
         session = self._make_session()
         session.record_turn("A", "B", "hey", "sup", directed=True)
         rows = self.store.connection.execute(
-            "SELECT m.channel_id, c.channel_type FROM messages m"
+            "SELECT m.channel_id, c.channel_type, m.visibility FROM messages m"
             " LEFT JOIN channels c ON c.channel_id = m.channel_id"
             " WHERE m.session_id=?", (session.run_id,)
         ).fetchall()
         self.assertTrue(rows)
         self.assertTrue(all(r["channel_type"] == CHANNEL_AGENT_DM for r in rows))
+        self.assertTrue(all(r["visibility"] == "private" for r in rows))
+
+    def test_directed_message_excluded_from_org_chat_context(self):
+        from robits.core.context import format_org_chat_context
+        session = self._make_session()
+        session.record_turn("A", "B", "public update", "ack", directed=False)
+        session.record_turn("A", "B", "private dm", "private reply", directed=True)
+        ctx = format_org_chat_context(session.transcript, 10)
+        self.assertIn("public update", ctx)
+        self.assertNotIn("private dm", ctx)
 
     def test_undirected_message_tagged_with_org_chat_channel(self):
         from robits.memory.sqlite import CHANNEL_ORG_CHAT

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3267,5 +3267,164 @@ class WorkTodoToolTests(unittest.TestCase):
         self.assertEqual(rows[0]["content"], "detailed notes here")
 
 
+class ChannelScopedMemoryTests(unittest.TestCase):
+    """Tests for channel-scoped memory tagging and filtering (issue #69)."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "ch.sqlite3")
+        self.addCleanup(self.store.close)
+        self.original_store = main.memory_store
+        main.memory_store = self.store
+        self.addCleanup(self._restore)
+        self.store.create_session("s1")
+        self.store.upsert_agent("A", "Role", "A")
+        self.store.upsert_agent("B", "Role", "B")
+
+    def _restore(self):
+        main.memory_store = self.original_store
+
+    def _make_session(self, participants=None):
+        if participants is None:
+            participants = {
+                "A": SimpleNamespace(
+                    name="A", lifecycle_state="active",
+                    interact=lambda *a, **kw: "resp",
+                    update_group_conversations=lambda m: None,
+                ),
+                "B": SimpleNamespace(
+                    name="B", lifecycle_state="active",
+                    interact=lambda *a, **kw: "resp",
+                    update_group_conversations=lambda m: None,
+                ),
+            }
+        return main.Session(participants=participants)
+
+    def test_record_thought_tagged_with_agent_thought_channel(self):
+        from robits.memory.sqlite import CHANNEL_AGENT_THOUGHT
+        session = self._make_session()
+        session.record_thought("A", "private reflection")
+        rows = self.store.connection.execute(
+            "SELECT t.channel_id, c.channel_type FROM thoughts t"
+            " LEFT JOIN channels c ON c.channel_id = t.channel_id"
+            " WHERE t.agent_id = 'A'"
+        ).fetchall()
+        self.assertTrue(rows, "No thought row found")
+        self.assertEqual(rows[0]["channel_type"], CHANNEL_AGENT_THOUGHT)
+
+    def test_thought_channel_is_stable_across_calls(self):
+        session = self._make_session()
+        session.record_thought("A", "first")
+        session.record_thought("A", "second")
+        channel_ids = self.store.connection.execute(
+            "SELECT DISTINCT channel_id FROM thoughts WHERE agent_id='A'"
+        ).fetchall()
+        self.assertEqual(len(channel_ids), 1, "Thoughts should share a single agent_thought channel")
+
+    def test_directed_message_tagged_with_agent_dm_channel(self):
+        from robits.memory.sqlite import CHANNEL_AGENT_DM
+        session = self._make_session()
+        session.record_turn("A", "B", "hey", "sup", directed=True)
+        rows = self.store.connection.execute(
+            "SELECT m.channel_id, c.channel_type FROM messages m"
+            " LEFT JOIN channels c ON c.channel_id = m.channel_id"
+            " WHERE m.session_id=?", (session.run_id,)
+        ).fetchall()
+        self.assertTrue(rows)
+        self.assertTrue(all(r["channel_type"] == CHANNEL_AGENT_DM for r in rows))
+
+    def test_undirected_message_tagged_with_org_chat_channel(self):
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT
+        session = self._make_session()
+        session.record_turn("A", "B", "org update", "acknowledged", directed=False)
+        rows = self.store.connection.execute(
+            "SELECT m.channel_id, c.channel_type FROM messages m"
+            " LEFT JOIN channels c ON c.channel_id = m.channel_id"
+            " WHERE m.session_id=?", (session.run_id,)
+        ).fetchall()
+        self.assertTrue(rows)
+        self.assertTrue(all(r["channel_type"] == CHANNEL_ORG_CHAT for r in rows))
+
+    def test_dm_channel_is_stable_for_pair(self):
+        session = self._make_session()
+        session.record_turn("A", "B", "msg1", "reply1", directed=True)
+        session.record_turn("A", "B", "msg2", "reply2", directed=True)
+        channel_ids = self.store.connection.execute(
+            "SELECT DISTINCT channel_id FROM messages WHERE session_id=?",
+            (session.run_id,)
+        ).fetchall()
+        self.assertEqual(len(channel_ids), 1, "All directed messages share one DM channel")
+
+    def test_memory_search_filters_by_channel_type(self):
+        from robits.memory.sqlite import CHANNEL_AGENT_THOUGHT, CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+        self.store.upsert_agent("alice", "Role", "alice")
+        self.store.create_session("s2")
+        org_ch = self.store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
+        thought_ch = self.store.get_or_create_channel(
+            CHANNEL_AGENT_THOUGHT, participants=["alice"], visibility="private", social_distance=0.0
+        )
+        self.store.append_message("s2", "alice", "alice", "standup meeting notes xkw1", channel_id=org_ch)
+        self.store.append_thought("alice", "personal reflection xkw1", session_id="s2", channel_id=thought_ch)
+
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="alice", capabilities=set())
+        try:
+            all_results = json.loads(main.memory_search({}, "alice", "xkw1"))
+            thought_results = json.loads(main.memory_search({}, "alice", "xkw1", channel_type=CHANNEL_AGENT_THOUGHT))
+            org_results = json.loads(main.memory_search({}, "alice", "xkw1", channel_type=CHANNEL_ORG_CHAT))
+        finally:
+            main.active_tool_caller = old_caller
+
+        self.assertGreaterEqual(len(all_results), 2, "Unfiltered search should return both")
+        self.assertTrue(all(r["conversation_type"] == CHANNEL_AGENT_THOUGHT for r in thought_results))
+        self.assertTrue(all(r["conversation_type"] == CHANNEL_ORG_CHAT for r in org_results))
+
+    def test_off_clock_work_peer_result_prepends_parking_note(self):
+        """work_peer channel content should also trigger the parking note when off-clock."""
+        from robits.memory.sqlite import CHANNEL_WORK_PEER, SOCIAL_PROFESSIONAL
+        self.store.upsert_agent("dave", "Role", "dave")
+        self.store.create_session("s3")
+        wp_ch = self.store.get_or_create_channel(
+            CHANNEL_WORK_PEER, participants=["dave"], social_distance=SOCIAL_PROFESSIONAL
+        )
+        self.store.append_message("s3", "dave", "dave", "project timeline xkw2", channel_id=wp_ch)
+        original_clock = main.clock_state
+        main.clock_state = "off"
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="dave", capabilities=set())
+        try:
+            result = main.memory_search({}, "dave", "xkw2")
+        finally:
+            main.active_tool_caller = old_caller
+            main.clock_state = original_clock
+        self.assertIn("System note", result)
+
+    def test_personal_experience_scenario(self):
+        """Agents searching for personal/work experience get channel-scoped results."""
+        from robits.memory.sqlite import CHANNEL_AGENT_THOUGHT, CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+        self.store.upsert_agent("frank", "Role", "frank")
+        self.store.create_session("s4")
+        org_ch = self.store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
+        thought_ch = self.store.get_or_create_channel(
+            CHANNEL_AGENT_THOUGHT, participants=["frank"], visibility="private", social_distance=0.0
+        )
+        self.store.append_message("s4", "frank", "frank", "I used Python at work for data pipelines xkw3", channel_id=org_ch)
+        self.store.append_thought("frank", "Personally I love cooking Italian food xkw3", session_id="s4", channel_id=thought_ch)
+
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="frank", capabilities=set())
+        try:
+            personal = json.loads(main.memory_search({}, "frank", "xkw3", channel_type=CHANNEL_AGENT_THOUGHT))
+            work = json.loads(main.memory_search({}, "frank", "xkw3", channel_type=CHANNEL_ORG_CHAT))
+        finally:
+            main.active_tool_caller = old_caller
+
+        self.assertEqual(len(personal), 1)
+        self.assertIn("cooking", personal[0]["content"])
+        self.assertEqual(len(work), 1)
+        self.assertIn("Python", work[0]["content"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools.yaml
+++ b/tools.yaml
@@ -381,9 +381,9 @@
   grantable: true
   owner_capability: agent
   description: >
-    Record a private thought or reasoning step before acting. Silent — returns nothing
-    visible to other agents. Use this to reason through a problem, weigh options, or
-    plan a sequence of actions before committing to one.
+    Record a private thought before acting. Silent — not visible to other agents.
+    Use to reason, weigh options, or plan before committing. Prefer this over
+    fabricating an answer when uncertain.
   parameters:
     type: object
     properties:
@@ -416,7 +416,11 @@
   system_tool: true
   grantable: true
   owner_capability: system
-  description: Search an agent's accessible SQLite memory records. Returns outer-level FTS hits and surfaces parent digests for any inner records that also match.
+  description: >
+    Search an agent's memory records. Use this whenever asked about past events,
+    personal experiences, or work history — do not answer from assumed knowledge.
+    Use channel_type=agent_thought for personal/private memories,
+    channel_type=org_chat for work context. Returns FTS hits and parent digests.
   parameters:
     type: object
     properties:
@@ -451,7 +455,7 @@
   system_tool: true
   grantable: true
   owner_capability: system
-  description: List an agent's current accessible memory digests.
+  description: List an agent's memory digests. Use to recall summarised identity, goals, or episode history before responding about who you are or what you've done.
   parameters:
     type: object
     properties:

--- a/tools.yaml
+++ b/tools.yaml
@@ -432,6 +432,9 @@
       cascade:
         type: boolean
         description: Also search inner source records of digests and surface parent digests for matches (default true).
+      channel_type:
+        type: string
+        description: "Restrict search to a specific conversation scope. Valid values: org_chat, agent_thought, agent_dm, therapist, family_member, family_group, work_peer, system. Omit to search across all channels."
     required:
       - agent_name
       - query
@@ -442,6 +445,7 @@
         query,
         limit=limit if limit is not None else 10,
         cascade=cascade if cascade is not None else True,
+        channel_type=channel_type if channel_type is not None else None,
     )
 - name: memory.list_digests
   system_tool: true


### PR DESCRIPTION
Closes #69, closes #45

## Summary

- **\`session.py\`**: thoughts tagged with per-agent \`agent_thought\` channel; directed messages use a private \`agent_dm\` channel and are excluded from org-chat context and \`org_chat.jsonl\`; undirected messages use \`org_chat\`. Phase-shift uses the actual message channel for social-distance lookup.
- **\`tool_functions.py\`**: \`memory_search()\` gains a \`channel_type\` param. Off-clock parking note covers \`org_chat\` and \`work_peer\`.
- **\`tools.yaml\`**: \`memory.search\` exposes \`channel_type\`; \`agent.think\`, \`memory.search\`, \`memory.list_digests\` descriptions guide models on *when* to use each tool.
- **\`roles.py\`**: base prompt: "When thinking, recalling past events, or forming memories, use your tools rather than relying on assumed knowledge."
- **\`context.py\`**: \`agent_name\` in runtime context is now the participant key (\`SE\` not \`SoftwareEngineer\`) so tools receive the correct DB identifier.
- **\`lifecycle.py\`**: \`_caller_can_act_for_agent\` uses \`active_tool_caller_name\` as the single canonical identity.

## What's not in this PR

- \`conversation_type\` coexists with \`channel_id\` for backward compat (removal tracked separately)
- TUI navigation of scopes (#67) out of scope

## Local LLM validation (granite4.1:3b via Ollama)

Seeded SE with personal thoughts (\`agent_thought\`) and work messages (\`org_chat\`), prompt: *"have you had any personal or work experience with Python or cooking?"* — SE called \`memory.search\` twice unprompted, used correct key (\`SE\`), retrieved channel-separated results, answered from memory only. See PR comment for full tool-call output.

## Test plan

- [x] \`test_record_thought_tagged_with_agent_thought_channel\`
- [x] \`test_thought_channel_is_stable_across_calls\`
- [x] \`test_directed_message_tagged_with_agent_dm_channel\` (+ visibility=private)
- [x] \`test_directed_message_excluded_from_org_chat_context\`
- [x] \`test_undirected_message_tagged_with_org_chat_channel\`
- [x] \`test_dm_channel_is_stable_for_pair\`
- [x] \`test_memory_search_filters_by_channel_type\`
- [x] \`test_off_clock_work_peer_result_prepends_parking_note\`
- [x] \`test_personal_experience_scenario\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)