### PR TITLE
feat: persona seeding, break clock state, and embedding-based semantic search

### DIFF
--- a/personas.yaml
+++ b/personas.yaml
@@ -1,0 +1,41 @@
+# Per-agent persona seeds — preloaded into memory on first session.
+# kind: thought | message | entry | digest
+# See robits/core/persona.py for seeding logic.
+
+- agent: SE
+  memories:
+    - kind: thought
+      channel: agent_thought
+      content: "Python was my first serious language — started in college writing data-analysis scripts."
+      visibility: private
+    - kind: thought
+      channel: agent_thought
+      content: "I really enjoy cooking on weekends, especially Italian food."
+      visibility: private
+    - kind: digest
+      digest_type: identity
+      content: >
+        SE is a pragmatic backend engineer with deep Python experience who values
+        clean APIs, strong test coverage, and minimal abstractions. Enjoys cooking
+        and outdoor running outside of work hours.
+      relationship_type: personal
+
+- agent: HR
+  memories:
+    - kind: digest
+      digest_type: identity
+      content: >
+        HR is the organisation's people-ops lead: manages role lifecycle, mediates
+        disputes, and keeps the org chart healthy. Values fairness, clear communication,
+        and process transparency.
+      relationship_type: work
+
+- agent: CEO
+  memories:
+    - kind: digest
+      digest_type: identity
+      content: >
+        CEO sets strategic direction, approves major decisions, and represents the
+        organisation's mission externally. Prioritises long-term impact over
+        short-term comfort.
+      relationship_type: work

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai
 PyYaml
 termcolor
 aiosqlite
+sqlite-vec

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -90,13 +90,18 @@ class Config:
             0, int(env.get("ROBITS_ORG_DIGEST_INTERVAL", "0"))
         )
 
+        # --- personas ---
+        self.personas_file = env.get("ROBITS_PERSONAS_FILE", "").strip() or None
+        from robits.core.persona import load_personas
+        self.persona_entries = load_personas(self.personas_file)
+
         # --- misc ---
         self.builtin_search_url = env.get("ROBITS_SEARCH_URL", "").strip()
         self._reasoning_effort_env = (
             env.get("ROBITS_REASONING_EFFORT", "").strip().lower() or None
         )
         _raw_clock = env.get("ROBITS_CLOCK_STATE", "on").strip().lower()
-        self.clock_state = _raw_clock if _raw_clock in {"on", "off"} else "on"
+        self.clock_state = _raw_clock if _raw_clock in {"on", "off", "break"} else "on"
         self.default_location = env.get("ROBITS_LOCATION", "").strip()
         self.default_timezone = env.get("ROBITS_TIMEZONE", "").strip()
 

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -90,6 +90,16 @@ class Config:
             0, int(env.get("ROBITS_ORG_DIGEST_INTERVAL", "0"))
         )
 
+        # --- embeddings ---
+        self.embedding_model = env.get("ROBITS_EMBEDDING_MODEL", "").strip()
+        self.embedding_base_url = (
+            env.get("ROBITS_EMBEDDING_BASE_URL")
+            or env.get("OPENAI_BASE_URL")
+            or env.get("OPENAI_API_BASE")
+            or ""
+        ).strip() or None
+        self.embedding_api_key = env.get("ROBITS_EMBEDDING_API_KEY", "").strip() or None
+
         # --- personas ---
         self.personas_file = env.get("ROBITS_PERSONAS_FILE", "").strip() or None
         from robits.core.persona import load_personas

--- a/robits/core/context.py
+++ b/robits/core/context.py
@@ -44,7 +44,7 @@ def _get_identity_digests(agent_id):
     work = _fetch("work") or _fetch(None)
     if _m.clock_state == "on":
         return work, personal
-    return personal, work
+    return personal, work  # break and off both weight personal identity higher
 
 
 def agent_runtime_context(role=None):

--- a/robits/core/embeddings.py
+++ b/robits/core/embeddings.py
@@ -1,23 +1,17 @@
 """Embedding generation via OpenAI-compatible API for semantic memory search."""
 from __future__ import annotations
 
-import os
 from typing import List
 
 
