### PR TITLE
fix: directed routing by name/alias, run_local.py persona awareness, close #95 #96

### DIFF
--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -314,6 +314,7 @@ def build_employee_dict(persona_map=None):
                 default_keys_replaced.add(default_key)
             instance = RoleClass(employee_dict)
             instance.name = username
+            instance.role_key = role_key
             instance.full_name = full_name
             parts = full_name.split(None, 1)
             instance.first_name = parts[0] if parts else username

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -191,7 +191,18 @@ class Session:
         self._last_identity_digest_meaningful_turn = 0
         self._last_goal_digest_meaningful_turn = 0
         self.last_receiver = self.participants.get("CEO") or next(iter(self.participants.values()))
-        self._name_to_key = {getattr(p, "name", k): k for k, p in self.participants.items()}
+        _name_map: dict = {}
+        for k, p in self.participants.items():
+            for form in (
+                k,
+                getattr(p, "name", None),
+                getattr(p, "runtime_role_name", None),
+                getattr(p, "full_name", None),
+                getattr(p, "first_name", None),
+            ):
+                if form and isinstance(form, str):
+                    _name_map.setdefault(form.lower(), k)
+        self._name_to_key = _name_map
         self._role_to_key = {id(p): k for k, p in self.participants.items()}
         _cs = clock_state or _m.clock_state
         self.clock_state = _cs if _cs in {"on", "off", "break"} else "on"
@@ -328,19 +339,20 @@ class Session:
         """Determine the next receiver for message; honour 'Name, prompt' directed syntax."""
         prompt_split = message.split(",", 1) if isinstance(message, str) else []
         if len(prompt_split) > 1:
-            receiver_name = prompt_split[0].strip()
-            if receiver_name in self.participants:
-                print(colored(f"// Directed to {receiver_name}", "grey"))
-                self.scheduler.observe(receiver_name)
+            receiver_token = prompt_split[0].strip()
+            resolved_key = self._name_to_key.get(receiver_token.lower())
+            if resolved_key is not None:
+                print(colored(f"// Directed to {resolved_key}", "grey"))
+                self.scheduler.observe(resolved_key)
                 self.event_stream.emit(
                     "message.routed",
                     self.run_id,
                     {
-                        "receiver": receiver_name,
+                        "receiver": resolved_key,
                         "directed": True,
                     },
                 )
-                return RoutedMessage(self.participants[receiver_name], prompt_split[1].strip(), True)
+                return RoutedMessage(self.participants[resolved_key], prompt_split[1].strip(), True)
 
         now = datetime.now(timezone.utc)
         tried: set = set()
@@ -720,7 +732,7 @@ class Session:
 
     def _canonical_agent_id(self, name):
         """Resolve a role display name to its participant dict key for FK-safe storage."""
-        return self._name_to_key.get(name, name)
+        return self._name_to_key.get(name.lower(), name) if isinstance(name, str) else name
 
     def _detect_mentions(self, message: str) -> set:
         """Return the set of participant keys mentioned in message.

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -196,7 +196,7 @@ class Session:
             for form in (
                 k,
                 getattr(p, "name", None),
-                getattr(p, "runtime_role_name", None),
+                getattr(p, "role_key", None),
                 getattr(p, "full_name", None),
                 getattr(p, "first_name", None),
             ):

--- a/run_local.py
+++ b/run_local.py
@@ -5,14 +5,24 @@ Usage:
   OPENAI_BASE_URL=http://127.0.0.1:11434/v1/ OPENAI_API_KEY=ollama \
   OPENAI_MODEL=granite4.1:3b ROBITS_PROVIDER_API=chat \
   ROBITS_MEMORY_DB=/tmp/robits_local.db python3 run_local.py \
-  --prompt "SE, have you had any personal or work experience with Python or cooking?"
+  --prompt "Alex, have you had any personal or work experience with Python or cooking?"
+
+The script detects the SE persona username from personas.yaml (via Config) and seeds
+memory under that key so directed routing works correctly after the persona redesign.
 """
-import os
 import sys
 
-DB_PATH = os.environ.get("ROBITS_MEMORY_DB", "/tmp/robits_local.db")
 
-def seed_memory(db_path):
+def _se_username():
+    """Return the username of the first SE persona, or 'SE' if none configured."""
+    from robits.core.config import _config as _m
+    for username, info in (_m.persona_entries or {}).items():
+        if isinstance(info, dict) and info.get("role") in ("SE", "SoftwareEngineer"):
+            return username, info.get("full_name", username)
+    return "SE", "SE"
+
+
+def seed_memory(db_path, agent_id, full_name):
     from robits.memory.sqlite import (
         SQLiteMemoryStore,
         CHANNEL_AGENT_THOUGHT, CHANNEL_ORG_CHAT,
@@ -20,51 +30,58 @@ def seed_memory(db_path):
     )
     store = SQLiteMemoryStore(db_path)
     store.create_session("seed-session")
