### PR TITLE
feat: persona redesign, scheduled breaks, top_p modulation, embedding fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,196 +1,215 @@
 # AI-Powered Organization Simulation
 
-Welcome to the AI-Powered Organization Simulation project. This project explores how an organization with AI-driven roles can communicate and work together.
+A Python-based simulation of an AI-driven organisation where agents with distinct roles collaborate through a shared conversation loop backed by SQLite memory and OpenAI-compatible model APIs.
 
-## Table of Contents 📚
+## Table of Contents
 
-- [Getting Started](#getting-started)
 - [Roles](#roles)
 - [How It Works](#how-it-works)
+- [Memory](#memory)
+- [Personas](#personas)
+- [Clock States and Circadian Rhythm](#clock-states-and-circadian-rhythm)
+- [Embedding Search](#embedding-search)
+- [Observability](#observability)
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Running the Simulation](#running-the-simulation)
+- [Local Models (Ollama / LMStudio)](#local-models-ollama--lmstudio)
 - [Testing](#testing)
-- [Contributing](#contributing)
-- [Future Directions](#future-directions)
 
-## Getting Started 🏁
+## Roles
 
-The AI-Powered Organization Simulation is a Python-based project that simulates an organization with AI-driven roles, such as CEO, Ops, SE, and HR. The simulation demonstrates how these AI roles can communicate with each other and perform tasks specific to their roles.
+| Role | Description |
+|---|---|
+| CEO | Human-in-the-loop: reads from stdin, issues directives. |
+| Ops | Operations: oversees the agent environment; holds `operator` capability. |
+| SE | Software Engineer: designs and proposes new trusted tools; uses the costly model. |
+| HR | Human Resources: manages role lifecycle; holds `hr` capability. |
+| Samandriel | Angel guardian: speaks Enochian, protects employees. |
 
-## Roles 🧑‍💼
+HR can create additional dynamic roles at runtime via `org.create_role`.
 
-The organization has the following roles:
+Personas (see below) let individual identities fill these role slots with their own name, backstory, and memories.
 
-1. CEO (Human) - A human role responsible for making high-level decisions and setting the overall direction of the organization.
-2. Ops (Operations) - A role responsible for overseeing the execution environment and operational success of the agent organization.
-3. SE (Software Engineer) - A role responsible for designing, developing, and maintaining software applications, primarily proposing trusted tools when requested by other members of the organization.
-4. HR (Human Resources) - A role responsible for managing AI resources and creating new roles within the organization.
+## How It Works
 
-## How It Works 🛠️
+Sessions own a run ID, participant list, transcript, and a `RoundRobinScheduler`. Undirected messages cycle through all active participants; directed messages (`HR, ...`) still go through the scheduler via `observe()` to keep ordering consistent.
 
-The simulation runs in a session, where organization members communicate through messages. A session owns a run ID, participant list, turn count, transcript entries, and the system tool handler. Undirected messages use deterministic round-robin scheduling; directed messages such as `HR, ...` still route to the named role.
-
-The runtime can parse JSON tool instructions, load trusted tools from `tools.yaml`, and execute registered tools by name. Tools use namespaced identifiers such as `org.create_role`, with short aliases only where compatibility is useful.
-
-HR lifecycle tools keep role creation compatible while adding explicit states:
-`proposed`, `active`, `paused`, and `retired`. Current trusted tools create
-active roles directly, pause active roles, and retire active or paused roles.
-Lifecycle events record optional requester, approver, and reason fields.
-
-The target runtime direction is OpenAI-compatible tool calling through modern Responses-style loops: approved tools are exposed with JSON Schema metadata, the model may request function calls, the runtime executes those calls, and tool outputs are returned to the model without relying on ad hoc text parsing.
-
-See `docs/architecture-vision.md` for the staged runtime plan covering sessions, tools, SQLite-backed memory, memory digests, lifecycle, observability, TUI inspection, and local-model constraints.
+The System role parses JSON tool instructions from agent responses and executes registered tools. Approved tool proposals (from SE) are activated at rollout without a restart.
 
 ## Memory
 
-Robits includes a local SQLite memory substrate in `robits/memory/sqlite.py`.
-It defines durable tables for sessions, agents, contacts, messages, thoughts,
-todos, tool calls, and memory entries. FTS search indexes message, thought,
-tool-result, and memory-entry content with filters for agent, session,
-relationship type, conversation type, source, and date windows.
+SQLite memory store at `robits/memory/sqlite.py` with tables for sessions, agents, contacts, channels, messages, thoughts, todos, tool calls, memory entries, and memory digests. FTS5 full-text search with cascade expansion surfaces parent digests from raw hits. An async variant (`async_sqlite.py`) wraps the same interface for async runtimes.
 
-Generated local database files are ignored by git. Unit tests use temporary
-SQLite databases. Local runs should place generated databases under `data/` or
-`var/` unless the runtime is configured with another gitignored path.
+Memory digests are compacted artifacts with generation/version tracking, source references, and recursive expansion so future runs can re-analyse the original material.
 
-Memory digests are compacted memory artifacts stored with prompt version, source
-time range, retrieval filters, and ordered links back to raw source records so a
-future run can expand or reanalyze the original material.
+Enable automatic digest creation with:
+
+```
+ROBITS_DIGEST_INTERVAL=10          # episodic digest every 10 turns
+ROBITS_IDENTITY_DIGEST_INTERVAL=5  # identity checkpoint every 5 meaningful turns
+ROBITS_GOAL_DIGEST_INTERVAL=5      # goal checkpoint every 5 meaningful turns
+```
+
+## Personas
+
+`personas.yaml` pre-seeds individual identity memories for agents before their first session. The file uses `username` + `role` + `full_name` keys so multiple distinct individuals can fill the same role type:
+
+```yaml
+- username: alex_chen
+  full_name: Alex Chen
+  role: SE
+  memories:
+    - kind: thought
+      content: "Python was my first serious language."
+      visibility: private
+    - kind: digest
+      digest_type: identity
+      content: "Alex is a pragmatic backend engineer who values clean APIs."
+      relationship_type: personal
+
+- username: jamie_okonkwo
+  full_name: Jamie Okonkwo
+  role: SE
+  memories:
+    - kind: digest
+      digest_type: identity
+      content: "Jamie specialises in distributed systems."
+      relationship_type: personal
+```
+
+When `build_employee_dict()` receives the persona map, it instantiates each persona under its `username` key instead of the default role-type key. The `agents` table stores `username`, `first_name`, `last_name`, and `full_name` for mention matching.
+
+Seeding is idempotent: if any memory record already exists for the agent, the seed is skipped.
+
+Configure the file path with `ROBITS_PERSONAS_FILE` (defaults to `personas.yaml` in the working directory).
+
+### @mention detection
+
+When an org-chat message contains `@username` or any recognisable form of an agent's name (first name, last name, full name), the mentioned agent receives a lightweight note prepended to their next turn's prompt. The scheduler is not interrupted; mentions stay in the normal rotation.
+
+## Clock States and Circadian Rhythm
+
+Agents operate in one of three clock states that reflect the organisation's work rhythm:
+
+| State | Meaning | Temperature | top_p | Org-chat context |
+|---|---|---|---|---|
+| `on` | Work time | low (×0.6) | low (×0.6) | included |
+| `break` | Break time | moderate (×0.9) | moderate (×0.9) | suppressed |
+| `off` | Personal/family time | high (×1.3) | high (×1.3) | suppressed |
+
+`ROBITS_CLOCK_STATE` sets the base state. Temperature and `top_p` are modulated relative to each agent's own `base_temperature` and `base_top_p` so personality variation is preserved.
+
+### Scheduled breaks
+
+Set `ROBITS_BREAK_SCHEDULE` to comma-separated `HH:MM-HH:MM` windows in local time. The session auto-transitions to `break` during these windows without changing the base clock state:
+
+```
+ROBITS_BREAK_SCHEDULE=12:00-13:00,15:00-15:30
+```
+
+Agents can call `org.schedule` to see the current clock state and configured break windows.
+
+## Embedding Search
+
+sqlite-vec provides vector-similarity search over memory records. Set an embedding model and the search automatically enriches FTS results with semantic matches:
+
+```
+ROBITS_EMBEDDING_MODEL=granite-embedding:latest
+ROBITS_EMBEDDING_BASE_URL=http://127.0.0.1:11434/v1/
+ROBITS_EMBEDDING_API_KEY=ollama
+```
+
+Embeddings are computed lazily at agent wake-up (`_build_wait_summary`) and at session end. `embed_pending` processes only records not yet embedded for the configured model; different models can coexist in the same database.
+
+`search_hybrid` merges FTS cascade results with semantic results, deduplicating on `(kind, record_id)`.
 
 ## Observability
 
-Sessions emit a headless runtime event stream for session lifecycle, routing,
-message, tool, and private thought events. Tests and future TUI code can
-subscribe to the active stream without requiring an interactive terminal.
-Runtime events can also be persisted to SQLite and replayed later, with
-visibility fields separating public transcript events from private thoughts.
+Sessions emit a `RuntimeEventStream` for: `session.created`, `session.completed`, `message.routed`, `message.recorded`, `tool.executed`, `tool_call.requested`, `tool_call.executed`, `tool_call.failed`, `thought.recorded`, `agent.waited`, `clock.state.changed`. Tests can subscribe to the stream for assertions without a terminal.
 
 ## Sandboxes
 
-Agents can carry optional sandbox metadata. Default local runs keep sandboxing
-disabled and execute through the current runtime. When enabled, metadata names a
-backend plus a private per-agent workspace and a shared organization workspace.
-The runtime validates that an explicit configured backend matches the metadata
-before execution. The current implementation includes a fakeable runtime
-abstraction for tests and future container or cluster backends; it does not
-require containers for unit tests.
-
-See `docs/kind-sandbox-runtime.md` for the target kind/Kubernetes sandbox model.
-That design explains role-to-pod mapping, COO/operator permissions, capacity
-constraints, persistence, and the current gap between sandbox metadata and a
-real container backend.
+Agents carry optional `SandboxMetadata`. The current implementation provides a fakeable abstraction for tests; production backends (kind/Kubernetes) are described in `docs/kind-sandbox-runtime.md`.
 
 ## Installation
-
-To install the required packages for this project, run:
 
 ```bash
 pip install -r requirements.txt
 ```
 
+For local models with embedding support, `sqlite-vec` is included in `requirements.txt`.
+
 ## Configuration
 
-The runtime uses the OpenAI Python client and can target OpenAI or an OpenAI-compatible local endpoint.
-
-Relevant environment variables:
-
-- `OPENAI_API_KEY`: API key. Local compatible servers may accept any non-empty value.
-- `OPENAI_BASE_URL` or `OPENAI_API_BASE`: optional compatible endpoint URL.
-- `ROBITS_MODEL` or `OPENAI_MODEL`: default chat model.
-- `ROBITS_CHEAP_MODEL` and `ROBITS_COSTLY_MODEL`: optional per-role overrides.
-- `ROBITS_MEMORY_DB`: optional SQLite memory database path for memory introspection tools.
-- `ROBITS_MEMORY_MAX_DEPTH`: maximum recursive digest expansion depth (default `3`).
-- `ROBITS_MEMORY_MAX_ROWS`: maximum rows returned by any memory tool (default `100`).
-- `ROBITS_MEMORY_CACHE_THRESHOLD`: byte threshold above which memory tool results are offloaded to the agent's private workspace and a condensed snippet is returned (default `8192`).
-- `ROBITS_PROVIDER_API`: model API path, `responses` by default or `chat_completions` for compatibility.
-- `ROBITS_MAX_PARALLELISM`: maximum concurrent model calls, default `1`.
-- `ROBITS_MAX_API_RETRIES`: maximum retry attempts for transient API failures, default `3`.
-- `ROBITS_SEARCH_URL`: optional custom web search endpoint for `builtin.web_search`; falls back to the DuckDuckGo Instant Answers API.
-- `ROBITS_DIGEST_INTERVAL`: turns between automatic episodic digest creation; default `0` (disabled).
-- `ROBITS_DIGEST_CONTEXT_CHARS`: accumulated meaningful prompt/response characters that trigger automatic episodic digestion; default `0` (disabled).
-- `ROBITS_DIGEST_ELAPSED_SECONDS`: elapsed seconds with meaningful activity that trigger automatic episodic digestion; default `0` (disabled).
-- `ROBITS_IDENTITY_DIGEST_INTERVAL`: turns between automatic identity checkpoint digests; default `0` (disabled).
-- `ROBITS_GOAL_DIGEST_INTERVAL`: turns between automatic short-term goal checkpoint digests; default `0` (disabled).
-
-Automatic digest triggers skip silent/passive turns and tool-only runtime artifacts, so model-facing prompt context and operational noise do not bloat stored transcript memory. When enabled, digests are created for every agent and are searchable via `memory.search`.
-
-## Tools
-
-Trusted tools live in `tools.yaml`. Each entry includes a namespaced `name`, a JSON Schema `parameters` object, and trusted repo-owned code. Untrusted model output can request registered tools, but it cannot define new executable tools.
-Agents can use trusted alarm tools to create, list, and cancel their own reminders,
-and memory tools to inspect accessible SQLite memory. Memory digest creation and
-re-digestion remain automatic system behavior rather than agent-callable tools.
-Roles carry tool grants such as `agent.*` or `memory.search`; model providers
-only expose tools allowed for the active role, and execution denies disallowed
-tool calls. Operator roles can grant or revoke tool access, SE can propose
-non-system tool changes, and system tools such as memory internals and HR role
-management cannot be changed through SE proposals.
-
-The `builtin.*` namespace provides equivalents of the OpenAI built-in tool types
-as client-side function tools that work with any OpenAI-compatible endpoint:
-
-| Tool | Description | Capability required |
+| Variable | Default | Description |
 |---|---|---|
-| `builtin.web_search` | Search the web via DuckDuckGo or `ROBITS_SEARCH_URL` | — |
-| `builtin.file_search` | Search text in an agent's private workspace files | — |
-| `builtin.shell_run` | Run a shell command in the agent's workspace directory | `shell` |
-| `builtin.tool_search` | Search the tool registry by name or description | — |
-| `builtin.mcp_call` | Call a tool on an MCP server (not yet implemented) | `mcp` |
-| `builtin.computer_use` | Computer-use actions (not implemented) | `computer` |
-| `builtin.image_generation` | Generate images (not implemented) | — |
-
-All `builtin.*` tools are grantable. None are in the default tool grants; operators
-grant access explicitly via `tools.grant`.
-
-Example execution payload:
-
-```json
-{"exec": "org.create_role", "args": {"role_name": "QA", "role_description": "Tests the organization"}}
-```
+| `OPENAI_API_KEY` | — | API key (any non-empty string for local servers) |
+| `OPENAI_BASE_URL` | — | Compatible endpoint (Ollama: `http://127.0.0.1:11434/v1/`) |
+| `ROBITS_MODEL` / `OPENAI_MODEL` | `gpt-4o-mini` | Default chat model |
+| `ROBITS_CHEAP_MODEL` | `ROBITS_MODEL` | Model for cheap interactions |
+| `ROBITS_COSTLY_MODEL` | `ROBITS_MODEL` | Model for SE and costly interactions |
+| `ROBITS_PROVIDER_API` | `responses` | `responses` or `chat` / `chat_completions` |
+| `ROBITS_MEMORY_DB` | — | SQLite path; memory tools disabled when unset |
+| `ROBITS_CLOCK_STATE` | `on` | Base clock state: `on`, `break`, or `off` |
+| `ROBITS_BREAK_SCHEDULE` | — | Scheduled break windows, e.g. `12:00-13:00,15:00-15:30` |
+| `ROBITS_PERSONAS_FILE` | `personas.yaml` | Path to persona seed file |
+| `ROBITS_EMBEDDING_MODEL` | — | Embedding model name; disables semantic search when unset |
+| `ROBITS_EMBEDDING_BASE_URL` | `OPENAI_BASE_URL` | Embedding endpoint (can differ from chat endpoint) |
+| `ROBITS_EMBEDDING_API_KEY` | `OPENAI_API_KEY` | Embedding API key |
+| `ROBITS_MEMORY_MAX_DEPTH` | `3` | Max recursive digest expansion depth |
+| `ROBITS_MEMORY_MAX_ROWS` | `100` | Max rows per memory tool result |
+| `ROBITS_MEMORY_CACHE_THRESHOLD` | `8192` | Bytes above which memory results are offloaded to workspace |
+| `ROBITS_DIGEST_INTERVAL` | `0` | Turns between episodic digests (0 = disabled) |
+| `ROBITS_DIGEST_CONTEXT_CHARS` | `0` | Accumulated chars that trigger digestion (0 = disabled) |
+| `ROBITS_DIGEST_ELAPSED_SECONDS` | `0` | Elapsed seconds that trigger digestion (0 = disabled) |
+| `ROBITS_IDENTITY_DIGEST_INTERVAL` | `0` | Meaningful turns between identity checkpoints |
+| `ROBITS_GOAL_DIGEST_INTERVAL` | `0` | Meaningful turns between goal checkpoints |
+| `ROBITS_MAX_PARALLELISM` | `1` | Max concurrent model calls |
+| `ROBITS_MAX_API_RETRIES` | `3` | Retries on transient API errors |
+| `ROBITS_LOCATION` | — | Default location string for agent context |
+| `ROBITS_TIMEZONE` | — | Default timezone (e.g. `America/New_York`) |
 
 ## Running the Simulation
 
-To run the AI-Powered Organization Simulation:
+```bash
+python main.py
+```
 
-1. Run the Python file using a Python interpreter:
-   ```bash
-   python main.py
-   ```
-
-For non-interactive smoke checks, provide an initial prompt and turn limit:
+For non-interactive smoke checks:
 
 ```bash
 python main.py --prompt "Ops, say hello to HR" --turns 1
 ```
 
-To capture the same console transcript to a file while still watching the run:
+Capture to a log file while watching:
 
 ```bash
 python main.py --prompt "Ops, say hello to HR" --turns 1 --log run.log
 ```
 
-## Testing
+## Local Models (Ollama / LMStudio)
 
-The focused runtime tests do not call an external model service:
+`run_local.py` seeds a fresh memory database and delegates to `main.py`. It demonstrates persona recall with pre-seeded work and personal memories.
 
 ```bash
-python -m unittest
+OPENAI_BASE_URL=http://127.0.0.1:11434/v1/ \
+OPENAI_API_KEY=ollama \
+OPENAI_MODEL=granite4.1:3b \
+ROBITS_PROVIDER_API=chat \
+ROBITS_MEMORY_DB=/tmp/robits_local.db \
+ROBITS_EMBEDDING_MODEL=granite-embedding:latest \
+ROBITS_EMBEDDING_BASE_URL=http://127.0.0.1:11434/v1/ \
+ROBITS_EMBEDDING_API_KEY=ollama \
+python run_local.py --prompt "SE, do you have experience with Python or cooking?"
 ```
 
-## Contributing 🤝
+Tested with `granite4.1:3b` for tool calling; `granite-embedding:latest` and `embeddinggemma:latest` for embeddings. Models are pulled with `ollama pull <name>`.
 
-We welcome contributions to this project! Feel free to submit pull requests, report bugs, or suggest new features. To get started, check out the [Future Directions](#future-directions) section for some ideas on how you can contribute.
+## Testing
 
-## Future Directions 🚀
+```bash
+python -m pytest tests/
+```
 
-There are many exciting ways you can improve and expand this project. Here are a few ideas to get you started:
-
-1. Add more roles to the organization (e.g., marketing, sales, or finance roles) to explore new interactions between AI-driven roles.
-2. Enhance the AI's ability to understand context and engage in more complex conversations.
-3. Implement a graphical user interface (GUI) for a more immersive and user-friendly simulation experience.
-4. Explore ways to use real-world data to drive the simulation and make it more engaging and relevant.
-5. Experiment with different AI models or techniques to improve the performance and capabilities of the AI roles.
-6. Extend the deterministic time-share scheduler toward parallel role execution once shared state coordination is explicit.
-
-Have fun exploring the AI-Powered Organization Simulation! We can't wait to see what you come up with! 🎉💡
+Tests do not require an external model service or a running Ollama instance. Embedding tests use injected vectors (`_query_vector` parameter) to avoid network calls.

--- a/personas.yaml
+++ b/personas.yaml
@@ -1,8 +1,12 @@
-# Per-agent persona seeds — preloaded into memory on first session.
+# Per-persona seeds — preloaded into memory on first session.
+# New schema: role (class/type), username (agent_id), full_name (display name).
+# Legacy schema using `agent:` is still supported for backwards compatibility.
 # kind: thought | message | entry | digest
 # See robits/core/persona.py for seeding logic.
 
-- agent: SE
+- username: alex_chen
+  full_name: Alex Chen
+  role: SE
   memories:
     - kind: thought
       channel: agent_thought
@@ -15,22 +19,26 @@
     - kind: digest
       digest_type: identity
       content: >
-        SE is a pragmatic backend engineer with deep Python experience who values
+        Alex is a pragmatic backend engineer with deep Python experience who values
         clean APIs, strong test coverage, and minimal abstractions. Enjoys cooking
         and outdoor running outside of work hours.
       relationship_type: personal
 
-- agent: HR
+- username: hr_lead
+  full_name: Jordan Lee
+  role: HR
   memories:
     - kind: digest
       digest_type: identity
       content: >
-        HR is the organisation's people-ops lead: manages role lifecycle, mediates
+        Jordan is the organisation's people-ops lead: manages role lifecycle, mediates
         disputes, and keeps the org chart healthy. Values fairness, clear communication,
         and process transparency.
       relationship_type: work
 
-- agent: CEO
+- username: CEO
+  full_name: CEO
+  role: CEO
   memories:
     - kind: digest
       digest_type: identity

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -7,6 +7,20 @@ import os
 import threading
 
 
+def _parse_break_schedule(raw: str) -> list:
+    """Parse 'HH:MM-HH:MM[,HH:MM-HH:MM...]' into a list of (start, end) string pairs."""
+    windows = []
+    for segment in (raw or "").split(","):
+        segment = segment.strip()
+        if not segment or "-" not in segment:
+            continue
+        parts = segment.split("-", 1)
+        start, end = parts[0].strip(), parts[1].strip()
+        if len(start) == 5 and len(end) == 5:
+            windows.append((start, end))
+    return windows
+
+
 class Config:
     """All env-derived settings and mutable runtime state in one injectable object.
 
@@ -104,6 +118,9 @@ class Config:
         self.personas_file = env.get("ROBITS_PERSONAS_FILE", "").strip() or None
         from robits.core.persona import load_personas
         self.persona_entries = load_personas(self.personas_file)
+
+        # --- schedule ---
+        self.break_schedule = _parse_break_schedule(env.get("ROBITS_BREAK_SCHEDULE", ""))
 
         # --- misc ---
         self.builtin_search_url = env.get("ROBITS_SEARCH_URL", "").strip()

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -91,7 +91,8 @@ class Config:
             0, int(env.get("ROBITS_GOAL_DIGEST_INTERVAL", "0"))
         )
 
-        self.agent_workspace_store = AgentWorkspaceStore()
+        self.agent_workspace_root = env.get("ROBITS_AGENT_WORKSPACE_ROOT", "var/agents")
+        self.agent_workspace_store = AgentWorkspaceStore(self.agent_workspace_root)
         self._org_workspace = (
             self.agent_workspace_store if self.memory_store is not None else None
         )
@@ -121,6 +122,7 @@ class Config:
 
         # --- schedule ---
         self.break_schedule = _parse_break_schedule(env.get("ROBITS_BREAK_SCHEDULE", ""))
+        self.tool_proposals_file = env.get("ROBITS_TOOL_PROPOSALS_FILE", "var/tool_proposals.json")
 
         # --- misc ---
         self.builtin_search_url = env.get("ROBITS_SEARCH_URL", "").strip()

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -8,16 +8,35 @@ import threading
 
 
 def _parse_break_schedule(raw: str) -> list:
-    """Parse 'HH:MM-HH:MM[,HH:MM-HH:MM...]' into a list of (start, end) string pairs."""
+    """Parse 'HH:MM-HH:MM[,HH:MM-HH:MM...]' into a list of (start, end) string pairs.
+
+    Normalises single-digit hours (9:00 → 09:00). Rejects midnight-wrapping windows
+    (start >= end) and silently skips malformed segments.
+    """
+    import logging
     windows = []
     for segment in (raw or "").split(","):
         segment = segment.strip()
-        if not segment or "-" not in segment:
+        if not segment:
             continue
         parts = segment.split("-", 1)
-        start, end = parts[0].strip(), parts[1].strip()
-        if len(start) == 5 and len(end) == 5:
-            windows.append((start, end))
+        if len(parts) != 2:
+            logging.warning("robits: skipping malformed break schedule segment %r", segment)
+            continue
+        try:
+            from datetime import datetime as _dt
+            s = _dt.strptime(parts[0].strip(), "%H:%M").time()
+            e = _dt.strptime(parts[1].strip(), "%H:%M").time()
+        except ValueError:
+            logging.warning("robits: skipping unparseable break schedule segment %r", segment)
+            continue
+        if s >= e:
+            logging.warning(
+                "robits: skipping midnight-wrapping or zero-length break window %s-%s",
+                s.strftime("%H:%M"), e.strftime("%H:%M"),
+            )
+            continue
+        windows.append((s.strftime("%H:%M"), e.strftime("%H:%M")))
     return windows
 
 

--- a/robits/core/context.py
+++ b/robits/core/context.py
@@ -59,6 +59,10 @@ def agent_runtime_context(role=None):
     )
     canonical_id = role_name
     primary_id, secondary_id = _get_identity_digests(canonical_id)
+    effective_clock = (
+        getattr(role, "runtime_clock_state", None) or _m.clock_state
+    )
+    break_schedule = getattr(_m, "break_schedule", []) or None
     context = {
         "agent_name": role_name,
         "session_id": getattr(role, "runtime_session_id", None),
@@ -67,7 +71,8 @@ def agent_runtime_context(role=None):
         "current_date_local": now_local.date().isoformat(),
         "timezone": _runtime_timezone_name(local_tz),
         "location": _m.default_location or None,
-        "clock_state": _m.clock_state,
+        "clock_state": effective_clock,
+        "break_schedule": break_schedule,
         "identity_primary": primary_id,
         "identity_secondary": secondary_id,
     }

--- a/robits/core/persona.py
+++ b/robits/core/persona.py
@@ -9,10 +9,12 @@ _VALID_KINDS = {"thought", "message", "entry", "digest"}
 _DEFAULT_PERSONAS_FILE = "personas.yaml"
 
 
-def load_personas(path: str | None = None) -> dict[str, list[dict]]:
-    """Load personas.yaml and return {agent_name: [entry_dicts]}.
+def load_personas(path: str | None = None) -> dict[str, dict]:
+    """Load personas.yaml and return {username: {role, full_name, entries}}.
 
-    Returns an empty dict if the file is absent or unparseable.
+    Supports both the new schema (username/role/full_name) and the legacy
+    schema (agent) for backwards compatibility.  Returns an empty dict if
+    the file is absent or unparseable.
     """
     try:
         import yaml
@@ -28,17 +30,35 @@ def load_personas(path: str | None = None) -> dict[str, list[dict]]:
         return {}
     if not isinstance(data, list):
         return {}
-    result: dict[str, list[dict]] = {}
+    result: dict[str, dict] = {}
     for item in data:
         if not isinstance(item, dict):
             continue
-        agent = item.get("agent")
         memories = item.get("memories")
-        if not agent or not isinstance(memories, list):
+        if not isinstance(memories, list):
             continue
-        result.setdefault(agent, []).extend(
-            m for m in memories if isinstance(m, dict) and m.get("kind") in _VALID_KINDS
-        )
+        valid_entries = [m for m in memories if isinstance(m, dict) and m.get("kind") in _VALID_KINDS]
+
+        # New schema: username + role + optional full_name
+        username = item.get("username")
+        role = item.get("role")
+        if username and role:
+            full_name = item.get("full_name", username)
+            result[username] = {
+                "role": role,
+                "full_name": full_name,
+                "entries": valid_entries,
+            }
+            continue
+
+        # Legacy schema: agent key
+        agent = item.get("agent")
+        if agent:
+            result[agent] = {
+                "role": agent,
+                "full_name": agent,
+                "entries": valid_entries,
+            }
     return result
 
 

--- a/robits/core/persona.py
+++ b/robits/core/persona.py
@@ -1,7 +1,6 @@
 """Persona seeding: preload per-agent identity memories from a YAML configuration."""
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +20,7 @@ def load_personas(path: str | None = None) -> dict[str, dict]:
     except ImportError:
         return {}
 
-    resolved = Path(path or os.environ.get("ROBITS_PERSONAS_FILE", _DEFAULT_PERSONAS_FILE))
+    resolved = Path(path or _DEFAULT_PERSONAS_FILE)
     if not resolved.exists():
         return {}
     try:

--- a/robits/core/providers.py
+++ b/robits/core/providers.py
@@ -123,6 +123,9 @@ class ChatCompletionsProvider(ModelProvider):
             "temperature": role.temperature,
             "user": f"robits_{role.name}",
         }
+        top_p = getattr(role, "top_p", None)
+        if top_p is not None:
+            kwargs["top_p"] = top_p
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
@@ -193,6 +196,9 @@ class ResponsesProvider(ModelProvider):
             "temperature": role.temperature,
             "user": f"robits_{role.name}",
         }
+        top_p = getattr(role, "top_p", None)
+        if top_p is not None:
+            kwargs["top_p"] = top_p
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -187,7 +187,7 @@ class HR(Role):
             self.__class__.__name__, role_description, employee_dict, group_template_additions
         )
         self.capabilities = {"hr", "protected", "essential"}
-        self.allowed_tools.update({"org.*", "tools.list"})
+        self.allowed_tools.update({"org.*", "tools.list", "tools.list_proposals"})
 
 
 class Angel(Role):

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -217,7 +217,7 @@ class SoftwareEngineer(Role):
 class Human(Role):
     """CEO role — a human-in-the-loop participant that reads from stdin."""
 
-    def __init__(self):
+    def __init__(self, employee_dict=None):
         self.name = "CEO"
         self.template = "As CEO, you are responsible for making high-level decisions and setting the overall direction of the organization."
         self.lifecycle_state = "active"
@@ -266,6 +266,8 @@ _ROLE_CLASS_MAP = {
     "HR": HR,
     "Angel": Angel,
     "Samandriel": Angel,
+    "CEO": Human,
+    "Human": Human,
 }
 
 
@@ -295,6 +297,11 @@ def build_employee_dict(persona_map=None):
             full_name = info.get("full_name", username)
             RoleClass = _ROLE_CLASS_MAP.get(role_key)
             if RoleClass is None:
+                import logging
+                logging.warning(
+                    "robits: persona %r references unknown role %r — skipping",
+                    username, role_key,
+                )
                 continue
             # Remove the pre-built default entry for this role type (once per role class)
             default_key = next(

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -76,6 +76,8 @@ When thinking, recalling past events, or forming memories, use your tools rather
         self.global_conversation_history = []
         self.temperature = 0.7
         self.base_temperature = self.temperature
+        self.top_p = 0.9
+        self.base_top_p = self.top_p
         self.max_tokens = random.randint(250, 400)
         self.lifecycle_state = "active"
         self.lifecycle_events = []

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -259,14 +259,60 @@ class Human(Role):
         return text
 
 
-def build_employee_dict():
-    """Construct and return the default set of organisation participants."""
+_ROLE_CLASS_MAP = {
+    "SoftwareEngineer": SoftwareEngineer,
+    "SE": SoftwareEngineer,
+    "Ops": Ops,
+    "HR": HR,
+    "Angel": Angel,
+    "Samandriel": Angel,
+}
+
+
+def build_employee_dict(persona_map=None):
+    """Construct and return the default set of organisation participants.
+
+    If ``persona_map`` is provided ({username: {role, full_name, entries}}),
+    each persona is instantiated under its ``username`` key instead of the
+    default role-class name.  Personas override the default entry for their
+    role type when the role key is present in the default dict.
+    """
     employee_dict = {}
     employee_dict["CEO"] = Human()
     employee_dict["Ops"] = Ops(employee_dict)
     employee_dict["SE"] = SoftwareEngineer(employee_dict)
     employee_dict["HR"] = HR(employee_dict)
     employee_dict["Samandriel"] = Angel(employee_dict)
+
+    if persona_map:
+        # Track which pre-built default keys have been replaced by persona usernames
+        default_keys_replaced: set = set()
+        default_keys = set(employee_dict)
+        for username, info in persona_map.items():
+            if not isinstance(info, dict):
+                continue
+            role_key = info.get("role", username)
+            full_name = info.get("full_name", username)
+            RoleClass = _ROLE_CLASS_MAP.get(role_key)
+            if RoleClass is None:
+                continue
+            # Remove the pre-built default entry for this role type (once per role class)
+            default_key = next(
+                (k for k in default_keys if k not in default_keys_replaced
+                 and k in employee_dict and type(employee_dict[k]) is RoleClass),
+                None,
+            )
+            if default_key:
+                del employee_dict[default_key]
+                default_keys_replaced.add(default_key)
+            instance = RoleClass(employee_dict)
+            instance.name = username
+            instance.full_name = full_name
+            parts = full_name.split(None, 1)
+            instance.first_name = parts[0] if parts else username
+            instance.last_name = parts[1] if len(parts) > 1 else ""
+            employee_dict[username] = instance
+
     return employee_dict
 
 

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -173,7 +173,10 @@ class Session:
         event_stream=None,
         clock_state=None,
     ):
-        self.participants = participants if participants is not None else build_employee_dict()
+        self.participants = (
+            participants if participants is not None
+            else build_employee_dict(_m.persona_entries or None)
+        )
         self.system = system if system is not None else System(self.participants)
         scheduler_names = list(self.participants)
         self.scheduler = scheduler if scheduler is not None else RoundRobinScheduler(scheduler_names)
@@ -213,9 +216,19 @@ class Session:
                 _m.memory_store.create_session(self.run_id)
                 for name, participant in self.participants.items():
                     role_type = type(participant).__name__
-                    _m.memory_store.upsert_agent(name, role_type, display_name=name)
-                    if _m.persona_entries.get(name):
-                        seed_persona(_m.memory_store, name, _m.persona_entries[name])
+                    persona = _m.persona_entries.get(name) or {}
+                    full_name = persona.get("full_name") if isinstance(persona, dict) else None
+                    _m.memory_store.upsert_agent(
+                        name, role_type,
+                        display_name=full_name or name,
+                        username=name,
+                        full_name=full_name,
+                        first_name=getattr(participant, "first_name", None),
+                        last_name=getattr(participant, "last_name", None),
+                    )
+                    entries = persona.get("entries") if isinstance(persona, dict) else persona
+                    if entries:
+                        seed_persona(_m.memory_store, name, entries)
                 self._org_chat_channel_id = _m.memory_store.get_or_create_channel(
                     CHANNEL_ORG_CHAT,
                     social_distance=SOCIAL_PROFESSIONAL,
@@ -709,6 +722,34 @@ class Session:
         """Resolve a role display name to its participant dict key for FK-safe storage."""
         return self._name_to_key.get(name, name)
 
+    def _detect_mentions(self, message: str) -> set:
+        """Return the set of participant keys mentioned in message (by @username or name token)."""
+        import re as _re
+        if not isinstance(message, str) or not message:
+            return set()
+        text_lower = message.lower()
+        # Normalise: replace non-alphanumeric (except @/_) with space for word-boundary matching
+        normalised = _re.sub(r"[^a-z0-9@_]+", " ", text_lower)
+        mentioned: set = set()
+        if _m.memory_store is not None:
+            try:
+                name_tokens = _m.memory_store.get_agent_name_tokens()
+                for agent_id, tokens in name_tokens.items():
+                    if agent_id not in self.participants:
+                        continue
+                    for token in tokens:
+                        if not token:
+                            continue
+                        norm_token = _re.sub(r"[^a-z0-9@_]+", " ", token.lower()).strip()
+                        if not norm_token:
+                            continue
+                        if f"@{norm_token}" in normalised or f" {norm_token} " in f" {normalised} ":
+                            mentioned.add(agent_id)
+                            break
+            except Exception:
+                pass
+        return mentioned
+
     def _effective_clock_state(self) -> str:
         """Return 'break' if current time falls within a configured break window, else clock_state."""
         schedule = getattr(_m, "break_schedule", [])
@@ -771,6 +812,10 @@ class Session:
         reminders = due_alarm_reminders(routed.receiver)
         if reminders:
             prompt = "\n".join(reminders + [prompt])
+        receiver_key = self._role_to_key.get(id(routed.receiver))
+        mentions = self._detect_mentions(message)
+        if receiver_key and receiver_key in mentions:
+            prompt = f"[Note: you were mentioned in this message]\n{prompt}"
         raw_prompt = prepend_verified_tool_results(
             prompt,
             self.recent_system_events() + system_events,

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -147,15 +147,17 @@ _CLOCK_TEMP_MULTIPLIER = {"on": 0.6, "break": 0.9, "off": 1.3}
 
 
 def _modulate_temperature(role, clock_state):
-    """Adjust role.temperature around its base_temperature for the given clock state.
+    """Adjust role.temperature and role.top_p around their base values for clock state.
 
-    Initialises base_temperature from the current temperature on first call so
-    that repeated calls always modulate from the same stable baseline.
+    Initialises base values from current values on first call so repeated calls
+    always modulate from the same stable baseline.
     """
     if not hasattr(role, "base_temperature"):
         role.base_temperature = getattr(role, "temperature", 0.7)
     multiplier = _CLOCK_TEMP_MULTIPLIER.get(clock_state, 1.0)
     role.temperature = max(0.05, min(1.0, role.base_temperature * multiplier))
+    if hasattr(role, "base_top_p"):
+        role.top_p = max(0.1, min(1.0, role.base_top_p * multiplier))
 
 
 class Session:

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -709,6 +709,16 @@ class Session:
         """Resolve a role display name to its participant dict key for FK-safe storage."""
         return self._name_to_key.get(name, name)
 
+    def _effective_clock_state(self) -> str:
+        """Return 'break' if current time falls within a configured break window, else clock_state."""
+        schedule = getattr(_m, "break_schedule", [])
+        if schedule:
+            now = datetime.now(timezone.utc).astimezone().strftime("%H:%M")
+            for start, end in schedule:
+                if start <= now < end:
+                    return "break"
+        return self.clock_state
+
     def sync_scheduler_participants(self):
         """Add active roles to and remove non-active roles from the scheduler."""
         for name, participant in self.participants.items():
@@ -722,8 +732,9 @@ class Session:
         role.runtime_event_stream = self.event_stream
         role.runtime_session_id = self.run_id
         role.runtime_tool_results = []
-        role.runtime_clock_state = self.clock_state
-        _modulate_temperature(role, self.clock_state)
+        effective_clock = self._effective_clock_state()
+        role.runtime_clock_state = effective_clock
+        _modulate_temperature(role, effective_clock)
         for name, participant in self.participants.items():
             if participant is role:
                 role.runtime_role_name = name
@@ -764,7 +775,7 @@ class Session:
             prompt,
             self.recent_system_events() + system_events,
         )
-        effective_org_lines = _m.org_chat_context_lines if self.clock_state == "on" else 0
+        effective_org_lines = _m.org_chat_context_lines if self._effective_clock_state() == "on" else 0
         org_context = format_org_chat_context(self.transcript, effective_org_lines)
         model_prompt = org_context + raw_prompt if org_context else raw_prompt
         self.prepare_agent_runtime(routed.receiver)

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -723,13 +723,19 @@ class Session:
         return self._name_to_key.get(name, name)
 
     def _detect_mentions(self, message: str) -> set:
-        """Return the set of participant keys mentioned in message (by @username or name token)."""
+        """Return the set of participant keys mentioned in message.
+
+        Matching rules (in priority order):
+        - ``@username``: case-insensitive, always matched.
+        - Full name (multi-word): phrase match on normalised text, always matched.
+        - Single-word username / first / last name: only matched when the token
+          appears CAPITALISED in the original message, reducing false positives for
+          common English words (will, may, mark, grace, …).
+        """
         import re as _re
         if not isinstance(message, str) or not message:
             return set()
-        text_lower = message.lower()
-        # Normalise: replace non-alphanumeric (except @/_) with space for word-boundary matching
-        normalised = _re.sub(r"[^a-z0-9@_]+", " ", text_lower)
+        normalised = _re.sub(r"[^a-z0-9@_]+", " ", message.lower())
         mentioned: set = set()
         if _m.memory_store is not None:
             try:
@@ -743,7 +749,17 @@ class Session:
                         norm_token = _re.sub(r"[^a-z0-9@_]+", " ", token.lower()).strip()
                         if not norm_token:
                             continue
-                        if f"@{norm_token}" in normalised or f" {norm_token} " in f" {normalised} ":
+                        # @username — always match
+                        if f"@{norm_token}" in normalised:
+                            mentioned.add(agent_id)
+                            break
+                        # Multi-word full name — phrase match
+                        if " " in norm_token and f" {norm_token} " in f" {normalised} ":
+                            mentioned.add(agent_id)
+                            break
+                        # Single-word token — only if capitalised in original text
+                        cap = token[0].upper() + token[1:].lower() if len(token) > 1 else token.upper()
+                        if _re.search(r"\b" + _re.escape(cap) + r"\b", message):
                             mentioned.add(agent_id)
                             break
             except Exception:
@@ -751,13 +767,18 @@ class Session:
         return mentioned
 
     def _effective_clock_state(self) -> str:
-        """Return 'break' if current time falls within a configured break window, else clock_state."""
-        schedule = getattr(_m, "break_schedule", [])
-        if schedule:
-            now = datetime.now(timezone.utc).astimezone().strftime("%H:%M")
-            for start, end in schedule:
-                if start <= now < end:
-                    return "break"
+        """Return 'break' if inside a configured break window and base state is 'on', else clock_state.
+
+        Scheduled breaks only promote 'on' → 'break'; they never override 'off' (which
+        is more restrictive than 'break' and has a higher temperature multiplier).
+        """
+        if self.clock_state == "on":
+            schedule = getattr(_m, "break_schedule", [])
+            if schedule:
+                now = datetime.now(timezone.utc).astimezone().strftime("%H:%M")
+                for start, end in schedule:
+                    if start <= now < end:
+                        return "break"
         return self.clock_state
 
     def sync_scheduler_participants(self):

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -1,7 +1,6 @@
 """Tool functions exposed to agents."""
 import ast
 import json
-import os
 from datetime import datetime, timezone
 from uuid import uuid4
 
@@ -181,9 +180,7 @@ def list_registered_tools(employee_dict, role_name=None, include_system=True, on
 def get_tool_proposal_store():
     """Return the global ToolProposalStore, initialising it on first access."""
     if _m.tool_proposal_store is None:
-        _m.tool_proposal_store = ToolProposalStore(
-            os.environ.get("ROBITS_TOOL_PROPOSALS_FILE", "var/tool_proposals.json")
-        )
+        _m.tool_proposal_store = ToolProposalStore(_m.tool_proposals_file)
     return _m.tool_proposal_store
 
 

--- a/robits/memory/async_sqlite.py
+++ b/robits/memory/async_sqlite.py
@@ -151,18 +151,27 @@ class AsyncSQLiteMemoryStore:
         lifecycle_state="active",
         created_at=None,
         metadata=None,
+        username=None,
+        first_name=None,
+        last_name=None,
+        full_name=None,
     ):
         timestamp = created_at or _utc_now()
         async with self._db_lock:
             await self.connection.execute(
                 """
                 INSERT INTO agents(
-                    agent_id, role, display_name, lifecycle_state, created_at, metadata_json
+                    agent_id, role, display_name, username, first_name, last_name, full_name,
+                    lifecycle_state, created_at, metadata_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(agent_id) DO UPDATE SET
                     role = excluded.role,
                     display_name = excluded.display_name,
+                    username = COALESCE(excluded.username, agents.username),
+                    first_name = COALESCE(excluded.first_name, agents.first_name),
+                    last_name = COALESCE(excluded.last_name, agents.last_name),
+                    full_name = COALESCE(excluded.full_name, agents.full_name),
                     lifecycle_state = excluded.lifecycle_state,
                     metadata_json = excluded.metadata_json
                 """,
@@ -170,6 +179,10 @@ class AsyncSQLiteMemoryStore:
                     agent_id,
                     role,
                     display_name,
+                    username,
+                    first_name,
+                    last_name,
+                    full_name,
                     lifecycle_state,
                     timestamp,
                     _json_dumps(metadata),
@@ -177,6 +190,23 @@ class AsyncSQLiteMemoryStore:
             )
             await self.connection.commit()
         return agent_id
+
+    async def get_agent_name_tokens(self) -> dict:
+        """Return a mapping of active agent_id → set of lowercase name tokens."""
+        rows = await self._rows(
+            "SELECT agent_id, username, first_name, last_name, full_name "
+            "FROM agents WHERE lifecycle_state = 'active'"
+        )
+        result = {}
+        for row in rows:
+            tokens = set()
+            for col in ("agent_id", "username", "first_name", "last_name", "full_name"):
+                val = row[col] if hasattr(row, "__getitem__") else getattr(row, col, None)
+                if val:
+                    tokens.add(str(val).lower())
+            agent_id = row["agent_id"] if hasattr(row, "__getitem__") else row.agent_id
+            result[agent_id] = tokens
+        return result
 
     async def append_message(
         self,

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -124,6 +124,10 @@ class SQLiteMemoryStore:
                 agent_id TEXT PRIMARY KEY,
                 role TEXT NOT NULL,
                 display_name TEXT,
+                username TEXT,
+                first_name TEXT,
+                last_name TEXT,
+                full_name TEXT,
                 lifecycle_state TEXT NOT NULL DEFAULT 'active',
                 created_at TEXT NOT NULL,
                 metadata_json TEXT NOT NULL DEFAULT '{}'
@@ -337,6 +341,7 @@ class SQLiteMemoryStore:
         )
         self._ensure_agent_phase_column()
         self._ensure_message_sender_phase_column()
+        self._ensure_agent_identity_columns()
         self.connection.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_memory_digests_current
@@ -392,6 +397,15 @@ class SQLiteMemoryStore:
             self.connection.execute(
                 "ALTER TABLE messages ADD COLUMN sender_phase REAL"
             )
+
+    def _ensure_agent_identity_columns(self):
+        columns = {
+            row["name"]
+            for row in self.connection.execute("PRAGMA table_info(agents)").fetchall()
+        }
+        for col in ("username", "first_name", "last_name", "full_name"):
+            if col not in columns:
+                self.connection.execute(f"ALTER TABLE agents ADD COLUMN {col} TEXT")
 
     def get_agent_phase(self, agent_id) -> float | None:
         """Return the current circadian phase for an agent, or None if not found."""
@@ -473,17 +487,26 @@ class SQLiteMemoryStore:
         lifecycle_state="active",
         created_at=None,
         metadata=None,
+        username=None,
+        first_name=None,
+        last_name=None,
+        full_name=None,
     ):
         timestamp = created_at or _utc_now()
         self.connection.execute(
             """
             INSERT INTO agents(
-                agent_id, role, display_name, lifecycle_state, created_at, metadata_json
+                agent_id, role, display_name, username, first_name, last_name, full_name,
+                lifecycle_state, created_at, metadata_json
             )
-            VALUES (?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(agent_id) DO UPDATE SET
                 role = excluded.role,
                 display_name = excluded.display_name,
+                username = COALESCE(excluded.username, agents.username),
+                first_name = COALESCE(excluded.first_name, agents.first_name),
+                last_name = COALESCE(excluded.last_name, agents.last_name),
+                full_name = COALESCE(excluded.full_name, agents.full_name),
                 lifecycle_state = excluded.lifecycle_state,
                 metadata_json = excluded.metadata_json
             """,
@@ -491,6 +514,10 @@ class SQLiteMemoryStore:
                 agent_id,
                 role,
                 display_name,
+                username,
+                first_name,
+                last_name,
+                full_name,
                 lifecycle_state,
                 timestamp,
                 _json_dumps(metadata),
@@ -498,6 +525,25 @@ class SQLiteMemoryStore:
         )
         self.connection.commit()
         return agent_id
+
+    def get_agent_name_tokens(self) -> dict:
+        """Return a mapping of active agent_id → set of lowercase name tokens for mention detection.
+
+        Tokens include: agent_id, username, first_name, last_name, full_name.
+        """
+        rows = self.connection.execute(
+            "SELECT agent_id, username, first_name, last_name, full_name "
+            "FROM agents WHERE lifecycle_state = 'active'"
+        ).fetchall()
+        result = {}
+        for row in rows:
+            tokens = set()
+            for col in ("agent_id", "username", "first_name", "last_name", "full_name"):
+                val = row[col]
+                if val:
+                    tokens.add(val.lower())
+            result[row["agent_id"]] = tokens
+        return result
 
     def add_contact(
         self,

--- a/robits/runtime/workspace.py
+++ b/robits/runtime/workspace.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path, PurePosixPath
 
 MAX_READ_BYTES = 1024 * 1024
@@ -20,7 +19,7 @@ class AgentWorkspaceStore:
     """Private persistent filesystem roots for agents."""
 
     def __init__(self, root=None):
-        self.root = Path(root or os.environ.get("ROBITS_AGENT_WORKSPACE_ROOT", "var/agents"))
+        self.root = Path(root or "var/agents")
 
     def workspace_root(self, agent_name):
         return self.root / safe_agent_workspace_name(agent_name)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3497,6 +3497,76 @@ class PersonaSeedingTests(unittest.TestCase):
         self.assertIn("honesty", rows[0]["content"])
 
 
+class BreakScheduleTests(unittest.TestCase):
+    """Tests for scheduled break windows and org.schedule tool."""
+
+    def test_parse_break_schedule_single_window(self):
+        from robits.core.config import _parse_break_schedule
+        result = _parse_break_schedule("12:00-13:00")
+        self.assertEqual(result, [("12:00", "13:00")])
+
+    def test_parse_break_schedule_multiple_windows(self):
+        from robits.core.config import _parse_break_schedule
+        result = _parse_break_schedule("12:00-13:00,15:00-15:30")
+        self.assertEqual(result, [("12:00", "13:00"), ("15:00", "15:30")])
+
+    def test_parse_break_schedule_empty(self):
+        from robits.core.config import _parse_break_schedule
+        self.assertEqual(_parse_break_schedule(""), [])
+        self.assertEqual(_parse_break_schedule(None), [])
+
+    def test_effective_clock_state_within_window(self):
+        from robits.core.session import Session
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        session = Session(participants={"A": a}, clock_state="on")
+        session.clock_state = "on"
+        old_schedule = main.break_schedule
+        main.break_schedule = [("00:00", "23:59")]
+        try:
+            self.assertEqual(session._effective_clock_state(), "break")
+        finally:
+            main.break_schedule = old_schedule
+
+    def test_effective_clock_state_outside_window(self):
+        from robits.core.session import Session
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        session = Session(participants={"A": a}, clock_state="on")
+        old_schedule = main.break_schedule
+        main.break_schedule = [("99:00", "99:30")]
+        try:
+            self.assertEqual(session._effective_clock_state(), "on")
+        finally:
+            main.break_schedule = old_schedule
+
+    def test_effective_clock_state_no_schedule(self):
+        from robits.core.session import Session
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        session = Session(participants={"A": a}, clock_state="off")
+        old_schedule = main.break_schedule
+        main.break_schedule = []
+        try:
+            self.assertEqual(session._effective_clock_state(), "off")
+        finally:
+            main.break_schedule = old_schedule
+
+    def test_break_schedule_in_agent_context(self):
+        from robits.core.context import agent_runtime_context
+        old_schedule = main.break_schedule
+        main.break_schedule = [("09:00", "09:30")]
+        try:
+            ctx = agent_runtime_context()
+            self.assertIn("break_schedule", ctx)
+            self.assertEqual(ctx["break_schedule"], [("09:00", "09:30")])
+        finally:
+            main.break_schedule = old_schedule
+
+
 class BreakClockStateTests(unittest.TestCase):
     """Tests for the 'break' clock state — transitional between on and off."""
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3438,6 +3438,179 @@ class ChannelScopedMemoryTests(unittest.TestCase):
         self.assertIn("Python", work[0]["content"])
 
 
+class PersonaRedesignTests(unittest.TestCase):
+    """Tests for #93 persona redesign: username/full_name schema and @mention detection."""
+
+    def setUp(self):
+        self.store_temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.store_temp.cleanup)
+        self.store = SQLiteMemoryStore(Path(self.store_temp.name) / "persona93.sqlite3")
+        self.addCleanup(self.store.close)
+
+    def test_load_personas_new_schema(self):
+        import tempfile as _tf, yaml as _yaml
+        from robits.core.persona import load_personas
+        content = [
+            {"username": "alex_chen", "full_name": "Alex Chen", "role": "SE",
+             "memories": [{"kind": "thought", "content": "I like Python."}]},
+            {"username": "jamie", "full_name": "Jamie Okonkwo", "role": "SE",
+             "memories": [{"kind": "thought", "content": "Distributed systems fan."}]},
+        ]
+        with _tf.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            _yaml.dump(content, f)
+            path = f.name
+        try:
+            result = load_personas(path)
+            self.assertIn("alex_chen", result)
+            self.assertIn("jamie", result)
+            self.assertEqual(result["alex_chen"]["role"], "SE")
+            self.assertEqual(result["alex_chen"]["full_name"], "Alex Chen")
+            self.assertEqual(len(result["alex_chen"]["entries"]), 1)
+        finally:
+            import os; os.unlink(path)
+
+    def test_load_personas_legacy_schema_still_works(self):
+        import tempfile as _tf, yaml as _yaml
+        from robits.core.persona import load_personas
+        content = [
+            {"agent": "SE", "memories": [{"kind": "thought", "content": "Old schema."}]},
+        ]
+        with _tf.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            _yaml.dump(content, f)
+            path = f.name
+        try:
+            result = load_personas(path)
+            self.assertIn("SE", result)
+            self.assertEqual(result["SE"]["role"], "SE")
+            self.assertEqual(len(result["SE"]["entries"]), 1)
+        finally:
+            import os; os.unlink(path)
+
+    def test_multiple_personas_same_role(self):
+        import tempfile as _tf, yaml as _yaml
+        from robits.core.persona import load_personas
+        content = [
+            {"username": "eng1", "full_name": "Alice Smith", "role": "SE",
+             "memories": [{"kind": "thought", "content": "Alice's memory."}]},
+            {"username": "eng2", "full_name": "Bob Jones", "role": "SE",
+             "memories": [{"kind": "thought", "content": "Bob's memory."}]},
+        ]
+        with _tf.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            _yaml.dump(content, f)
+            path = f.name
+        try:
+            result = load_personas(path)
+            self.assertIn("eng1", result)
+            self.assertIn("eng2", result)
+            self.assertEqual(result["eng1"]["full_name"], "Alice Smith")
+            self.assertEqual(result["eng2"]["full_name"], "Bob Jones")
+        finally:
+            import os; os.unlink(path)
+
+    def test_upsert_agent_stores_identity_fields(self):
+        self.store.upsert_agent(
+            "alex_chen", "SE", display_name="Alex Chen",
+            username="alex_chen", first_name="Alex", last_name="Chen", full_name="Alex Chen"
+        )
+        rows = self.store._rows("SELECT * FROM agents WHERE agent_id = 'alex_chen'")
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["username"], "alex_chen")
+        self.assertEqual(rows[0]["first_name"], "Alex")
+        self.assertEqual(rows[0]["last_name"], "Chen")
+        self.assertEqual(rows[0]["full_name"], "Alex Chen")
+
+    def test_get_agent_name_tokens_returns_all_forms(self):
+        self.store.upsert_agent(
+            "alex_chen", "SE", username="alex_chen",
+            first_name="Alex", last_name="Chen", full_name="Alex Chen"
+        )
+        tokens_map = self.store.get_agent_name_tokens()
+        self.assertIn("alex_chen", tokens_map)
+        tokens = tokens_map["alex_chen"]
+        self.assertIn("alex_chen", tokens)
+        self.assertIn("alex", tokens)
+        self.assertIn("chen", tokens)
+        self.assertIn("alex chen", tokens)
+
+    def test_build_employee_dict_uses_persona_usernames(self):
+        from robits.core.roles import build_employee_dict
+        persona_map = {
+            "alex_chen": {"role": "SE", "full_name": "Alex Chen", "entries": []},
+        }
+        d = build_employee_dict(persona_map)
+        self.assertIn("alex_chen", d)
+        self.assertNotIn("SE", d)
+        self.assertEqual(d["alex_chen"].name, "alex_chen")
+
+    def test_build_employee_dict_multiple_same_role(self):
+        from robits.core.roles import build_employee_dict
+        persona_map = {
+            "eng1": {"role": "SE", "full_name": "Alice Smith", "entries": []},
+            "eng2": {"role": "SE", "full_name": "Bob Jones", "entries": []},
+        }
+        d = build_employee_dict(persona_map)
+        self.assertIn("eng1", d)
+        self.assertIn("eng2", d)
+        self.assertNotIn("SE", d)
+
+    def test_mention_detection_at_username(self):
+        from robits.core.session import Session
+        self.store.upsert_agent("alex_chen", "SE", username="alex_chen",
+                                first_name="Alex", last_name="Chen", full_name="Alex Chen")
+        a = SimpleNamespace(name="CEO", lifecycle_state="active",
+                            interact=lambda *a, **kw: "",
+                            update_group_conversations=lambda m: None)
+        b_role = SimpleNamespace(name="alex_chen", lifecycle_state="active",
+                                 interact=lambda *a, **kw: "",
+                                 update_group_conversations=lambda m: None)
+        session = Session(participants={"CEO": a, "alex_chen": b_role})
+        old_store = main.memory_store
+        main.memory_store = self.store
+        try:
+            mentioned = session._detect_mentions("Hey @alex_chen can you review this?")
+            self.assertIn("alex_chen", mentioned)
+        finally:
+            main.memory_store = old_store
+
+    def test_mention_detection_by_first_name(self):
+        from robits.core.session import Session
+        self.store.upsert_agent("alex_chen", "SE", username="alex_chen",
+                                first_name="Alex", last_name="Chen", full_name="Alex Chen")
+        a = SimpleNamespace(name="CEO", lifecycle_state="active",
+                            interact=lambda *a, **kw: "",
+                            update_group_conversations=lambda m: None)
+        b_role = SimpleNamespace(name="alex_chen", lifecycle_state="active",
+                                 interact=lambda *a, **kw: "",
+                                 update_group_conversations=lambda m: None)
+        session = Session(participants={"CEO": a, "alex_chen": b_role})
+        old_store = main.memory_store
+        main.memory_store = self.store
+        try:
+            mentioned = session._detect_mentions("Alex, what do you think about this?")
+            self.assertIn("alex_chen", mentioned)
+        finally:
+            main.memory_store = old_store
+
+    def test_no_mention_when_no_match(self):
+        from robits.core.session import Session
+        self.store.upsert_agent("alex_chen", "SE", username="alex_chen",
+                                first_name="Alex", last_name="Chen", full_name="Alex Chen")
+        a = SimpleNamespace(name="CEO", lifecycle_state="active",
+                            interact=lambda *a, **kw: "",
+                            update_group_conversations=lambda m: None)
+        b_role = SimpleNamespace(name="alex_chen", lifecycle_state="active",
+                                 interact=lambda *a, **kw: "",
+                                 update_group_conversations=lambda m: None)
+        session = Session(participants={"CEO": a, "alex_chen": b_role})
+        old_store = main.memory_store
+        main.memory_store = self.store
+        try:
+            mentioned = session._detect_mentions("What does everyone think?")
+            self.assertNotIn("alex_chen", mentioned)
+        finally:
+            main.memory_store = old_store
+
+
 class PersonaSeedingTests(unittest.TestCase):
     """Tests for persona seeding into memory on first session."""
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3610,6 +3610,38 @@ class PersonaRedesignTests(unittest.TestCase):
         finally:
             main.memory_store = old_store
 
+    def test_mention_no_false_positive_common_word(self):
+        from robits.core.session import Session
+        self.store.upsert_agent("will_smith", "SE", username="will_smith",
+                                first_name="Will", last_name="Smith", full_name="Will Smith")
+        a = SimpleNamespace(name="CEO", lifecycle_state="active",
+                            interact=lambda *a, **kw: "",
+                            update_group_conversations=lambda m: None)
+        b_role = SimpleNamespace(name="will_smith", lifecycle_state="active",
+                                 interact=lambda *a, **kw: "",
+                                 update_group_conversations=lambda m: None)
+        session = Session(participants={"CEO": a, "will_smith": b_role})
+        old_store = main.memory_store
+        main.memory_store = self.store
+        try:
+            # lowercase "will" in a sentence should NOT trigger a mention
+            mentioned = session._detect_mentions("I will look into it, no worries.")
+            self.assertNotIn("will_smith", mentioned)
+            # Capitalised "Will" (addressing the agent) SHOULD trigger
+            mentioned2 = session._detect_mentions("Will, can you review the PR?")
+            self.assertIn("will_smith", mentioned2)
+        finally:
+            main.memory_store = old_store
+
+    def test_build_employee_dict_ceo_persona(self):
+        from robits.core.roles import build_employee_dict, Human
+        persona_map = {
+            "CEO": {"role": "CEO", "full_name": "CEO", "entries": []},
+        }
+        d = build_employee_dict(persona_map)
+        self.assertIn("CEO", d)
+        self.assertIsInstance(d["CEO"], Human)
+
 
 class PersonaSeedingTests(unittest.TestCase):
     """Tests for persona seeding into memory on first session."""
@@ -3687,6 +3719,34 @@ class BreakScheduleTests(unittest.TestCase):
         from robits.core.config import _parse_break_schedule
         self.assertEqual(_parse_break_schedule(""), [])
         self.assertEqual(_parse_break_schedule(None), [])
+
+    def test_parse_break_schedule_single_digit_hour(self):
+        from robits.core.config import _parse_break_schedule
+        result = _parse_break_schedule("9:00-9:30")
+        self.assertEqual(result, [("09:00", "09:30")])
+
+    def test_parse_break_schedule_rejects_midnight_wrap(self):
+        from robits.core.config import _parse_break_schedule
+        result = _parse_break_schedule("22:00-02:00")
+        self.assertEqual(result, [])
+
+    def test_parse_break_schedule_rejects_malformed(self):
+        from robits.core.config import _parse_break_schedule
+        result = _parse_break_schedule("notawindow,12:00-13:00")
+        self.assertEqual(result, [("12:00", "13:00")])
+
+    def test_effective_clock_state_off_not_promoted_to_break(self):
+        from robits.core.session import Session
+        a = SimpleNamespace(name="A", lifecycle_state="active",
+                            interact=lambda *a, **kw: "hi",
+                            update_group_conversations=lambda m: None)
+        session = Session(participants={"A": a}, clock_state="off")
+        old_schedule = main.break_schedule
+        main.break_schedule = [("00:00", "23:59")]
+        try:
+            self.assertEqual(session._effective_clock_state(), "off")
+        finally:
+            main.break_schedule = old_schedule
 
     def test_effective_clock_state_within_window(self):
         from robits.core.session import Session

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3595,6 +3595,76 @@ class BreakClockStateTests(unittest.TestCase):
         self.assertIn("System note", result)
         self.assertIn("break", result)
 
+    def test_top_p_modulation_follows_clock_state(self):
+        from robits.core.session import _modulate_temperature
+        role = SimpleNamespace(temperature=0.7, base_temperature=0.7, top_p=0.9, base_top_p=0.9)
+        _modulate_temperature(role, "on")
+        on_top_p = role.top_p
+        role.top_p = 0.9
+        _modulate_temperature(role, "break")
+        break_top_p = role.top_p
+        role.top_p = 0.9
+        _modulate_temperature(role, "off")
+        off_top_p = role.top_p
+        self.assertLess(on_top_p, break_top_p)
+        self.assertLess(break_top_p, off_top_p)
+
+    def test_top_p_clamped_to_valid_range(self):
+        from robits.core.session import _modulate_temperature
+        role = SimpleNamespace(temperature=0.7, base_temperature=0.7, top_p=1.0, base_top_p=1.0)
+        _modulate_temperature(role, "off")
+        self.assertLessEqual(role.top_p, 1.0)
+        role2 = SimpleNamespace(temperature=0.7, base_temperature=0.7, top_p=0.1, base_top_p=0.1)
+        _modulate_temperature(role2, "on")
+        self.assertGreaterEqual(role2.top_p, 0.1)
+
+    def test_role_base_top_p_initialised(self):
+        from robits.core.roles import Role
+        role = Role("test_role", "template", {})
+        self.assertTrue(hasattr(role, "base_top_p"))
+        self.assertEqual(role.base_top_p, role.top_p)
+
+    def test_providers_pass_top_p(self):
+        from robits.core.providers import ChatCompletionsProvider
+        calls = []
+
+        class FakeClient:
+            class chat:
+                class completions:
+                    @staticmethod
+                    def create(**kwargs):
+                        calls.append(kwargs)
+                        msg = SimpleNamespace(
+                            tool_calls=None,
+                            content="done",
+                            model_dump=lambda: {"role": "assistant", "content": "done"},
+                        )
+                        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+        role = SimpleNamespace(
+            name="tester",
+            runtime_role_name="tester",
+            max_tokens=100,
+            temperature=0.5,
+            top_p=0.75,
+            employee_dict={},
+            allowed_tools=set(),
+        )
+
+        class FakeRegistry:
+            def as_chat_completion_tools(self, role):
+                return []
+            def execute(self, *a, **kw):
+                return ""
+            def resolve_name(self, n):
+                return n
+
+        provider = ChatCompletionsProvider(FakeClient(), registry=FakeRegistry())
+        provider.generate(role, "model-x", "sender", [{"role": "user", "content": "hi"}])
+        self.assertTrue(calls)
+        self.assertIn("top_p", calls[0])
+        self.assertAlmostEqual(calls[0]["top_p"], 0.75)
+
 
 class EmbeddingSearchTests(unittest.TestCase):
     """Tests for embedding-based semantic search in SQLiteMemoryStore."""

--- a/tools.yaml
+++ b/tools.yaml
@@ -279,6 +279,31 @@
     required: []
   code: |
     return org_chat_read(employee_dict, limit=min(int(limit if limit is not None else 20), 100))
+- name: org.schedule
+  required_capabilities: []
+  owner_capability: basic
+  system_tool: false
+  grantable: true
+  description: >
+    Show the organisation's clock schedule: current clock state (on/break/off),
+    any configured break windows for today, and whether the org is currently in a
+    scheduled break.
+  parameters:
+    type: object
+    properties: {}
+    required: []
+  code: |
+    ctx = current_agent_context()
+    clock = ctx.get("clock_state", "on")
+    schedule = ctx.get("break_schedule", [])
+    lines = [f"Current clock state: {clock}"]
+    if schedule:
+        lines.append("Scheduled break windows:")
+        for start, end in schedule:
+            lines.append(f"  {start} – {end}")
+    else:
+        lines.append("No scheduled break windows configured.")
+    return "\n".join(lines)
 - name: work.todo
   required_capabilities: []
   owner_capability: basic

--- a/tools.yaml
+++ b/tools.yaml
@@ -285,9 +285,8 @@
   system_tool: false
   grantable: true
   description: >
-    Show the organisation's clock schedule: current clock state (on/break/off),
-    any configured break windows for today, and whether the org is currently in a
-    scheduled break.
+    Show the organisation's clock schedule: current effective clock state (on/break/off),
+    configured break windows, and whether a scheduled break is currently active.
   parameters:
     type: object
     properties: {}
@@ -296,7 +295,9 @@
     ctx = current_agent_context()
     clock = ctx.get("clock_state", "on")
     schedule = ctx.get("break_schedule", [])
+    in_scheduled_break = clock == "break" and bool(schedule)
     lines = [f"Current clock state: {clock}"]
+    lines.append(f"In scheduled break: {'yes' if in_scheduled_break else 'no'}")
     if schedule:
         lines.append("Scheduled break windows:")
         for start, end in schedule:


### PR DESCRIPTION
## Summary

- **top_p modulation** (refs #66): `top_p` is now modulated alongside `temperature` for the clock-state rhythm. `Role` gains `top_p=0.9` / `base_top_p` attributes; both providers pass `top_p` when set.
- **Scheduled break windows + `org.schedule` tool** (refs #66): `ROBITS_BREAK_SCHEDULE=HH:MM-HH:MM[,...]` env var; `Session._effective_clock_state()` auto-transitions to `break` during configured windows. `org.schedule` tool exposes current state and windows to agents.
- **Persona redesign** (fixes #93): `personas.yaml` now uses `role:` + `username:` + `full_name:` keys; legacy `agent:` still supported. `load_personas()` returns `{username: {role, full_name, entries}}`. `build_employee_dict(persona_map)` uses usernames as participant keys, supports multiple personas per role. `agents` table gains `username`, `first_name`, `last_name`, `full_name` columns. `Session.step()` detects `@username` and name-token mentions, injecting a soft annotation without interrupting the scheduler.
- **Config cleanup**: `ROBITS_AGENT_WORKSPACE_ROOT`, `ROBITS_TOOL_PROPOSALS_FILE`, and `ROBITS_PERSONAS_FILE` now go through `Config` instead of being read directly from `os.environ` in sub-modules.
- **README**: Updated with personas, clock states, embedding search, scheduled breaks, local model setup, and full env-var reference table.

## Test plan

- [ ] `python -m pytest tests/` — 317 tests pass
- [ ] `PersonaRedesignTests`: new schema parsing, multiple personas per role, @mention detection
- [ ] `BreakScheduleTests`: schedule parsing, effective clock state during/outside window, agent context inclusion
- [ ] `BreakClockStateTests`: top_p modulation ordering, clamping, provider kwargs, role attribute initialisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)