### PR TITLE
feat: semantic search cascade parity (#97) and context-window trimming (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For local models with embedding support, `sqlite-vec` is included in `requiremen
 | `ROBITS_CHEAP_MODEL` | `ROBITS_MODEL` | Model for cheap interactions |
 | `ROBITS_COSTLY_MODEL` | `ROBITS_MODEL` | Model for SE and costly interactions |
 | `ROBITS_PROVIDER_API` | `responses` | `responses` or `chat` / `chat_completions` |
+| `ROBITS_MAX_CONTEXT_TOKENS` | `0` (unlimited) | Trim conversation history to this token budget before each model call (~4 chars/token). Useful for small-context local models (e.g. `3500` for 4k-context models) |
 | `ROBITS_MEMORY_DB` | `~/.local/share/robits/memory.db` | SQLite path for memory storage |
 | `ROBITS_CLOCK_STATE` | `on` | Base clock state: `on`, `break`, or `off` |
 | `ROBITS_BREAK_SCHEDULE` | — | Scheduled break windows, e.g. `12:00-13:00,15:00-15:30` |

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -69,6 +69,7 @@ class Config:
         self.costly_model = env.get("ROBITS_COSTLY_MODEL", _default)
         self.cheap_model = env.get("ROBITS_CHEAP_MODEL", _default)
         self.provider_api = env.get("ROBITS_PROVIDER_API", "responses").strip().lower()
+        self.max_context_tokens = max(0, int(env.get("ROBITS_MAX_CONTEXT_TOKENS", "0")))
 
         # --- concurrency / retry ---
         self.max_parallelism = max(1, int(env.get("ROBITS_MAX_PARALLELISM", "1")))

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -36,10 +36,25 @@ def interact(self, model, sender, message):
         messages.insert(0, {"role": "system", "content": system_content})
     if message is not None and message != "":
         messages.append({"role": "user", "content": message, "name": sender})
-    from termcolor import colored
-    print(colored(f"\n---\n// {self.name}\n{json.dumps(messages)}\n---\n", "grey"))
 
-    content = _m.model_provider.generate(self, model, sender, messages)
+    send_messages = messages
+    if _m.max_context_tokens > 0 and len(messages) > 1:
+        budget = _m.max_context_tokens * 4  # ~4 chars per token
+        system_msg = messages[0]
+        kept = []
+        chars = len(json.dumps(system_msg))
+        for msg in reversed(messages[1:]):
+            msg_chars = len(json.dumps(msg))
+            if chars + msg_chars > budget and kept:
+                break
+            kept.insert(0, msg)
+            chars += msg_chars
+        send_messages = [system_msg] + kept
+
+    from termcolor import colored
+    print(colored(f"\n---\n// {self.name}\n{json.dumps(send_messages)}\n---\n", "grey"))
+
+    content = _m.model_provider.generate(self, model, sender, send_messages)
     message = {"role": "assistant", "content": content or "", "name": self.name}
 
     message["content"] = message["content"].strip()

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -1903,6 +1903,8 @@ class SQLiteMemoryStore:
             "thoughts": "thought",
             "memory_digests": "memory_digest",
         }
+        # Collect up to limit*2 semantic hits so cascade digests have room within [:limit].
+        inner_limit = limit * 2
         results = []
         seen_ids: set[str] = set()
         cascade_ids: dict[str, list[str]] = {}
@@ -1942,11 +1944,12 @@ class SQLiteMemoryStore:
                 cascade_digest_ids.add(source_id)
             else:
                 cascade_ids.setdefault(source_table, []).append(source_id)
-            if len(results) >= limit:
+            if len(results) >= inner_limit:
                 break
 
         # Cascade: surface parent digests for non-digest semantic hits,
         # matching the behaviour of search_cascade for FTS results.
+        import sqlite3 as _sqlite3
         for source_table, source_ids in cascade_ids.items():
             if not source_ids:
                 continue