-    store.upsert_agent("SE", "SoftwareEngineer", "SE")
+    store.upsert_agent(agent_id, "SoftwareEngineer", full_name,
+                       username=agent_id, full_name=full_name)
     store.upsert_agent("CEO", "Human", "CEO")
 
     org_ch = store.get_or_create_channel(CHANNEL_ORG_CHAT, social_distance=SOCIAL_PROFESSIONAL)
     thought_ch = store.get_or_create_channel(
-        CHANNEL_AGENT_THOUGHT, participants=["SE"],
+        CHANNEL_AGENT_THOUGHT, participants=[agent_id],
         visibility="private", social_distance=0.0,
     )
 
+    first = full_name.split()[0] if full_name else agent_id
+
     # Work memories — org_chat channel
-    store.append_message("seed-session", "CEO", "SE",
-        "SE, can you refactor the auth module to use Python async/await?",
+    store.append_message("seed-session", "CEO", agent_id,
+        f"{first}, can you refactor the auth module to use Python async/await?",
         channel_id=org_ch)
-    store.append_message("seed-session", "SE", "CEO",
+    store.append_message("seed-session", agent_id, "CEO",
         "Sure, I'll migrate it to asyncio. I've done this pattern several times — "
         "Python async has become second nature to me after years of backend work.",
         channel_id=org_ch)
-    store.append_message("seed-session", "CEO", "SE",
+    store.append_message("seed-session", "CEO", agent_id,
         "What's your take on the new SQLite FTS5 integration?",
         channel_id=org_ch)
-    store.append_message("seed-session", "SE", "CEO",
+    store.append_message("seed-session", agent_id, "CEO",
         "I find it elegant. The cascade-search approach is something I proposed "
         "based on prior experience building search pipelines in Python.",
         channel_id=org_ch)
 
     # Personal memories — agent_thought channel
-    store.append_thought("SE",
+    store.append_thought(agent_id,
         "I really enjoy cooking on weekends — especially Italian food. "
         "Last Saturday I made a proper carbonara from scratch; took about an hour.",
         session_id="seed-session", channel_id=thought_ch, visibility="private")
-    store.append_thought("SE",
+    store.append_thought(agent_id,
         "Been meaning to pick up sourdough baking. I've been reading about "
         "fermentation science — there's a surprising amount of chemistry involved.",
         session_id="seed-session", channel_id=thought_ch, visibility="private")
-    store.append_thought("SE",
+    store.append_thought(agent_id,
         "Python was actually my first serious language — started with it in college "
         "writing small data scripts. Feels personal, not just a work tool.",
         session_id="seed-session", channel_id=thought_ch, visibility="private")
 
     store.close()
-    print(f"[run_local] Memory seeded at {db_path}", file=sys.stderr)
+    print(f"[run_local] Memory seeded for {agent_id!r} ({full_name}) at {db_path}",
+          file=sys.stderr)
 
 
 if __name__ == "__main__":
-    seed_memory(DB_PATH)
+    from robits.core.config import _config as _m
+    db_path = _m.memory_db_path or "/tmp/robits_local.db"
+    agent_id, full_name = _se_username()
+    seed_memory(db_path, agent_id, full_name)
     # Delegate to main.py's entry point
     import main
     main.main(argv=sys.argv[1:])

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4029,5 +4029,85 @@ class EmbeddingSearchTests(unittest.TestCase):
         self.assertIn(256, self.store._vec_tables)
 
 
+class DirectedRoutingTests(unittest.TestCase):
+    """Tests for #96 — route_message resolves by username, full_name, role key, and first name."""
+
+    def _make_participants(self):
+        se = FakeRole("alex_chen", ["ok"])
+        se.runtime_role_name = "SE"
+        se.full_name = "Alex Chen"
+        se.first_name = "Alex"
+        hr = FakeRole("HR", ["ok"])
+        participants = {
+            "CEO": FakeRole("CEO", ["initial"]),
+            "Ops": FakeRole("Ops", ["ok"]),
+            "alex_chen": se,
+            "HR": hr,
+        }
+        return participants
+
+    def _route(self, participants, message, last="CEO"):
+        session = main.Session(participants=participants, run_id="routing-test")
+        with redirect_stdout(StringIO()):
+            return session.route_message(message, last)
+
+    def test_route_by_participant_key(self):
+        p = self._make_participants()
+        routed = self._route(p, "alex_chen, do this")
+        self.assertTrue(routed.directed)
+        self.assertIs(routed.receiver, p["alex_chen"])
+        self.assertEqual(routed.prompt, "do this")
+
+    def test_route_by_role_key_alias(self):
+        p = self._make_participants()
+        routed = self._route(p, "SE, do this")
+        self.assertTrue(routed.directed)
+        self.assertIs(routed.receiver, p["alex_chen"])
+        self.assertEqual(routed.prompt, "do this")
+
+    def test_route_by_full_name(self):
+        p = self._make_participants()
+        routed = self._route(p, "Alex Chen, do this")
+        self.assertTrue(routed.directed)
+        self.assertIs(routed.receiver, p["alex_chen"])
+
+    def test_route_by_first_name(self):
+        p = self._make_participants()
+        routed = self._route(p, "Alex, do this")
+        self.assertTrue(routed.directed)
+        self.assertIs(routed.receiver, p["alex_chen"])
+
+    def test_route_case_insensitive(self):
+        p = self._make_participants()
+        routed = self._route(p, "se, do this")
+        self.assertTrue(routed.directed)
+        self.assertIs(routed.receiver, p["alex_chen"])
+
+    def test_unknown_prefix_falls_through(self):
+        p = self._make_participants()
+        routed = self._route(p, "Finance, do this")
+        self.assertFalse(routed.directed)
+
+    def test_name_to_key_includes_role_alias(self):
+        p = self._make_participants()
+        session = main.Session(participants=p, run_id="routing-test")
+        self.assertEqual(session._name_to_key.get("se"), "alex_chen")
+
+    def test_name_to_key_includes_full_name(self):
+        p = self._make_participants()
+        session = main.Session(participants=p, run_id="routing-test")
+        self.assertEqual(session._name_to_key.get("alex chen"), "alex_chen")
+
+    def test_canonical_agent_id_resolves_role_alias(self):
+        p = self._make_participants()
+        session = main.Session(participants=p, run_id="routing-test")
+        self.assertEqual(session._canonical_agent_id("SE"), "alex_chen")
+
+    def test_canonical_agent_id_passthrough_for_unknown(self):
+        p = self._make_participants()
+        session = main.Session(participants=p, run_id="routing-test")
+        self.assertEqual(session._canonical_agent_id("Unknown"), "Unknown")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4034,7 +4034,7 @@ class DirectedRoutingTests(unittest.TestCase):
 
     def _make_participants(self):
         se = FakeRole("alex_chen", ["ok"])
-        se.runtime_role_name = "SE"
+        se.role_key = "SE"
         se.full_name = "Alex Chen"
         se.first_name = "Alex"
         hr = FakeRole("HR", ["ok"])
@@ -4107,6 +4107,19 @@ class DirectedRoutingTests(unittest.TestCase):
         p = self._make_participants()
         session = main.Session(participants=p, run_id="routing-test")
         self.assertEqual(session._canonical_agent_id("Unknown"), "Unknown")
+
+    def test_route_by_role_key_with_real_persona_build(self):
+        """Role alias routing works for persona-built participants (role_key set by build_employee_dict)."""
+        from robits.core.roles import build_employee_dict
+        persona_map = {
+            "alex_chen": {"role": "SE", "full_name": "Alex Chen", "entries": []},
+        }
+        participants = build_employee_dict(persona_map)
+        session = main.Session(participants=participants, run_id="routing-real")
+        with redirect_stdout(StringIO()):
+            routed = session.route_message("SE, implement the feature", "CEO")
+        self.assertTrue(routed.directed)
+        self.assertEqual(routed.receiver.name, "alex_chen")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **#96** — `route_message` now resolves directed messages by any of: participant key, role-type alias (`SE`), full name (`Alex Chen`), or first name (`Alex`), case-insensitively. `Session._name_to_key` is built from all name forms at init time. 10 new `DirectedRoutingTests`.
- **#95** — `run_local.py` detects the active SE persona username from `Config.persona_entries` and seeds memory under that key rather than the hardcoded `"SE"`. Prompt example updated to use first name. DB path comes from `_m.memory_db_path`.
- **#93, #98** — Closed as already resolved in the prior merge.
- **#66** — Fully covered by the prior merge (top_p modulation, scheduled breaks, `org.schedule` tool, break-aware temperature, `_effective_clock_state`).

## Test plan

- [ ] `python -m pytest tests/test_runtime.py` — 225 tests pass
- [ ] `DirectedRoutingTests` covers: participant key, role alias (`SE`), full name, first name, case-insensitive, unknown prefix fallthrough, `_name_to_key` contents, `_canonical_agent_id` resolution
- [ ] `run_local.py` — `_se_username()` returns `("SE", "SE")` when no personas configured; returns persona username/full_name when `personas.yaml` defines an SE persona

🤖 Generated with [Claude Code](https://claude.com/claude-code)