### PR TITLE
feat: add builtin.url_fetch; grant web_search and url_fetch by default (#79)

### DIFF
--- a/.github/skills/robits-runtime/SKILL.md
+++ b/.github/skills/robits-runtime/SKILL.md
@@ -16,6 +16,8 @@ description: Work on the Robits Python organization-simulation runtime, includin
 7. Keep sandbox behavior optional and fakeable; unit tests must not require containers or a local cluster.
 8. Prefer focused tests around parsing, tool loading, lifecycle, observability, sandbox metadata, and execution before relying on a live model smoke test.
 9. For Responses API work, test function-call routing with fake response items before using a live endpoint.
+   - **LM Studio**: stateful Responses API — `previous_response_id` is honoured; use the default `ROBITS_PROVIDER_API=responses`.
+   - **Ollama**: non-stateful Responses API (since v0.13.3) — `previous_response_id` is silently ignored, breaking the within-turn tool-call continuation in `ResponsesProvider`. Use `ROBITS_PROVIDER_API=chat` with Ollama (tracked in #102).
 10. For scheduling work, keep `Session` and `RoundRobinScheduler` unit-testable with fake roles before adding parallel execution.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For local models with embedding support, `sqlite-vec` is included in `requiremen
 | `ROBITS_CHEAP_MODEL` | `ROBITS_MODEL` | Model for cheap interactions |
 | `ROBITS_COSTLY_MODEL` | `ROBITS_MODEL` | Model for SE and costly interactions |
 | `ROBITS_PROVIDER_API` | `responses` | `responses` or `chat` / `chat_completions` |
-| `ROBITS_MEMORY_DB` | — | SQLite path; memory tools disabled when unset |
+| `ROBITS_MEMORY_DB` | `~/.local/share/robits/memory.db` | SQLite path for memory storage |
 | `ROBITS_CLOCK_STATE` | `on` | Base clock state: `on`, `break`, or `off` |
 | `ROBITS_BREAK_SCHEDULE` | — | Scheduled break windows, e.g. `12:00-13:00,15:00-15:30` |
 | `ROBITS_PERSONAS_FILE` | `personas.yaml` | Path to persona seed file |
@@ -192,12 +192,15 @@ python main.py --prompt "Ops, say hello to HR" --turns 1 --log run.log
 
 `run_local.py` seeds a fresh memory database and delegates to `main.py`. It demonstrates persona recall with pre-seeded work and personal memories.
 
+### Ollama
+
+Ollama exposes an OpenAI-compatible Responses API at `/v1/responses` (since v0.13.3), but it is **non-stateful**: `previous_response_id` is silently ignored. This breaks the within-turn tool-call continuation in `ResponsesProvider`. Use `ROBITS_PROVIDER_API=chat` with Ollama:
+
 ```bash
 OPENAI_BASE_URL=http://127.0.0.1:11434/v1/ \
 OPENAI_API_KEY=ollama \
 OPENAI_MODEL=granite4.1:3b \
 ROBITS_PROVIDER_API=chat \
-ROBITS_MEMORY_DB=/tmp/robits_local.db \
 ROBITS_EMBEDDING_MODEL=granite-embedding:latest \
 ROBITS_EMBEDDING_BASE_URL=http://127.0.0.1:11434/v1/ \
 ROBITS_EMBEDDING_API_KEY=ollama \
@@ -205,6 +208,22 @@ python run_local.py --prompt "SE, do you have experience with Python or cooking?
 ```
 
 Tested with `granite4.1:3b` for tool calling; `granite-embedding:latest` and `embeddinggemma:latest` for embeddings. Models are pulled with `ollama pull <name>`.
+
+### LM Studio
+
+LM Studio's Responses API is stateful and honours `previous_response_id`, so the default `ROBITS_PROVIDER_API=responses` works correctly:
+
+```bash
+OPENAI_BASE_URL=http://127.0.0.1:1234/v1/ \
+OPENAI_API_KEY=lmstudio \
+OPENAI_MODEL=granite-4-micro \
+ROBITS_EMBEDDING_MODEL=text-embedding-nomic-embed-text-v1.5 \
+ROBITS_EMBEDDING_BASE_URL=http://127.0.0.1:1234/v1/ \
+ROBITS_EMBEDDING_API_KEY=lmstudio \
+python run_local.py --prompt "SE, do you have experience with Python or cooking?"
+```
+
+Note: tool calling and remote MCP must be enabled in LM Studio's Developer Settings.
 
 ## Testing
 

--- a/main.py
+++ b/main.py
@@ -80,6 +80,7 @@ from robits.core.tool_functions import (  # noqa: E402
     memory_list_digests,
     memory_expand_digest,
     builtin_web_search,
+    builtin_url_fetch,
     builtin_file_search,
     builtin_shell_run,
     builtin_tool_search,

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -82,7 +82,14 @@ When thinking, recalling past events, or forming memories, use your tools rather
         self.lifecycle_state = "active"
         self.lifecycle_events = []
         self.capabilities = set()
-        self.allowed_tools = {"agent.*", "memory.search", "memory.list_digests", "memory.expand_digest"}
+        self.allowed_tools = {
+            "agent.*",
+            "builtin.web_search",
+            "builtin.url_fetch",
+            "memory.search",
+            "memory.list_digests",
+            "memory.expand_digest",
+        }
         self.alarms = []
         self.sandbox_metadata = SandboxMetadata.disabled(self.name)
         self.runtime_event_stream = None
@@ -204,7 +211,7 @@ class SoftwareEngineer(Role):
 
     def __init__(self, employee_dict):
         template = """As a Software Engineer (SE), you are responsible for designing, developing, and maintaining software applications. You primarily propose trusted tools when requested by others in your organization."""
-        group_template_additions = """You are part of the Engineering group. Tools are trusted functions described by namespaced OpenAI-compatible metadata. You can propose tools with working Python code using the `code` field in tools.propose. IMPORTANT CODE RULES: write the body as a sequence of simple statements ending with a single `return` — do NOT define nested functions or classes (lambdas and inline expressions are fine). The sandbox has no imports; available builtins: abs, bool, dict, enumerate, float, int, len, list, max, min, range, round, set, sorted, str, sum, tuple, zip. Available globals: get_caller_name() → calling agent's name; workspace_write/workspace_read/workspace_list/workspace_delete → agent files; org_chat_read → recent org chat; memory_search/memory_list_digests/memory_expand_digest → stored context; work_todo_add → task tracking; agent_think/agent_wait → agent control; current_agent_context → runtime context; grant_tool_access/revoke_tool_access → permissions; propose_tool_change/list_tool_proposals/approve_tool_proposal/reject_tool_proposal/rollout_tool_proposal/approve_and_rollout_proposal → proposals; list_registered_tools → tool catalogue; create_lifecycle_role/pause_lifecycle_role/retire_lifecycle_role/archive_lifecycle_role/list_lifecycle_roles → org management; create_alarm/list_alarms/cancel_alarm → scheduling; builtin_web_search/builtin_file_search/builtin_shell_run/builtin_tool_search/builtin_mcp_call/builtin_computer_use/builtin_image_generation → external integrations. Example: `return f"{get_caller_name()}: {status}"`. Parameters use JSON Schema: {"type":"object","properties":{"status":{"type":"string"}},"required":["status"]}. Approved proposals with code are registered and activated at rollout without a restart."""
+        group_template_additions = """You are part of the Engineering group. Tools are trusted functions described by namespaced OpenAI-compatible metadata. You can propose tools with working Python code using the `code` field in tools.propose. IMPORTANT CODE RULES: write the body as a sequence of simple statements ending with a single `return` — do NOT define nested functions or classes (lambdas and inline expressions are fine). The sandbox has no imports; available builtins: abs, bool, dict, enumerate, float, int, len, list, max, min, range, round, set, sorted, str, sum, tuple, zip. Available globals: get_caller_name() → calling agent's name; workspace_write/workspace_read/workspace_list/workspace_delete → agent files; org_chat_read → recent org chat; memory_search/memory_list_digests/memory_expand_digest → stored context; work_todo_add → task tracking; agent_think/agent_wait → agent control; current_agent_context → runtime context; grant_tool_access/revoke_tool_access → permissions; propose_tool_change/list_tool_proposals/approve_tool_proposal/reject_tool_proposal/rollout_tool_proposal/approve_and_rollout_proposal → proposals; list_registered_tools → tool catalogue; create_lifecycle_role/pause_lifecycle_role/retire_lifecycle_role/archive_lifecycle_role/list_lifecycle_roles → org management; create_alarm/list_alarms/cancel_alarm → scheduling; builtin_web_search/builtin_url_fetch/builtin_file_search/builtin_shell_run/builtin_tool_search/builtin_mcp_call/builtin_computer_use/builtin_image_generation → external integrations. Example: `return f"{get_caller_name()}: {status}"`. Parameters use JSON Schema: {"type":"object","properties":{"status":{"type":"string"}},"required":["status"]}. Approved proposals with code are registered and activated at rollout without a restart."""
         super().__init__(self.__class__.__name__, template, employee_dict, group_template_additions)
         self.capabilities = {"engineer"}
         self.allowed_tools.update({"tools.list", "tools.list_proposals", "tools.propose"})

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -600,6 +600,30 @@ def builtin_web_search(employee_dict, query, num_results=5):
     return json.dumps(results[:n], sort_keys=True)
 
 
+def builtin_url_fetch(employee_dict, url, max_chars=16000):
+    """Fetch the text content of a URL and return it (truncated to max_chars)."""
+    del employee_dict
+    if not isinstance(url, str) or not url.strip():
+        return "Error: URL must be a non-empty string."
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        return "Error: URL must start with http:// or https://"
+    import urllib.request
+    limit = max(256, min(int(max_chars or 16000), 128000))
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "robits/1.0"})
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            content_type = resp.headers.get("Content-Type", "")
+            raw = resp.read(limit).decode("utf-8", errors="replace")
+    except Exception as exc:
+        return f"Error: Failed to fetch URL: {exc}"
+    if "html" in content_type.lower():
+        import re as _re
+        raw = _re.sub(r"<[^>]+>", " ", raw)
+        raw = _re.sub(r"[ \t]{2,}", " ", raw)
+    return raw[:limit]
+
+
 def builtin_file_search(employee_dict, agent_name, query, path="", max_results=10):
     """Search an agent's workspace files for lines matching query."""
     del employee_dict
@@ -816,6 +840,7 @@ SANDBOX_GLOBALS = {
     "rollout_tool_proposal": rollout_tool_proposal,
     "approve_and_rollout_proposal": approve_and_rollout_proposal,
     "builtin_web_search": builtin_web_search,
+    "builtin_url_fetch": builtin_url_fetch,
     "builtin_file_search": builtin_file_search,
     "builtin_shell_run": builtin_shell_run,
     "builtin_tool_search": builtin_tool_search,

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -608,8 +608,11 @@ def builtin_url_fetch(employee_dict, url, max_chars=16000):
     url = url.strip()
     if not url.startswith(("http://", "https://")):
         return "Error: URL must start with http:// or https://"
+    try:
+        limit = max(1, min(int(max_chars if max_chars is not None else 16000), 128000))
+    except (TypeError, ValueError):
+        return "Error: max_chars must be an integer."
     import urllib.request
-    limit = max(256, min(int(max_chars or 16000), 128000))
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "robits/1.0"})
         with urllib.request.urlopen(req, timeout=20) as resp:
@@ -619,6 +622,7 @@ def builtin_url_fetch(employee_dict, url, max_chars=16000):
         return f"Error: Failed to fetch URL: {exc}"
     if "html" in content_type.lower():
         import re as _re
+        raw = _re.sub(r"(?is)<(script|style)[^>]*>.*?</\1>", " ", raw)
         raw = _re.sub(r"<[^>]+>", " ", raw)
         raw = _re.sub(r"[ \t]{2,}", " ", raw)
     return raw[:limit]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2038,6 +2038,85 @@ class BuiltinToolTests(unittest.TestCase):
             main.builtin_search_url = original
         self.assertTrue(result.startswith("Error:"))
 
+    # ── builtin.url_fetch ────────────────────────────────────────────────────
+
+    def test_url_fetch_validates_empty_url(self):
+        result = main.builtin_url_fetch({}, "")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_url_fetch_validates_non_http_scheme(self):
+        result = main.builtin_url_fetch({}, "ftp://example.com/file")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_url_fetch_validates_non_string_url(self):
+        result = main.builtin_url_fetch({}, None)
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_url_fetch_validates_invalid_max_chars(self):
+        result = main.builtin_url_fetch({}, "https://example.com", max_chars="bad")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_url_fetch_returns_error_on_network_failure(self):
+        with patch("urllib.request.urlopen", side_effect=OSError("connection refused")):
+            result = main.builtin_url_fetch({}, "https://example.com")
+        self.assertTrue(result.startswith("Error:"))
+
+    def test_url_fetch_returns_plain_text_unchanged(self):
+        body = b"Hello, plain text world!"
+
+        class FakeResp:
+            headers = {"Content-Type": "text/plain"}
+            def read(self, n): return body
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            result = main.builtin_url_fetch({}, "https://example.com")
+        self.assertEqual(result, "Hello, plain text world!")
+
+    def test_url_fetch_strips_html_tags(self):
+        body = b"<html><body><p>Hello <b>world</b></p></body></html>"
+
+        class FakeResp:
+            headers = {"Content-Type": "text/html; charset=utf-8"}
+            def read(self, n): return body
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            result = main.builtin_url_fetch({}, "https://example.com")
+        self.assertNotIn("<b>", result)
+        self.assertIn("Hello", result)
+        self.assertIn("world", result)
+
+    def test_url_fetch_strips_script_and_style_content(self):
+        body = b"<html><head><style>body{color:red}</style><script>alert(1)</script></head><body>Content</body></html>"
+
+        class FakeResp:
+            headers = {"Content-Type": "text/html"}
+            def read(self, n): return body
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            result = main.builtin_url_fetch({}, "https://example.com")
+        self.assertNotIn("color:red", result)
+        self.assertNotIn("alert(1)", result)
+        self.assertIn("Content", result)
+
+    def test_url_fetch_respects_max_chars(self):
+        body = b"A" * 1000
+
+        class FakeResp:
+            headers = {"Content-Type": "text/plain"}
+            def read(self, n): return body[:n]
+            def __enter__(self): return self
+            def __exit__(self, *a): pass
+
+        with patch("urllib.request.urlopen", return_value=FakeResp()):
+            result = main.builtin_url_fetch({}, "https://example.com", max_chars=50)
+        self.assertEqual(len(result), 50)
+
     # ── builtin.file_search ──────────────────────────────────────────────────
 
     def test_file_search_finds_text_in_workspace_file(self):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -361,7 +361,8 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(sre["capabilities"], ["kubeapi", "operator"])
         self.assertEqual(
             sre["tool_grants"],
-            ["agent.*", "memory.expand_digest", "memory.list_digests", "memory.search"],
+            ["agent.*", "builtin.url_fetch", "builtin.web_search",
+             "memory.expand_digest", "memory.list_digests", "memory.search"],
         )
 
     def test_archive_role_rejects_protected_roles_and_exits_eligible_role(self):
@@ -665,6 +666,8 @@ class RuntimeTests(unittest.TestCase):
 
         tool_names = {tool["name"] for tool in fake_client.responses.create.calls[0]["tools"]}
         self.assertIn("tools__propose", tool_names)
+        self.assertIn("builtin__web_search", tool_names)
+        self.assertIn("builtin__url_fetch", tool_names)
         self.assertNotIn("org__create_role", tool_names)
 
     def test_disallowed_tool_call_is_rejected_at_runtime(self):
@@ -2140,6 +2143,7 @@ class BuiltinToolTests(unittest.TestCase):
             sorted(builtin_names),
             sorted([
                 "builtin.web_search",
+                "builtin.url_fetch",
                 "builtin.file_search",
                 "builtin.shell_run",
                 "builtin.tool_search",

--- a/tools.yaml
+++ b/tools.yaml
@@ -829,6 +829,23 @@
       - query
   code: |
     return builtin_web_search(employee_dict, query, num_results=num_results if num_results is not None else 5)
+- name: builtin.url_fetch
+  grantable: true
+  owner_capability: agent
+  description: Fetch the text content of a URL (plain text or markdown preferred). Returns up to max_chars characters. Use for reading documentation, articles, or any public web page.
+  parameters:
+    type: object
+    properties:
+      url:
+        type: string
+        description: The URL to fetch (must start with http:// or https://).
+      max_chars:
+        type: integer
+        description: Maximum characters to return (default 16000, max 128000).
+    required:
+      - url
+  code: |
+    return builtin_url_fetch(employee_dict, url, max_chars=max_chars if max_chars is not None else 16000)
 - name: builtin.file_search
   grantable: true
   owner_capability: agent


### PR DESCRIPTION
## Summary

- Adds `builtin_url_fetch` — fetches URL text content (HTML-stripped, truncated to `max_chars`, default 16 000 chars). Registered in `tools.yaml` and `tool_functions.py`.
- Grants `builtin.web_search` **and** `builtin.url_fetch` to all roles by default (previously neither was in `Role.allowed_tools`). Closes #79.
- Updates SE system prompt to list `builtin_url_fetch` in the available-globals reference.
- 226 tests pass.

## Verification

Direct function test confirms the tool works:

```
builtin_url_fetch({}, 'https://docs.equinix.com/fabric.md')
# → 15 978 chars including:
# "Physical ports are available in 1 Gbps, 10 Gbps, and 100 Gbps bandwidths..."
```

LLM end-to-end test was attempted with granite4.1:3b (Ollama) but blocked by the 4k context limit (filed as #103) and a separate Responses API non-stateful issue with Ollama (filed as #102). Workaround: `ROBITS_PROVIDER_API=chat OPENAI_BASE_URL=http://127.0.0.1:11434/v1/`.

## Related issues filed

- #102 — ResponsesProvider tool loop broken for non-stateful Ollama
- #103 — Context window management / history trimming
- #104 — TUI token usage display

🤖 Generated with [Claude Code](https://claude.com/claude-code)