@@ -1974,7 +1977,7 @@ class SQLiteMemoryStore:
                     """,
                     params,
                 ).fetchall()
-            except Exception:
+            except _sqlite3.Error:
                 continue
             for crow in cascade_rows:
                 digest_id_str = str(crow["digest_id"])

--- a/robits/memory/sqlite.py
+++ b/robits/memory/sqlite.py
@@ -1905,6 +1905,8 @@ class SQLiteMemoryStore:
         }
         results = []
         seen_ids: set[str] = set()
+        cascade_ids: dict[str, list[str]] = {}
+        cascade_digest_ids: set[str] = set()
         for row in rows:
             source_table = row["source_table"]
             source_id = row["source_id"]
@@ -1936,9 +1938,63 @@ class SQLiteMemoryStore:
                     created_at=rec.get("created_at", ""),
                 )
             )
+            if source_table == "memory_digests":
+                cascade_digest_ids.add(source_id)
+            else:
+                cascade_ids.setdefault(source_table, []).append(source_id)
             if len(results) >= limit:
                 break
-        return results
+
+        # Cascade: surface parent digests for non-digest semantic hits,
+        # matching the behaviour of search_cascade for FTS results.
+        for source_table, source_ids in cascade_ids.items():
+            if not source_ids:
+                continue
+            placeholders = ", ".join("?" * len(source_ids))
+            params: list[Any] = [source_table] + source_ids
+            agent_filter = ""
+            if agent_id is not None:
+                agent_filter = "AND md.agent_id = ?"
+                params.append(agent_id)
+            params.append(limit)
+            try:
+                cascade_rows = self.connection.execute(
+                    f"""
+                    SELECT DISTINCT md.digest_id, md.agent_id, md.session_id,
+                           md.source, md.relationship_type, md.conversation_type,
+                           md.created_at, md.content
+                    FROM memory_digest_sources mds
+                    JOIN memory_digests md ON md.digest_id = mds.digest_id
+                    WHERE mds.source_table = ?
+                      AND mds.source_id IN ({placeholders})
+                      AND md.accessibility = 'agent'
+                      AND md.system_only = 0
+                      {agent_filter}
+                    LIMIT ?
+                    """,
+                    params,
+                ).fetchall()
+            except Exception:
+                continue
+            for crow in cascade_rows:
+                digest_id_str = str(crow["digest_id"])
+                if digest_id_str not in cascade_digest_ids:
+                    results.append(
+                        MemorySearchResult(
+                            kind="memory_digest",
+                            record_id=digest_id_str,
+                            content=crow["content"],
+                            agent_id=crow["agent_id"],
+                            session_id=crow["session_id"],
+                            source=crow["source"],
+                            relationship_type=crow["relationship_type"],
+                            conversation_type=crow["conversation_type"],
+                            created_at=crow["created_at"],
+                        )
+                    )
+                    cascade_digest_ids.add(digest_id_str)
+
+        return results[:limit]
 
     def search_hybrid(
         self,

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4110,6 +4110,54 @@ class EmbeddingSearchTests(unittest.TestCase):
         contents = [r.content for r in results]
         self.assertTrue(any("xyz99" in c for c in contents))
 
+    def test_search_semantic_cascades_parent_digest(self):
+        if not self.store._vec_enabled:
+            self.skipTest("sqlite-vec not available")
+        self.store.create_session("s_casc")
+        msg_id = self.store.append_message(
+            "s_casc", "zoe", "zoe", "semantic cascade unique_sem_kw"
+        )
+        digest_id = self.store.append_memory_digest(
+            "Semantic cascade digest summary.",
+            [{"source_table": "messages", "source_id": msg_id}],
+            agent_id="zoe",
+            session_id="s_casc",
+        )
+        vector = [0.5] * 768
+        self.store.store_embedding("messages", str(msg_id), vector, "test-model")
+        results = self.store.search_semantic(
+            "cascade", "test-model", agent_id="zoe", limit=10,
+            _query_vector=vector,
+        )
+        kinds = {r.kind for r in results}
+        record_ids = {r.record_id for r in results}
+        self.assertIn("memory_digest", kinds)
+        self.assertIn(str(digest_id), record_ids)
+
+    def test_search_semantic_cascade_deduplicates_existing_digest_hits(self):
+        if not self.store._vec_enabled:
+            self.skipTest("sqlite-vec not available")
+        self.store.create_session("s_dedup")
+        msg_id = self.store.append_message(
+            "s_dedup", "zoe", "zoe", "dedup cascade content"
+        )
+        digest_id = self.store.append_memory_digest(
+            "Digest already in semantic hits.",
+            [{"source_table": "messages", "source_id": msg_id}],
+            agent_id="zoe",
+            session_id="s_dedup",
+        )
+        msg_vector = [0.3] * 768
+        digest_vector = [0.3] * 768
+        self.store.store_embedding("messages", str(msg_id), msg_vector, "test-model")
+        self.store.store_embedding("memory_digests", str(digest_id), digest_vector, "test-model")
+        results = self.store.search_semantic(
+            "dedup", "test-model", agent_id="zoe", limit=10,
+            _query_vector=digest_vector,
+        )
+        digest_hits = [r for r in results if r.kind == "memory_digest" and r.record_id == str(digest_id)]
+        self.assertEqual(len(digest_hits), 1)
+
     def test_vec_table_created_per_dimension(self):
         if not self.store._vec_enabled:
             self.skipTest("sqlite-vec not available")
@@ -4210,6 +4258,117 @@ class DirectedRoutingTests(unittest.TestCase):
             routed = session.route_message("SE, implement the feature", "CEO")
         self.assertTrue(routed.directed)
         self.assertEqual(routed.receiver.name, "alex_chen")
+
+
+class ContextTrimTests(unittest.TestCase):
+    """Tests for #103 — ROBITS_MAX_CONTEXT_TOKENS trims conversation_history before generate()."""
+
+    def _fake_role(self, history):
+        """Build a minimal role-like object with the given conversation history."""
+        role = SimpleNamespace(
+            name="SE",
+            template="system prompt",
+            conversation_history={"SE": history},
+            max_tokens=200,
+            temperature=0.7,
+            top_p=0.9,
+            employee_dict={},
+        )
+        return role
+
+    def test_trimming_disabled_when_zero(self):
+        """No trimming when ROBITS_MAX_CONTEXT_TOKENS=0 (default)."""
+        captured = []
+
+        def fake_generate(role, model, sender, messages):
+            captured.append(list(messages))
+            return "ok"
+
+        history = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "msg1", "name": "CEO"},
+            {"role": "assistant", "content": "rep1", "name": "SE"},
+            {"role": "user", "content": "msg2", "name": "CEO"},
+        ]
+        role = self._fake_role(history)
+        expected_len = len(history)
+        orig = main._config.max_context_tokens
+        orig_provider = main._config.model_provider
+        try:
+            main._config.max_context_tokens = 0
+            main._config.model_provider = SimpleNamespace(generate=fake_generate)
+            with redirect_stdout(StringIO()):
+                from robits.core.roles import interact
+                interact(role, "model", "CEO", None)
+        finally:
+            main._config.max_context_tokens = orig
+            main._config.model_provider = orig_provider
+        self.assertEqual(len(captured[0]), expected_len)
+
+    def test_trimming_drops_oldest_non_system_messages(self):
+        """Old turns are dropped to fit within the token budget; system + newest kept."""
+        captured = []
+
+        def fake_generate(role, model, sender, messages):
+            captured.append(list(messages))
+            return "ok"
+
+        long_content = "x" * 400
+        history = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": long_content, "name": "CEO"},
+            {"role": "assistant", "content": long_content, "name": "SE"},
+            {"role": "user", "content": "new msg", "name": "CEO"},
+        ]
+        role = self._fake_role(history)
+        orig = main._config.max_context_tokens
+        orig_provider = main._config.model_provider
+        try:
+            # Budget: 50 tokens * 4 chars = 200 chars — fits system + new msg but not the long history
+            main._config.max_context_tokens = 50
+            main._config.model_provider = SimpleNamespace(generate=fake_generate)
+            with redirect_stdout(StringIO()):
+                from robits.core.roles import interact
+                interact(role, "model", "CEO", None)
+        finally:
+            main._config.max_context_tokens = orig
+            main._config.model_provider = orig_provider
+        sent = captured[0]
+        self.assertEqual(sent[0]["role"], "system")
+        self.assertLess(len(sent), len(history))
+        # Most recent message must always be present
+        self.assertTrue(any(m.get("content") == "new msg" for m in sent))
+
+    def test_trimming_does_not_mutate_conversation_history(self):
+        """Trimming is applied only to the messages sent to generate(), not stored history."""
+        captured = []
+
+        def fake_generate(role, model, sender, messages):
+            captured.append(list(messages))
+            return "ok"
+
+        long_content = "y" * 400
+        history = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": long_content, "name": "CEO"},
+            {"role": "assistant", "content": long_content, "name": "SE"},
+            {"role": "user", "content": "check history", "name": "CEO"},
+        ]
+        role = self._fake_role(history)
+        orig_len = len(history)
+        orig = main._config.max_context_tokens
+        orig_provider = main._config.model_provider
+        try:
+            main._config.max_context_tokens = 50
+            main._config.model_provider = SimpleNamespace(generate=fake_generate)
+            with redirect_stdout(StringIO()):
+                from robits.core.roles import interact
+                interact(role, "model", "CEO", None)
+        finally:
+            main._config.max_context_tokens = orig
+            main._config.model_provider = orig_provider
+        # The stored history grows by one (the assistant reply), trimming must not shrink it
+        self.assertGreaterEqual(len(role.conversation_history["SE"]), orig_len)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