-def _embedding_client():
-    """Return an OpenAI client pointed at the configured embedding base URL."""
-    from openai import OpenAI
-    base_url = (
-        os.environ.get("ROBITS_EMBEDDING_BASE_URL")
-        or os.environ.get("OPENAI_BASE_URL")
-        or os.environ.get("OPENAI_API_BASE")
+def _embedding_config():
+    """Return (base_url, api_key, model) from the shared Config singleton."""
+    from robits.core.config import _config as _m
+    return (
+        getattr(_m, "embedding_base_url", None),
+        getattr(_m, "embedding_api_key", None) or _m.client.api_key,
+        getattr(_m, "embedding_model", ""),
     )
-    api_key = os.environ.get("ROBITS_EMBEDDING_API_KEY") or os.environ.get("OPENAI_API_KEY", "not-needed")
-    kwargs = {"api_key": api_key}
-    if base_url:
-        kwargs["base_url"] = base_url
-    return OpenAI(**kwargs)
 
 
 def get_embedding(text: str, model: str | None = None) -> List[float] | None:
@@ -25,11 +19,16 @@ def get_embedding(text: str, model: str | None = None) -> List[float] | None:
 
     Returns None if no model is configured or the request fails.
     """
-    effective_model = model or os.environ.get("ROBITS_EMBEDDING_MODEL", "")
+    from openai import OpenAI
+    base_url, api_key, configured_model = _embedding_config()
+    effective_model = model or configured_model
     if not effective_model:
         return None
     try:
-        client = _embedding_client()
+        kwargs: dict = {"api_key": api_key or "not-needed"}
+        if base_url:
+            kwargs["base_url"] = base_url
+        client = OpenAI(**kwargs)
         response = client.embeddings.create(input=[text], model=effective_model)
         return response.data[0].embedding
     except Exception:
@@ -38,4 +37,5 @@ def get_embedding(text: str, model: str | None = None) -> List[float] | None:
 
 def embedding_model_name() -> str:
     """Return the configured embedding model name, or empty string if none."""
-    return os.environ.get("ROBITS_EMBEDDING_MODEL", "")
+    from robits.core.config import _config as _m
+    return getattr(_m, "embedding_model", "")

--- a/robits/core/embeddings.py
+++ b/robits/core/embeddings.py
@@ -1,0 +1,41 @@
+"""Embedding generation via OpenAI-compatible API for semantic memory search."""
+from __future__ import annotations
+
+import os
+from typing import List
+
+
+def _embedding_client():
+    """Return an OpenAI client pointed at the configured embedding base URL."""
+    from openai import OpenAI
+    base_url = (
+        os.environ.get("ROBITS_EMBEDDING_BASE_URL")
+        or os.environ.get("OPENAI_BASE_URL")
+        or os.environ.get("OPENAI_API_BASE")
+    )
+    api_key = os.environ.get("ROBITS_EMBEDDING_API_KEY") or os.environ.get("OPENAI_API_KEY", "not-needed")
+    kwargs = {"api_key": api_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    return OpenAI(**kwargs)
+
+
+def get_embedding(text: str, model: str | None = None) -> List[float] | None:
+    """Return a float vector for text using the configured embedding model.
+
+    Returns None if no model is configured or the request fails.
+    """
+    effective_model = model or os.environ.get("ROBITS_EMBEDDING_MODEL", "")
+    if not effective_model:
+        return None
+    try:
+        client = _embedding_client()
+        response = client.embeddings.create(input=[text], model=effective_model)
+        return response.data[0].embedding
+    except Exception:
+        return None
+
+
+def embedding_model_name() -> str:
+    """Return the configured embedding model name, or empty string if none."""
+    return os.environ.get("ROBITS_EMBEDDING_MODEL", "")

--- a/robits/core/persona.py
+++ b/robits/core/persona.py
@@ -42,6 +42,17 @@ def load_personas(path: str | None = None) -> dict[str, list[dict]]:
     return result
 
 
+def _resolve_channel_id(store: Any, channel: str | None) -> int | None:
+    """Resolve a channel name to its DB id, or return None."""
+    if not channel:
+        return None
+    try:
+        from robits.memory.sqlite import SOCIAL_PROFESSIONAL
+        return store.get_or_create_channel(channel, social_distance=SOCIAL_PROFESSIONAL)
+    except Exception:
+        return None
+
+
 def seed_persona(
     store: Any,
     agent_name: str,
@@ -55,28 +66,16 @@ def seed_persona(
     if not entries:
         return 0
 
-    # Ensure a session record exists for FK constraints; persona seeds use their own session.
+    # Ensure a session record exists for FK constraints.
     try:
         store.create_session(session_id)
     except Exception:
         pass  # session may already exist
 
-    # Idempotency: skip if the agent already has any memory
+    # Idempotency: skip if the agent already has *any* indexed memory record.
     try:
-        existing = store.list_memory_digests(
-            agent_id=agent_name, digest_type="identity", current_only=True, limit=1
-        )
-        if existing:
-            return 0
-        # Also check raw memory entries
         rows = store._rows(
-            "SELECT 1 FROM memory_entries WHERE agent_id = ? LIMIT 1",
-            [agent_name],
-        )
-        if rows:
-            return 0
-        rows = store._rows(
-            "SELECT 1 FROM thoughts WHERE agent_id = ? LIMIT 1",
+            "SELECT 1 FROM memory_fts WHERE agent_id = ? LIMIT 1",
             [agent_name],
         )
         if rows:
@@ -92,25 +91,17 @@ def seed_persona(
             continue
         try:
             if kind == "thought":
+                channel_id = _resolve_channel_id(store, entry.get("channel"))
                 store.append_thought(
                     agent_id=agent_name,
                     content=content,
                     session_id=session_id,
                     visibility=entry.get("visibility", "private"),
+                    channel_id=channel_id,
                 )
                 written += 1
             elif kind == "message":
-                channel = entry.get("channel")
-                channel_id = None
-                if channel:
-                    try:
-                        from robits.memory.sqlite import SOCIAL_PROFESSIONAL
-                        channel_id = store.get_or_create_channel(
-                            channel,
-                            social_distance=SOCIAL_PROFESSIONAL,
-                        )
-                    except Exception:
-                        pass
+                channel_id = _resolve_channel_id(store, entry.get("channel"))
                 store.append_message(
                     session_id=session_id,
                     sender_agent_id=agent_name,

--- a/robits/core/persona.py
+++ b/robits/core/persona.py
@@ -1,0 +1,158 @@
+"""Persona seeding: preload per-agent identity memories from a YAML configuration."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+_VALID_KINDS = {"thought", "message", "entry", "digest"}
+_DEFAULT_PERSONAS_FILE = "personas.yaml"
+
+
+def load_personas(path: str | None = None) -> dict[str, list[dict]]:
+    """Load personas.yaml and return {agent_name: [entry_dicts]}.
+
+    Returns an empty dict if the file is absent or unparseable.
+    """
+    try:
+        import yaml
+    except ImportError:
+        return {}
+
+    resolved = Path(path or os.environ.get("ROBITS_PERSONAS_FILE", _DEFAULT_PERSONAS_FILE))
+    if not resolved.exists():
+        return {}
+    try:
+        data = yaml.safe_load(resolved.read_text())
+    except Exception:
+        return {}
+    if not isinstance(data, list):
+        return {}
+    result: dict[str, list[dict]] = {}
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        agent = item.get("agent")
+        memories = item.get("memories")
+        if not agent or not isinstance(memories, list):
+            continue
+        result.setdefault(agent, []).extend(
+            m for m in memories if isinstance(m, dict) and m.get("kind") in _VALID_KINDS
+        )
+    return result
+
+
+def seed_persona(
+    store: Any,
+    agent_name: str,
+    entries: list[dict],
+    session_id: str = "persona-seed",
+) -> int:
+    """Write persona memories for agent_name; skip entirely if any memory exists.
+
+    Returns the number of records written (0 if skipped).
+    """
+    if not entries:
+        return 0
+
+    # Ensure a session record exists for FK constraints; persona seeds use their own session.
+    try:
+        store.create_session(session_id)
+    except Exception:
+        pass  # session may already exist
+
+    # Idempotency: skip if the agent already has any memory
+    try:
+        existing = store.list_memory_digests(
+            agent_id=agent_name, digest_type="identity", current_only=True, limit=1
+        )
+        if existing:
+            return 0
+        # Also check raw memory entries
+        rows = store._rows(
+            "SELECT 1 FROM memory_entries WHERE agent_id = ? LIMIT 1",
+            [agent_name],
+        )
+        if rows:
+            return 0
+        rows = store._rows(
+            "SELECT 1 FROM thoughts WHERE agent_id = ? LIMIT 1",
+            [agent_name],
+        )
+        if rows:
+            return 0
+    except Exception:
+        return 0
+
+    written = 0
+    for entry in entries:
+        kind = entry.get("kind")
+        content = entry.get("content", "")
+        if not content:
+            continue
+        try:
+            if kind == "thought":
+                store.append_thought(
+                    agent_id=agent_name,
+                    content=content,
+                    session_id=session_id,
+                    visibility=entry.get("visibility", "private"),
+                )
+                written += 1
+            elif kind == "message":
+                channel = entry.get("channel")
+                channel_id = None
+                if channel:
+                    try:
+                        from robits.memory.sqlite import SOCIAL_PROFESSIONAL
+                        channel_id = store.get_or_create_channel(
+                            channel,
+                            social_distance=SOCIAL_PROFESSIONAL,
+                        )
+                    except Exception:
+                        pass
+                store.append_message(
+                    session_id=session_id,
+                    sender_agent_id=agent_name,
+                    receiver_agent_id=agent_name,
+                    content=content,
+                    kind="message",
+                    visibility=entry.get("visibility", "public"),
+                    channel_id=channel_id,
+                )
+                written += 1
+            elif kind == "entry":
+                store.append_memory_entry(
+                    kind=entry.get("digest_type", "identity"),
+                    content=content,
+                    agent_id=agent_name,
+                    session_id=session_id,
+                    source="persona",
+                    relationship_type=entry.get("relationship_type"),
+                    conversation_type=entry.get("conversation_type"),
+                )
+                written += 1
+            elif kind == "digest":
+                seed_entry_id = store.append_memory_entry(
+                    kind="identity",
+                    content=content,
+                    agent_id=agent_name,
+                    session_id=session_id,
+                    source="persona",
+                )
+                store.append_memory_digest(
+                    content=content,
+                    source_refs=[{"source_table": "memory_entries", "source_id": seed_entry_id}],
+                    agent_id=agent_name,
+                    session_id=session_id,
+                    digest_type=entry.get("digest_type", "identity"),
+                    accessibility="agent",
+                    system_only=False,
+                    source="persona",
+                    relationship_type=entry.get("relationship_type"),
+                )
+                written += 1
+        except Exception:
+            pass
+
+    return written

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -75,6 +75,7 @@ When thinking, recalling past events, or forming memories, use your tools rather
         self.group_conversation_history = {}
         self.global_conversation_history = []
         self.temperature = 0.7
+        self.base_temperature = self.temperature
         self.max_tokens = random.randint(250, 400)
         self.lifecycle_state = "active"
         self.lifecycle_events = []

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -24,6 +24,7 @@ from robits.core.context import (
 )
 from robits.core.lifecycle import due_alarm_reminders
 from robits.core.tool_functions import _restore_wait_state, _WAIT_STATE_FILE
+from robits.core.persona import seed_persona
 
 
 @dataclass
@@ -142,6 +143,16 @@ class RoundRobinScheduler:
             self.index %= len(self.participant_names)
 
 
+_CLOCK_TEMP_MULTIPLIER = {"on": 0.6, "break": 0.9, "off": 1.3}
+
+
+def _modulate_temperature(role, clock_state):
+    """Adjust role.temperature around its base_temperature for the given clock state."""
+    base = getattr(role, "base_temperature", getattr(role, "temperature", 0.7))
+    multiplier = _CLOCK_TEMP_MULTIPLIER.get(clock_state, 1.0)
+    role.temperature = max(0.05, min(1.0, base * multiplier))
+
+
 class Session:
     """Orchestrates a multi-turn conversation between participants, routing messages and managing memory."""
 
@@ -173,7 +184,7 @@ class Session:
         self._name_to_key = {getattr(p, "name", k): k for k, p in self.participants.items()}
         self._role_to_key = {id(p): k for k, p in self.participants.items()}
         _cs = clock_state or _m.clock_state
-        self.clock_state = _cs if _cs in {"on", "off"} else "on"
+        self.clock_state = _cs if _cs in {"on", "off", "break"} else "on"
         self.event_stream.emit(
             "session.created",
             self.run_id,
@@ -196,6 +207,8 @@ class Session:
                 for name, participant in self.participants.items():
                     role_type = type(participant).__name__
                     _m.memory_store.upsert_agent(name, role_type, display_name=name)
+                    if _m.persona_entries.get(name):
+                        seed_persona(_m.memory_store, name, _m.persona_entries[name])
                 self._org_chat_channel_id = _m.memory_store.get_or_create_channel(
                     CHANNEL_ORG_CHAT,
                     social_distance=SOCIAL_PROFESSIONAL,
@@ -247,6 +260,18 @@ class Session:
             except Exception:
                 pass
 
+    def _embed_pending(self):
+        """Backfill embeddings for any unembedded memory records (sleep-cycle task)."""
+        if _m.memory_store is None:
+            return
+        from robits.core.embeddings import embedding_model_name
+        model = embedding_model_name()
+        if model:
+            try:
+                _m.memory_store.embed_pending(model)
+            except Exception:
+                pass
+
     def _build_wait_summary(self, role):
         """Clear a role's wait state and return a summary of what happened while it was waiting."""
         started = getattr(role, "wait_started_turn", None) or 0
@@ -255,6 +280,7 @@ class Session:
         role.wait_started_turn = None
         role.wait_clock_state = None
         self._clear_wait_state_file(role)
+        self._embed_pending()
         if not since:
             return "Your wait has ended. Nothing notable happened while you were waiting."
         lines = ["Your wait has ended. Here is what happened while you were waiting:"]
@@ -690,6 +716,7 @@ class Session:
         role.runtime_session_id = self.run_id
         role.runtime_tool_results = []
         role.runtime_clock_state = self.clock_state
+        _modulate_temperature(role, self.clock_state)
         for name, participant in self.participants.items():
             if participant is role:
                 role.runtime_role_name = name
@@ -787,4 +814,5 @@ class Session:
                 _m.memory_store.end_session(self.run_id)
             except Exception:
                 pass
+        self._embed_pending()
         return self

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -147,10 +147,15 @@ _CLOCK_TEMP_MULTIPLIER = {"on": 0.6, "break": 0.9, "off": 1.3}
 
 
 def _modulate_temperature(role, clock_state):
-    """Adjust role.temperature around its base_temperature for the given clock state."""
-    base = getattr(role, "base_temperature", getattr(role, "temperature", 0.7))
+    """Adjust role.temperature around its base_temperature for the given clock state.
+
+    Initialises base_temperature from the current temperature on first call so
+    that repeated calls always modulate from the same stable baseline.
+    """
+    if not hasattr(role, "base_temperature"):
+        role.base_temperature = getattr(role, "temperature", 0.7)
     multiplier = _CLOCK_TEMP_MULTIPLIER.get(clock_state, 1.0)
-    role.temperature = max(0.05, min(1.0, base * multiplier))
+    role.temperature = max(0.05, min(1.0, role.base_temperature * multiplier))
 
 
 class Session:

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -444,19 +444,30 @@ def memory_search(employee_dict, agent_name, query, limit=10, cascade=True, chan
     search_kwargs = dict(agent_id=normalized_name, limit=effective_limit)
     if channel_type is not None:
         search_kwargs["conversation_type"] = channel_type
-    if cascade:
+    from robits.core.embeddings import embedding_model_name
+    _embed_model = embedding_model_name()
+    if cascade and _embed_model:
+        results = store.search_hybrid(query, _embed_model, **search_kwargs)
+    elif cascade:
         results = store.search_cascade(query, **search_kwargs)
     else:
         results = store.search(query, **search_kwargs)
     result_json = json.dumps([result.__dict__ for result in results], sort_keys=True)
-    if _m.clock_state == "off" and any(
+    _clock = _m.clock_state
+    if _clock in {"off", "break"} and any(
         getattr(r, "conversation_type", None) in _WORK_CHANNEL_TYPES for r in results
     ):
-        note = (
-            "[System note: work-related content surfaced in these results. "
-            "Consider parking any useful insights via the work.todo tool "
-            "and return focus to the current personal context.]\n"
-        )
+        if _clock == "off":
+            note = (
+                "[System note: work-related content surfaced in these results. "
+                "Consider parking any useful insights via the work.todo tool "
+                "and return focus to the current personal context.]\n"
+            )
+        else:
+            note = (
+                "[System note: work-related content surfaced during a break. "
+                "You may briefly note any insights via work.todo, but keep your break focus.]\n"
+            )
         result_json = note + result_json
     return _condense_if_large(normalized_name, "memory_search", result_json)
 

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -783,3 +783,18 @@ class AsyncSQLiteMemoryStore:
     async def get_channel_social_distance(self, channel_id) -> float | None:
         """Return the social_distance for a channel, or None if not found or unset."""
         return await self._run_sync("get_channel_social_distance", channel_id)
+
+    async def store_embedding(self, source_table, source_id, vector, model_name):
+        return await self._run_sync("store_embedding", source_table, source_id, vector, model_name)
+
+    async def get_pending_embedding_records(self, model_name, limit=50):
+        return await self._run_sync("get_pending_embedding_records", model_name, limit=limit)
+
+    async def embed_pending(self, model_name, limit=50):
+        return await self._run_sync("embed_pending", model_name, limit=limit)
+
+    async def search_semantic(self, query, model_name, agent_id=None, limit=20, _query_vector=None):
+        return await self._run_sync("search_semantic", query, model_name, agent_id=agent_id, limit=limit, _query_vector=_query_vector)
+
+    async def search_hybrid(self, query, model_name, agent_id=None, limit=20, **kwargs):
+        return await self._run_sync("search_hybrid", query, model_name, agent_id=agent_id, limit=limit, **kwargs)

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -1750,7 +1750,14 @@ class SQLiteMemoryStore:
     def get_pending_embedding_records(
         self, model_name: str, limit: int = 50
     ) -> list[dict]:
-        """Return FTS records that have no embedding for model_name yet."""
+        """Return embeddable FTS records that have no embedding for model_name yet.
+
+        Only the embeddable kinds (message, thought, memory_digest, and
+        memory_entries variants) are returned; tool_call and other non-content
+        kinds are excluded.
+        """
+        if not self._vec_enabled:
+            return []
         return self._rows(
             """
             SELECT mf.rowid AS fts_rowid, mf.kind, mf.record_id,
@@ -1758,14 +1765,16 @@ class SQLiteMemoryStore:
             FROM memory_fts mf
             LEFT JOIN memory_embeddings me
                 ON me.source_table = CASE mf.kind
-                    WHEN 'message'      THEN 'messages'
-                    WHEN 'thought'      THEN 'thoughts'
+                    WHEN 'message'       THEN 'messages'
+                    WHEN 'thought'       THEN 'thoughts'
                     WHEN 'memory_digest' THEN 'memory_digests'
                     ELSE 'memory_entries'
                    END
                 AND me.source_id = mf.record_id
                 AND me.embedding_model = ?
             WHERE me.embedding_id IS NULL
+              AND mf.kind IN ('message', 'thought', 'memory_digest',
+                              'identity', 'episodic', 'goal_short_term', 'goal_long_term')
             LIMIT ?
             """,
             [model_name, limit],
@@ -1773,6 +1782,8 @@ class SQLiteMemoryStore:
 
     def embed_pending(self, model_name: str, limit: int = 50) -> int:
         """Generate and store embeddings for unembedded FTS records; return count written."""
+        if not self._vec_enabled:
+            return 0
         from robits.core.embeddings import get_embedding
         _kind_to_table = {
             "message": "messages",
@@ -1828,13 +1839,14 @@ class SQLiteMemoryStore:
             placeholders = ", ".join("?" * len(rowid_to_dist))
             meta_rows = self.connection.execute(
                 f"SELECT embedding_id, source_table, source_id FROM memory_embeddings "
-                f"WHERE embedding_id IN ({placeholders})",
-                list(rowid_to_dist.keys()),
+                f"WHERE embedding_id IN ({placeholders}) AND embedding_model = ?",
+                list(rowid_to_dist.keys()) + [model_name],
             ).fetchall()
             rows = [
                 {"rowid": r["embedding_id"], "distance": rowid_to_dist[r["embedding_id"]],
                  "source_table": r["source_table"], "source_id": r["source_id"]}
                 for r in meta_rows
+                if r["embedding_id"] in rowid_to_dist
             ]
             rows.sort(key=lambda r: r["distance"])
         except Exception:
@@ -1844,12 +1856,11 @@ class SQLiteMemoryStore:
             "messages": "message",
             "thoughts": "thought",
             "memory_digests": "memory_digest",
-            "memory_entries": "identity",
         }
         results = []
         seen_ids: set[str] = set()
         for row in rows:
-            source_table = row["source_table"]  # plain dict from our list comprehension
+            source_table = row["source_table"]
             source_id = row["source_id"]
             key = f"{source_table}:{source_id}"
             if key in seen_ids:
@@ -1861,9 +1872,14 @@ class SQLiteMemoryStore:
             if agent_id is not None and rec_agent != agent_id:
                 continue
             seen_ids.add(key)
+            # For memory_entries, use the row's own kind field rather than a fixed label.
+            kind = (
+                rec.get("kind") if source_table == "memory_entries"
+                else _table_to_kind.get(source_table, source_table)
+            )
             results.append(
                 MemorySearchResult(
-                    kind=_table_to_kind.get(source_table, "memory_entry"),
+                    kind=kind,
                     record_id=source_id,
                     content=rec.get("content", ""),
                     agent_id=rec_agent,
@@ -1886,14 +1902,15 @@ class SQLiteMemoryStore:
         limit: int = 20,
         **kwargs,
     ) -> list[MemorySearchResult]:
-        """Merge FTS cascade results with semantic results, deduplicating by record_id."""
+        """Merge FTS cascade results with semantic results, deduplicating by (kind, record_id)."""
         fts_results = self.search_cascade(query, agent_id=agent_id, limit=limit, **kwargs)
         if not self._vec_enabled:
             return fts_results
         sem_results = self.search_semantic(query, model_name, agent_id=agent_id, limit=limit)
-        seen = {r.record_id for r in fts_results}
+        seen = {(r.kind, r.record_id) for r in fts_results}
         for r in sem_results:
-            if r.record_id not in seen:
+            key = (r.kind, r.record_id)
+            if key not in seen:
                 fts_results.append(r)
-                seen.add(r.record_id)
+                seen.add(key)
         return fts_results[:limit]

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -87,7 +87,18 @@ class SQLiteMemoryStore:
         self.connection = sqlite3.connect(str(self.path))
         self.connection.row_factory = sqlite3.Row
         self.connection.execute("PRAGMA foreign_keys = ON")
+        self._vec_enabled = self._load_vec_extension()
+        self._vec_tables: set[int] = set()
         self.ensure_schema()
+
+    def _load_vec_extension(self) -> bool:
+        """Load sqlite-vec if available; return True on success."""
+        try:
+            import sqlite_vec
+            sqlite_vec.load(self.connection)
+            return True
+        except Exception:
+            return False
 
     def close(self):
         self.connection.close()
@@ -297,9 +308,23 @@ class SQLiteMemoryStore:
             CREATE INDEX IF NOT EXISTS idx_memory_digests_agent ON memory_digests(agent_id);
             CREATE INDEX IF NOT EXISTS idx_memory_digest_sources_digest
                 ON memory_digest_sources(digest_id);
+            CREATE TABLE IF NOT EXISTS memory_embeddings (
+                embedding_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_table TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                embedding_model TEXT NOT NULL,
+                embedding_dimension INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                UNIQUE(source_table, source_id, embedding_model)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_runtime_events_session ON runtime_events(session_id);
             CREATE INDEX IF NOT EXISTS idx_runtime_events_type ON runtime_events(event_type);
             CREATE INDEX IF NOT EXISTS idx_channels_type ON channels(channel_type);
+            CREATE INDEX IF NOT EXISTS idx_memory_embeddings_source
+                ON memory_embeddings(source_table, source_id);
+            CREATE INDEX IF NOT EXISTS idx_memory_embeddings_model
+                ON memory_embeddings(embedding_model);
             """
         )
         self._ensure_memory_digest_columns()
@@ -1651,3 +1676,224 @@ class SQLiteMemoryStore:
 
     def _rows(self, query, params=()):
         return [dict(row) for row in self.connection.execute(query, params).fetchall()]
+
+    # ------------------------------------------------------------------ #
+    # Embedding / semantic search                                          #
+    # ------------------------------------------------------------------ #
+
+    def _vec_table_name(self, dimension: int) -> str:
+        return f"vec_{dimension}"
+
+    def _ensure_vec_table(self, dimension: int) -> bool:
+        """Create the vec0 virtual table for the given dimension if needed."""
+        if not self._vec_enabled:
+            return False
+        if dimension in self._vec_tables:
+            return True
+        table = self._vec_table_name(dimension)
+        try:
+            self.connection.execute(
+                f"CREATE VIRTUAL TABLE IF NOT EXISTS {table} "
+                f"USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[{dimension}])"
+            )
+            self.connection.commit()
+            self._vec_tables.add(dimension)
+            return True
+        except Exception:
+            return False
+
+    def store_embedding(
+        self,
+        source_table: str,
+        source_id: str | int,
+        vector: list[float],
+        model_name: str,
+    ) -> int | None:
+        """Store a float vector for a memory record; return embedding_id or None on error."""
+        if not self._vec_enabled or not vector:
+            return None
+        dim = len(vector)
+        if not self._ensure_vec_table(dim):
+            return None
+        try:
+            import sqlite_vec
+            cursor = self.connection.execute(
+                """
+                INSERT OR IGNORE INTO memory_embeddings
+                    (source_table, source_id, embedding_model, embedding_dimension, created_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (source_table, str(source_id), model_name, dim, _utc_now()),
+            )
+            embedding_id = cursor.lastrowid
+            if embedding_id == 0:
+                # Row already existed; fetch its id
+                row = self.connection.execute(
+                    "SELECT embedding_id FROM memory_embeddings "
+                    "WHERE source_table=? AND source_id=? AND embedding_model=?",
+                    (source_table, str(source_id), model_name),
+                ).fetchone()
+                if row is None:
+                    return None
+                embedding_id = row["embedding_id"]
+            table = self._vec_table_name(dim)
+            self.connection.execute(f"DELETE FROM {table} WHERE rowid = ?", (embedding_id,))
+            self.connection.execute(
+                f"INSERT INTO {table}(rowid, embedding) VALUES (?, ?)",
+                (embedding_id, sqlite_vec.serialize_float32(vector)),
+            )
+            self.connection.commit()
+            return embedding_id
+        except Exception:
+            return None
+
+    def get_pending_embedding_records(
+        self, model_name: str, limit: int = 50
+    ) -> list[dict]:
+        """Return FTS records that have no embedding for model_name yet."""
+        return self._rows(
+            """
+            SELECT mf.rowid AS fts_rowid, mf.kind, mf.record_id,
+                   mf.agent_id, mf.created_at, mf.content
+            FROM memory_fts mf
+            LEFT JOIN memory_embeddings me
+                ON me.source_table = CASE mf.kind
+                    WHEN 'message'      THEN 'messages'
+                    WHEN 'thought'      THEN 'thoughts'
+                    WHEN 'memory_digest' THEN 'memory_digests'
+                    ELSE 'memory_entries'
+                   END
+                AND me.source_id = mf.record_id
+                AND me.embedding_model = ?
+            WHERE me.embedding_id IS NULL
+            LIMIT ?
+            """,
+            [model_name, limit],
+        )
+
+    def embed_pending(self, model_name: str, limit: int = 50) -> int:
+        """Generate and store embeddings for unembedded FTS records; return count written."""
+        from robits.core.embeddings import get_embedding
+        _kind_to_table = {
+            "message": "messages",
+            "thought": "thoughts",
+            "memory_digest": "memory_digests",
+        }
+        records = self.get_pending_embedding_records(model_name, limit=limit)
+        written = 0
+        for rec in records:
+            vector = get_embedding(rec["content"], model=model_name)
+            if vector is None:
+                continue
+            source_table = _kind_to_table.get(rec["kind"], "memory_entries")
+            if self.store_embedding(source_table, rec["record_id"], vector, model_name):
+                written += 1
+        return written
+
+    def search_semantic(
+        self,
+        query: str,
+        model_name: str,
+        agent_id: str | None = None,
+        limit: int = 20,
+        _query_vector: list[float] | None = None,
+    ) -> list[MemorySearchResult]:
+        """Return MemorySearchResults ordered by embedding distance for query.
+
+        Pass _query_vector to skip the embedding API call (useful in tests).
+        """
+        if not self._vec_enabled:
+            return []
+        if _query_vector is not None:
+            vector = _query_vector
+        else:
+            from robits.core.embeddings import get_embedding
+            vector = get_embedding(query, model=model_name)
+        if vector is None:
+            return []
+        dim = len(vector)
+        if not self._ensure_vec_table(dim):
+            return []
+        try:
+            import sqlite_vec
+            table = self._vec_table_name(dim)
+            # vec0 requires LIMIT as the 'k' constraint; JOIN prevents this, so split into two queries.
+            knn_rows = self.connection.execute(
+                f"SELECT rowid, distance FROM {table} WHERE embedding MATCH ? ORDER BY distance LIMIT ?",
+                [sqlite_vec.serialize_float32(vector), limit * 2],
+            ).fetchall()
+            if not knn_rows:
+                return []
+            rowid_to_dist = {row["rowid"]: row["distance"] for row in knn_rows}
+            placeholders = ", ".join("?" * len(rowid_to_dist))
+            meta_rows = self.connection.execute(
+                f"SELECT embedding_id, source_table, source_id FROM memory_embeddings "
+                f"WHERE embedding_id IN ({placeholders})",
+                list(rowid_to_dist.keys()),
+            ).fetchall()
+            rows = [
+                {"rowid": r["embedding_id"], "distance": rowid_to_dist[r["embedding_id"]],
+                 "source_table": r["source_table"], "source_id": r["source_id"]}
+                for r in meta_rows
+            ]
+            rows.sort(key=lambda r: r["distance"])
+        except Exception:
+            return []
+
+        _table_to_kind = {
+            "messages": "message",
+            "thoughts": "thought",
+            "memory_digests": "memory_digest",
+            "memory_entries": "identity",
+        }
+        results = []
+        seen_ids: set[str] = set()
+        for row in rows:
+            source_table = row["source_table"]  # plain dict from our list comprehension
+            source_id = row["source_id"]
+            key = f"{source_table}:{source_id}"
+            if key in seen_ids:
+                continue
+            rec = self._fetch_source_record(source_table, source_id)
+            if rec is None:
+                continue
+            rec_agent = rec.get("agent_id") or rec.get("sender_agent_id")
+            if agent_id is not None and rec_agent != agent_id:
+                continue
+            seen_ids.add(key)
+            results.append(
+                MemorySearchResult(
+                    kind=_table_to_kind.get(source_table, "memory_entry"),
+                    record_id=source_id,
+                    content=rec.get("content", ""),
+                    agent_id=rec_agent,
+                    session_id=rec.get("session_id"),
+                    source=rec.get("source"),
+                    relationship_type=rec.get("relationship_type"),
+                    conversation_type=rec.get("conversation_type"),
+                    created_at=rec.get("created_at", ""),
+                )
+            )
+            if len(results) >= limit:
+                break
+        return results
+
+    def search_hybrid(
+        self,
+        query: str,
+        model_name: str,
+        agent_id: str | None = None,
+        limit: int = 20,
+        **kwargs,
+    ) -> list[MemorySearchResult]:
+        """Merge FTS cascade results with semantic results, deduplicating by record_id."""
+        fts_results = self.search_cascade(query, agent_id=agent_id, limit=limit, **kwargs)
+        if not self._vec_enabled:
+            return fts_results
+        sem_results = self.search_semantic(query, model_name, agent_id=agent_id, limit=limit)
+        seen = {r.record_id for r in fts_results}
+        for r in sem_results:
+            if r.record_id not in seen:
+                fts_results.append(r)
+                seen.add(r.record_id)
+        return fts_results[:limit]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3438,5 +3438,223 @@ class ChannelScopedMemoryTests(unittest.TestCase):
         self.assertIn("Python", work[0]["content"])
 
 
+class PersonaSeedingTests(unittest.TestCase):
+    """Tests for persona seeding into memory on first session."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "persona.sqlite3")
+        self.addCleanup(self.store.close)
+
+    def test_seed_persona_writes_thought(self):
+        self.store.upsert_agent("alice", "Role", "alice")
+        from robits.core.persona import seed_persona
+        written = seed_persona(self.store, "alice", [
+            {"kind": "thought", "content": "I enjoy hiking.", "visibility": "private"},
+        ])
+        self.assertEqual(written, 1)
+        rows = self.store._rows("SELECT * FROM thoughts WHERE agent_id = 'alice'")
+        self.assertEqual(len(rows), 1)
+        self.assertIn("hiking", rows[0]["content"])
+
+    def test_seed_persona_writes_digest(self):
+        self.store.upsert_agent("bob", "Role", "bob")
+        from robits.core.persona import seed_persona
+        written = seed_persona(self.store, "bob", [
+            {"kind": "digest", "digest_type": "identity", "content": "Bob is a backend engineer."},
+        ])
+        self.assertEqual(written, 1)
+        digests = self.store.list_memory_digests(agent_id="bob", digest_type="identity")
+        self.assertEqual(len(digests), 1)
+        self.assertIn("backend engineer", digests[0]["content"])
+
+    def test_seed_persona_is_idempotent(self):
+        self.store.upsert_agent("carol", "Role", "carol")
+        from robits.core.persona import seed_persona
+        entries = [{"kind": "thought", "content": "First seed.", "visibility": "private"}]
+        first = seed_persona(self.store, "carol", entries)
+        second = seed_persona(self.store, "carol", entries)
+        self.assertEqual(first, 1)
+        self.assertEqual(second, 0)
+        rows = self.store._rows("SELECT * FROM thoughts WHERE agent_id = 'carol'")
+        self.assertEqual(len(rows), 1)
+
+    def test_load_personas_missing_file_returns_empty(self):
+        from robits.core.persona import load_personas
+        result = load_personas("/nonexistent/path/personas.yaml")
+        self.assertEqual(result, {})
+
+    def test_seed_persona_writes_memory_entry(self):
+        self.store.upsert_agent("dave", "Role", "dave")
+        from robits.core.persona import seed_persona
+        written = seed_persona(self.store, "dave", [
+            {"kind": "entry", "digest_type": "identity", "content": "Dave values honesty."},
+        ])
+        self.assertEqual(written, 1)
+        rows = self.store._rows("SELECT * FROM memory_entries WHERE agent_id = 'dave'")
+        self.assertEqual(len(rows), 1)
+        self.assertIn("honesty", rows[0]["content"])
+
+
+class BreakClockStateTests(unittest.TestCase):
+    """Tests for the 'break' clock state — transitional between on and off."""
+
+    def setUp(self):
+        self.original_clock = main.clock_state
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        main.clock_state = self.original_clock
+
+    def test_break_is_valid_session_clock_state(self):
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        session = main.Session(participants={"A": a}, clock_state="break")
+        self.assertEqual(session.clock_state, "break")
+
+    def test_break_suppresses_org_chat_context(self):
+        received_prompts = []
+
+        class CapturingRole:
+            name = "B"
+            lifecycle_state = "active"
+            conversation_history = {}
+            template = ""
+            max_tokens = 100
+            temperature = 0.7
+            base_temperature = 0.7
+            runtime_tool_results = []
+            runtime_event_stream = None
+            runtime_session_id = None
+            runtime_role_name = None
+            runtime_clock_state = None
+            allowed_tools = set()
+
+            def interact(self, sender=None, prompt=None):
+                received_prompts.append(prompt or "")
+                return "response"
+
+            def update_group_conversations(self, m):
+                pass
+
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "initial",
+                            update_group_conversations=lambda m: None)
+        b = CapturingRole()
+        old_lines = main.org_chat_context_lines
+        main.org_chat_context_lines = 5
+        try:
+            session = main.Session(participants={"A": a, "B": b}, clock_state="break")
+            session.transcript.append(main.TranscriptEntry(1, "A", "B", "seed", "response"))
+            session.turns_completed = 1
+            session.last_receiver = a
+            session.step("hello")
+        finally:
+            main.org_chat_context_lines = old_lines
+
+        self.assertFalse(any("Recent org chat" in p for p in received_prompts))
+
+    def test_break_temperature_modulation(self):
+        from robits.core.session import _modulate_temperature
+        role = SimpleNamespace(temperature=0.7, base_temperature=0.7)
+        _modulate_temperature(role, "on")
+        on_temp = role.temperature
+        role.temperature = 0.7
+        _modulate_temperature(role, "break")
+        break_temp = role.temperature
+        role.temperature = 0.7
+        _modulate_temperature(role, "off")
+        off_temp = role.temperature
+        self.assertLess(on_temp, break_temp)
+        self.assertLess(break_temp, off_temp)
+
+    def test_break_parking_note_is_softer(self):
+        store_temp = tempfile.TemporaryDirectory()
+        store = SQLiteMemoryStore(Path(store_temp.name) / "bp.sqlite3")
+        store.upsert_agent("eve", "Role", "eve")
+        store.create_session("s_break")
+        from robits.memory.sqlite import CHANNEL_ORG_CHAT, SOCIAL_PROFESSIONAL
+        ch = store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
+        store.append_message("s_break", "eve", "eve", "sprint review xkw_break", channel_id=ch)
+        original_store = main.memory_store
+        original_clock = main.clock_state
+        main.memory_store = store
+        main.clock_state = "break"
+        old_caller = main.active_tool_caller
+        main.active_tool_caller = SimpleNamespace(name="eve", capabilities=set())
+        try:
+            result = main.memory_search({}, "eve", "xkw_break")
+        finally:
+            main.active_tool_caller = old_caller
+            main.memory_store = original_store
+            main.clock_state = original_clock
+            store.close()
+            store_temp.cleanup()
+        self.assertIn("System note", result)
+        self.assertIn("break", result)
+
+
+class EmbeddingSearchTests(unittest.TestCase):
+    """Tests for embedding-based semantic search in SQLiteMemoryStore."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "embed.sqlite3")
+        self.addCleanup(self.store.close)
+        self.store.upsert_agent("zoe", "Role", "zoe")
+        self.store.create_session("s_embed")
+
+    def test_store_embedding_and_search_semantic(self):
+        if not self.store._vec_enabled:
+            self.skipTest("sqlite-vec not available")
+        msg_id = self.store.append_message(
+            "s_embed", "zoe", "zoe", "semantic pool chemistry test"
+        )
+        vector = [0.1] * 768
+        self.store.store_embedding("messages", str(msg_id), vector, "test-model")
+        results = self.store.search_semantic(
+            "pool chemistry", "test-model", agent_id="zoe", limit=5,
+            _query_vector=vector,
+        )
+        record_ids = [r.record_id for r in results]
+        self.assertIn(str(msg_id), record_ids)
+
+    def test_store_embedding_idempotent(self):
+        if not self.store._vec_enabled:
+            self.skipTest("sqlite-vec not available")
+        msg_id = self.store.append_message("s_embed", "zoe", "zoe", "embedding idempotency check")
+        vector = [0.2] * 384
+        eid1 = self.store.store_embedding("messages", str(msg_id), vector, "model-a")
+        eid2 = self.store.store_embedding("messages", str(msg_id), vector, "model-a")
+        self.assertEqual(eid1, eid2)
+
+    def test_get_pending_embedding_records_returns_unembedded(self):
+        if not self.store._vec_enabled:
+            self.skipTest("sqlite-vec not available")
+        self.store.append_message("s_embed", "zoe", "zoe", "unembedded record abc")
+        pending = self.store.get_pending_embedding_records("test-model", limit=50)
+        contents = [r["content"] for r in pending]
+        self.assertTrue(any("unembedded record abc" in c for c in contents))
+
+    def test_search_hybrid_falls_back_to_fts_without_model(self):
+        self.store.append_message("s_embed", "zoe", "zoe", "hybrid fts only search xyz99")
+        results = self.store.search_hybrid(
+            "xyz99", "nonexistent-model", agent_id="zoe", limit=10
+        )
+        contents = [r.content for r in results]
+        self.assertTrue(any("xyz99" in c for c in contents))
+
+    def test_vec_table_created_per_dimension(self):
+        if not self.store._vec_enabled:
+            self.skipTest("sqlite-vec not available")
+        self.store._ensure_vec_table(128)
+        self.store._ensure_vec_table(256)
+        self.assertIn(128, self.store._vec_tables)
+        self.assertIn(256, self.store._vec_tables)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements three issues in one branch (at least 3 separate commits):

## Issues addressed
- Closes #91 — Persona: per-agent identity seeds preloaded from `personas.yaml`
- Refs #66 — Break clock state + temperature modulation
- Closes #82 — Embedding-based semantic search via sqlite-vec

---

## Commit 1 — Persona seeding (#91)

- New `robits/core/persona.py`: `load_personas()` + idempotent `seed_persona()`
- `personas.yaml` at repo root with example seeds for SE, HR, CEO
- `ROBITS_PERSONAS_FILE` env var overrides default path
- Four seed kinds: `thought` (private channel), `message` (org_chat), `entry` (memory_entries), `digest` (identity digest)
- `Config.persona_entries` loaded at startup; `Session.__init__` seeds each participant on first session (skips if any memory already exists)

## Commit 2 — Break clock state & temperature modulation (#66)

- `break` is now a valid `ROBITS_CLOCK_STATE` value alongside `on` and `off`
- `Role.base_temperature` captured at construction; `Session.prepare_agent_runtime` modulates temperature per turn: `on`→0.6×, `break`→0.9×, `off`→1.3× (clamped to [0.05, 1.0])
- Agents feel more exploratory at break/off-clock without requiring prompt changes — purely via temperature
- Break suppresses org-chat context injection (same as off)
- Memory search during `break` gets a softer parking note than full off-clock
- Personal identity weighted higher during both `break` and `off`

## Commit 3 — Embedding-based semantic search (#82)

- New `robits/core/embeddings.py`: thin wrapper around OpenAI-compatible embeddings API, controlled by `ROBITS_EMBEDDING_MODEL` and `ROBITS_EMBEDDING_BASE_URL`
- `SQLiteMemoryStore` gains sqlite-vec integration:
  - `memory_embeddings` metadata table — **embedding model stored as a field, not as the table name** (per issue feedback)
  - `vec_{dim}` virtual tables created lazily per embedding dimension
  - `store_embedding()`, `get_pending_embedding_records()`, `embed_pending()`, `search_semantic()`, `search_hybrid()`
- `memory_search` tool uses `search_hybrid()` transparently when `ROBITS_EMBEDDING_MODEL` is set; falls back to FTS-only cascade otherwise
- Embedding backfill (`embed_pending`) runs at end-of-wait and end-of-session (sleep-cycle)
- `sqlite-vec` added to `requirements.txt`; all new sync methods mirrored in `AsyncSQLiteMemoryStore`

## Test plan
- [ ] All 296 existing + new tests pass
- [ ] `PersonaSeedingTests`: seeding writes correct channel/visibility, idempotency skip, all four kinds
- [ ] `BreakClockStateTests`: `break` accepted as session clock state; org chat suppressed; temperature curve on < break < off; softer parking note
- [ ] `EmbeddingSearchTests`: store/search/pending/vec table creation; hybrid falls back to FTS without model
- [ ] Local test: `ROBITS_MEMORY_DB=/tmp/r.db ROBITS_PERSONAS_FILE=personas.yaml python3 main.py --prompt "SE, what do you know about yourself?"` should show persona identity digest

🤖 Generated with [Claude Code](https://claude.com/claude-code)