### #97 — `search_semantic` cascade parity with FTS

`search_cascade` (FTS) surfaces parent digests when a raw record (message/thought) is a source of an episodic digest. `search_semantic` did not. This meant semantic-only hits never returned their parent digests.

**Fix:** after the kNN lookup and result-building loop, run the same cascade SQL against `memory_digest_sources` for every non-digest hit. Digest IDs already present as direct kNN hits are deduplicated.

### #103 — `ROBITS_MAX_CONTEXT_TOKENS` conversation history trimming

`conversation_history` grows unboundedly. Local models with 4k context (e.g. `granite4.1:3b`) overflow before the user message arrives.

**Fix:** new `ROBITS_MAX_CONTEXT_TOKENS` env var (default `0` = uncapped). When set, `interact()` builds a `send_messages` slice — system message + most-recent turns that fit within `budget = tokens * 4 chars` — and passes that to `generate()`. The stored `conversation_history` is never trimmed; only the outbound payload is capped.

**Usage for 4k local models:**
```bash
ROBITS_MAX_CONTEXT_TOKENS=3500 ROBITS_PROVIDER_API=chat OPENAI_BASE_URL=http://127.0.0.1:11434/v1/ ...
```

## Tests

- 2 new embedding cascade tests (skip when `sqlite-vec` unavailable): cascade surfaces parent digest; deduplication prevents double-inclusion
- 3 new context trim tests: disabled at zero, oldest turns dropped, `conversation_history` not mutated

240 tests pass.

## Test plan

- [ ] Verify `search_semantic` returns parent digest when only the raw record has an embedding
- [ ] Verify `ROBITS_MAX_CONTEXT_TOKENS=3500` prevents Ollama truncation on granite4.1:3b

🤖 Generated with [Claude Code](https://claude.com/claude-code)