### PR TITLE
feat: capture and archive model thinking/reasoning tokens

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,6 +116,8 @@ from robits.core.providers import (  # noqa: E402
     make_model_provider,
     _emit_role_tool_event,
     _with_model_retries,
+    _extract_thinking_chat,
+    _extract_thinking_responses,
 )
 from robits.core.session import (  # noqa: E402
     TranscriptEntry,

--- a/robits/core/providers.py
+++ b/robits/core/providers.py
@@ -61,6 +61,78 @@ def _with_model_retries(operation):
             attempt += 1
 
 
+def _extract_thinking_chat(message):
+    """Extract thinking/reasoning from a ChatCompletions message.
+
+    Returns (content_text, thinking_text | None). content_text has inline
+    thinking tags stripped so only the final expressed output is returned.
+    """
+    import re as _re
+
+    # DeepSeek-R1 / QwQ via OpenAI-compat: dedicated reasoning_content field
+    reasoning = getattr(message, "reasoning_content", None)
+    if reasoning and isinstance(reasoning, str) and reasoning.strip():
+        content = getattr(message, "content", "") or ""
+        return str(content), reasoning.strip()
+
+    # Some providers expose a top-level thinking field
+    thinking_attr = getattr(message, "thinking", None)
+    if thinking_attr and isinstance(thinking_attr, str) and thinking_attr.strip():
+        content = getattr(message, "content", "") or ""
+        return str(content), thinking_attr.strip()
+
+    # Anthropic-compat via OpenAI endpoint: content is a list of typed blocks
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        text_parts = []
+        thinking_parts = []
+        for block in content:
+            if hasattr(block, "type"):
+                btype, btext = block.type, getattr(block, "text", None)
+                bthink = getattr(block, "thinking", None)
+            elif isinstance(block, dict):
+                btype = block.get("type")
+                btext = block.get("text")
+                bthink = block.get("thinking")
+            else:
+                continue
+            if btype == "thinking" and bthink:
+                thinking_parts.append(bthink)
+            elif btext:
+                text_parts.append(btext)
+        if thinking_parts:
+            return "".join(text_parts), "\n\n".join(thinking_parts)
+        return "".join(text_parts), None
+
+    # Inline tags in string content: <think>…</think> or <thinking>…</thinking>
+    content_str = str(content) if content is not None else ""
+    for pattern in (r"<thinking>(.*?)</thinking>", r"<think>(.*?)</think>"):
+        m = _re.search(pattern, content_str, _re.DOTALL)
+        if m:
+            thinking_text = m.group(1).strip()
+            clean = (content_str[: m.start()] + content_str[m.end() :]).strip()
+            return clean, thinking_text
+
+    return content_str, None
+
+
+def _extract_thinking_responses(response):
+    """Extract reasoning text from a Responses API response; return text or None."""
+    chunks = []
+    for item in getattr(response, "output", []) or []:
+        if getattr(item, "type", None) != "reasoning":
+            continue
+        for part in getattr(item, "content", []) or []:
+            text = getattr(part, "text", None)
+            if text:
+                chunks.append(text)
+        # Some providers surface text directly on the reasoning item
+        text = getattr(item, "text", None)
+        if text:
+            chunks.append(text)
+    return "\n\n".join(chunks) if chunks else None
+
+
 def _emit_role_tool_event(role, event_type, payload):
     """Emit a tool event to the role's event stream and persist it to the memory store."""
     event_stream = getattr(role, "runtime_event_stream", None)
@@ -135,7 +207,10 @@ class ChatCompletionsProvider(ModelProvider):
             message = response.choices[0].message
             tool_calls = getattr(message, "tool_calls", None) or []
             if not tool_calls:
-                return message.content or ""
+                content, thinking = _extract_thinking_chat(message)
+                if thinking:
+                    role.runtime_thinking = thinking
+                return content
             if employee_dict is None:
                 return "Error: Tool call requested but no employee dictionary is available."
             kwargs["messages"] = list(kwargs["messages"]) + [message.model_dump()]
@@ -210,6 +285,9 @@ class ResponsesProvider(ModelProvider):
         for _ in range(8):
             function_calls = _response_function_calls(response)
             if not function_calls:
+                thinking = _extract_thinking_responses(response)
+                if thinking:
+                    role.runtime_thinking = thinking
                 return _response_text(response)
             if employee_dict is None:
                 return "Error: Tool call requested but no employee dictionary is available."

--- a/robits/core/providers.py
+++ b/robits/core/providers.py
@@ -117,16 +117,29 @@ def _extract_thinking_chat(message):
 
 
 def _extract_thinking_responses(response):
-    """Extract reasoning text from a Responses API response; return text or None."""
+    """Extract reasoning text from a Responses API response; return text or None.
+
+    Handles three shapes:
+    - item.summary[{type:"summary_text", text:...}]  (reasoning.summary:"auto")
+    - item.content[{text:...}]                        (raw content blocks)
+    - item.text                                        (direct text field)
+    """
     chunks = []
     for item in getattr(response, "output", []) or []:
         if getattr(item, "type", None) != "reasoning":
             continue
+        # OpenAI Responses API with reasoning.summary:"auto"
+        for part in getattr(item, "summary", []) or []:
+            if getattr(part, "type", None) == "summary_text":
+                text = getattr(part, "text", None)
+                if text:
+                    chunks.append(text)
+        # Raw content blocks
         for part in getattr(item, "content", []) or []:
             text = getattr(part, "text", None)
             if text:
                 chunks.append(text)
-        # Some providers surface text directly on the reasoning item
+        # Direct text field (some providers)
         text = getattr(item, "text", None)
         if text:
             chunks.append(text)

--- a/robits/core/providers.py
+++ b/robits/core/providers.py
@@ -107,13 +107,23 @@ def _extract_thinking_chat(message):
                 bthink = block.get("thinking")
             else:
                 continue
-            if btype == "thinking" and bthink:
-                thinking_parts.append(bthink)
+            if btype == "thinking":
+                if bthink:
+                    thinking_parts.append(bthink)
+                elif btext:
+                    thinking_parts.append(btext)
             elif btext:
                 text_parts.append(btext)
         content_text, inline_thinking = _strip_inline_thinking("".join(text_parts))
         typed_thinking = "\n\n".join([str(t).strip() for t in thinking_parts if str(t).strip()]) or None
-        return content_text, _join_thinking(typed_thinking, inline_thinking)
+        reasoning = getattr(message, "reasoning_content", None)
+        thinking_attr = getattr(message, "thinking", None)
+        provider_thinking = None
+        if reasoning and isinstance(reasoning, str):
+            provider_thinking = reasoning
+        elif thinking_attr and isinstance(thinking_attr, str):
+            provider_thinking = thinking_attr
+        return content_text, _join_thinking(provider_thinking, typed_thinking, inline_thinking)
 
     # String content: always strip inline tags, then merge with any provider-specific fields.
     content_str = str(content) if content is not None else ""
@@ -235,10 +245,11 @@ class ChatCompletionsProvider(ModelProvider):
             response = _with_model_retries(lambda: self.client.chat.completions.create(**kwargs))
             message = response.choices[0].message
             tool_calls = getattr(message, "tool_calls", None) or []
+            content, thinking = _extract_thinking_chat(message)
+            if thinking:
+                current = getattr(role, "runtime_thinking", None)
+                role.runtime_thinking = (current + "\n\n" + thinking) if current else thinking
             if not tool_calls:
-                content, thinking = _extract_thinking_chat(message)
-                if thinking:
-                    role.runtime_thinking = thinking
                 return content
             if employee_dict is None:
                 return "Error: Tool call requested but no employee dictionary is available."
@@ -313,10 +324,11 @@ class ResponsesProvider(ModelProvider):
         response = _with_model_retries(lambda: self.client.responses.create(**kwargs))
         for _ in range(8):
             function_calls = _response_function_calls(response)
+            thinking = _extract_thinking_responses(response)
+            if thinking:
+                current = getattr(role, "runtime_thinking", None)
+                role.runtime_thinking = (current + "\n\n" + thinking) if current else thinking
             if not function_calls:
-                thinking = _extract_thinking_responses(response)
-                if thinking:
-                    role.runtime_thinking = thinking
                 return _response_text(response)
             if employee_dict is None:
                 return "Error: Tool call requested but no employee dictionary is available."

--- a/robits/core/providers.py
+++ b/robits/core/providers.py
@@ -69,17 +69,28 @@ def _extract_thinking_chat(message):
     """
     import re as _re
 
-    # DeepSeek-R1 / QwQ via OpenAI-compat: dedicated reasoning_content field
-    reasoning = getattr(message, "reasoning_content", None)
-    if reasoning and isinstance(reasoning, str) and reasoning.strip():
-        content = getattr(message, "content", "") or ""
-        return str(content), reasoning.strip()
+    _inline_pattern = _re.compile(
+        r"<(?P<tag>think|thinking)>(?P<body>.*?)</(?P=tag)>",
+        flags=_re.DOTALL | _re.IGNORECASE,
+    )
 
-    # Some providers expose a top-level thinking field
-    thinking_attr = getattr(message, "thinking", None)
-    if thinking_attr and isinstance(thinking_attr, str) and thinking_attr.strip():
-        content = getattr(message, "content", "") or ""
-        return str(content), thinking_attr.strip()
+    def _strip_inline_thinking(text):
+        if not text:
+            return "", None
+        blocks = []
+        for match in _inline_pattern.finditer(text):
+            body = (match.group("body") or "").strip()
+            if body:
+                blocks.append(body)
+        clean = _inline_pattern.sub("", text).strip()
+        return clean, ("\n\n".join(blocks) if blocks else None)
+
+    def _join_thinking(*parts):
+        chunks = []
+        for part in parts:
+            if part and isinstance(part, str) and part.strip():
+                chunks.append(part.strip())
+        return "\n\n".join(chunks) if chunks else None
 
     # Anthropic-compat via OpenAI endpoint: content is a list of typed blocks
     content = getattr(message, "content", None)
@@ -100,20 +111,25 @@ def _extract_thinking_chat(message):
                 thinking_parts.append(bthink)
             elif btext:
                 text_parts.append(btext)
-        if thinking_parts:
-            return "".join(text_parts), "\n\n".join(thinking_parts)
-        return "".join(text_parts), None
+        content_text, inline_thinking = _strip_inline_thinking("".join(text_parts))
+        typed_thinking = "\n\n".join([str(t).strip() for t in thinking_parts if str(t).strip()]) or None
+        return content_text, _join_thinking(typed_thinking, inline_thinking)
 
-    # Inline tags in string content: <think>…</think> or <thinking>…</thinking>
+    # String content: always strip inline tags, then merge with any provider-specific fields.
     content_str = str(content) if content is not None else ""
-    for pattern in (r"<thinking>(.*?)</thinking>", r"<think>(.*?)</think>"):
-        m = _re.search(pattern, content_str, _re.DOTALL)
-        if m:
-            thinking_text = m.group(1).strip()
-            clean = (content_str[: m.start()] + content_str[m.end() :]).strip()
-            return clean, thinking_text
+    content_text, inline_thinking = _strip_inline_thinking(content_str)
 
-    return content_str, None
+    # DeepSeek-R1 / QwQ via OpenAI-compat: dedicated reasoning_content field
+    reasoning = getattr(message, "reasoning_content", None)
+    # Some providers expose a top-level thinking field
+    thinking_attr = getattr(message, "thinking", None)
+    provider_thinking = None
+    if reasoning and isinstance(reasoning, str):
+        provider_thinking = reasoning
+    elif thinking_attr and isinstance(thinking_attr, str):
+        provider_thinking = thinking_attr
+
+    return content_text, _join_thinking(provider_thinking, inline_thinking)
 
 
 def _extract_thinking_responses(response):

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -437,7 +437,7 @@ class Session:
             return "", system_events
         return message, []
 
-    def record_turn(self, sender, receiver, prompt, response, directed=False, system_events=None):
+    def record_turn(self, sender, receiver, prompt, response, directed=False, system_events=None, thinking=None):
         """Append a TranscriptEntry, update memory, and trigger auto-digest if due."""
         meaningful_response = bool(str(response or "").strip())
         system_events = system_events or []
@@ -489,8 +489,9 @@ class Session:
                         channel_id=msg_channel_id,
                         sender_phase=sender_phase,
                     )
+                response_msg_id = None
                 if meaningful_response and response:
-                    _m.memory_store.append_message(
+                    response_msg_id = _m.memory_store.append_message(
                         session_id=self.run_id,
                         sender_agent_id=canonical_receiver,
                         receiver_agent_id=canonical_sender,
@@ -500,6 +501,20 @@ class Session:
                         channel_id=msg_channel_id,
                         sender_phase=receiver_phase,
                     )
+                if thinking and response_msg_id is not None:
+                    thought_channel_id = self._get_thought_channel_id(canonical_receiver)
+                    try:
+                        _m.memory_store.append_thought(
+                            agent_id=canonical_receiver,
+                            content=thinking,
+                            session_id=self.run_id,
+                            visibility="private",
+                            source="model_thinking",
+                            channel_id=thought_channel_id,
+                            metadata={"linked_message_id": response_msg_id},
+                        )
+                    except Exception:
+                        pass
                 if msg_channel_id is not None and sender_phase is not None and receiver_phase is not None:
                     try:
                         social_distance = _m.memory_store.get_channel_social_distance(
@@ -806,6 +821,7 @@ class Session:
         role.runtime_event_stream = self.event_stream
         role.runtime_session_id = self.run_id
         role.runtime_tool_results = []
+        role.runtime_thinking = None
         effective_clock = self._effective_clock_state()
         role.runtime_clock_state = effective_clock
         _modulate_temperature(role, effective_clock)
@@ -859,6 +875,7 @@ class Session:
         self.prepare_agent_runtime(routed.receiver)
         response = routed.receiver.interact(sender.name, model_prompt)
         response = "" if response is None else response
+        model_thinking = getattr(routed.receiver, "runtime_thinking", None)
         native_tool_events = list(getattr(routed.receiver, "runtime_tool_results", []))
         if native_tool_events:
             system_events.extend(native_tool_events)
@@ -877,6 +894,7 @@ class Session:
             response=response,
             directed=routed.directed,
             system_events=system_events,
+            thinking=model_thinking,
         )
         self.last_receiver = routed.receiver
         return response

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -513,8 +513,12 @@ class Session:
                             channel_id=thought_channel_id,
                             metadata={"linked_message_id": response_msg_id},
                         )
-                    except Exception:
-                        pass
+                    except Exception as _e:
+                        self.event_stream.emit(
+                            "thought.store_failed",
+                            self.run_id,
+                            {"agent_id": canonical_receiver, "error": str(_e)},
+                        )
                 if msg_channel_id is not None and sender_phase is not None and receiver_phase is not None:
                     try:
                         social_distance = _m.memory_store.get_channel_social_distance(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2648,6 +2648,34 @@ class SessionMemoryCaptureTests(unittest.TestCase):
         self.assertEqual(rows[0]["content"], "my private thought")
         self.assertEqual(rows[0]["visibility"], "private")
 
+    def test_model_thinking_stored_as_thought_linked_to_response_message(self):
+        session = self._make_session()
+        session.record_turn("A", "SE", "what color?", "Green.", thinking="I considered blue but chose green.")
+        thought_rows = self.store.connection.execute(
+            "SELECT content, source, metadata_json FROM thoughts WHERE agent_id = 'SE'"
+        ).fetchall()
+        self.assertEqual(len(thought_rows), 1)
+        self.assertEqual(thought_rows[0]["content"], "I considered blue but chose green.")
+        self.assertEqual(thought_rows[0]["source"], "model_thinking")
+        import json as _json
+        meta = _json.loads(thought_rows[0]["metadata_json"])
+        # linked_message_id should point to the response message row
+        self.assertIn("linked_message_id", meta)
+        response_msg = self.store.connection.execute(
+            "SELECT content FROM messages WHERE message_id = ?",
+            (meta["linked_message_id"],),
+        ).fetchone()
+        self.assertIsNotNone(response_msg)
+        self.assertEqual(response_msg["content"], "Green.")
+
+    def test_model_thinking_not_stored_when_no_response(self):
+        session = self._make_session()
+        session.record_turn("A", "SE", "hello", "", thinking="silent thought")
+        thought_rows = self.store.connection.execute(
+            "SELECT COUNT(*) AS n FROM thoughts WHERE source = 'model_thinking'"
+        ).fetchone()
+        self.assertEqual(thought_rows["n"], 0)
+
     def test_session_ended_at_set_on_run_completion(self):
         session = self._make_session()
         session.turns_completed = 0
@@ -3177,6 +3205,128 @@ class ReasoningEffortTests(unittest.TestCase):
             main._reasoning_effort_env = old_effort
 
         self.assertEqual(captured.get("reasoning"), {"effort": "high"})
+
+
+class ThinkingExtractionTests(unittest.TestCase):
+    """Tests for _extract_thinking_chat and _extract_thinking_responses."""
+
+    def _make_role(self):
+        return SimpleNamespace(
+            name="SE",
+            max_tokens=100,
+            temperature=0.0,
+            employee_dict=None,
+            allowed_tools=set(),
+            runtime_thinking=None,
+        )
+
+    # --- _extract_thinking_chat ---
+
+    def test_reasoning_content_field(self):
+        msg = SimpleNamespace(content="Green.", reasoning_content="I like blue but green more.")
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "Green.")
+        self.assertEqual(thinking, "I like blue but green more.")
+
+    def test_thinking_field(self):
+        msg = SimpleNamespace(content="Sure.", thinking="hidden reasoning", reasoning_content=None)
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "Sure.")
+        self.assertEqual(thinking, "hidden reasoning")
+
+    def test_content_blocks_thinking_type(self):
+        blocks = [
+            {"type": "thinking", "thinking": "private thoughts"},
+            {"type": "text", "text": "public answer"},
+        ]
+        msg = SimpleNamespace(content=blocks, reasoning_content=None, thinking=None)
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "public answer")
+        self.assertEqual(thinking, "private thoughts")
+
+    def test_inline_think_tags_stripped(self):
+        msg = SimpleNamespace(
+            content="<think>considered this</think>Final answer.",
+            reasoning_content=None,
+            thinking=None,
+        )
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "Final answer.")
+        self.assertEqual(thinking, "considered this")
+
+    def test_inline_thinking_tags_stripped(self):
+        msg = SimpleNamespace(
+            content="<thinking>deep thoughts</thinking>Result.",
+            reasoning_content=None,
+            thinking=None,
+        )
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "Result.")
+        self.assertEqual(thinking, "deep thoughts")
+
+    def test_no_thinking_returns_none(self):
+        msg = SimpleNamespace(content="plain answer", reasoning_content=None, thinking=None)
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "plain answer")
+        self.assertIsNone(thinking)
+
+    # --- _extract_thinking_responses ---
+
+    def test_reasoning_output_item(self):
+        part = SimpleNamespace(text="reasoning text")
+        item = SimpleNamespace(type="reasoning", content=[part], text=None)
+        response = SimpleNamespace(output=[item])
+        thinking = main._extract_thinking_responses(response)
+        self.assertEqual(thinking, "reasoning text")
+
+    def test_no_reasoning_output_returns_none(self):
+        item = SimpleNamespace(type="message", content=[], text="hi")
+        response = SimpleNamespace(output=[item])
+        thinking = main._extract_thinking_responses(response)
+        self.assertIsNone(thinking)
+
+    # --- provider sets runtime_thinking ---
+
+    def test_chat_provider_sets_runtime_thinking(self):
+        role = self._make_role()
+        msg = SimpleNamespace(
+            content="<think>I deliberated</think>Answer.",
+            tool_calls=None,
+            reasoning_content=None,
+            thinking=None,
+            model_dump=lambda: {},
+        )
+        response = SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+        registry = SimpleNamespace(
+            as_chat_completion_tools=lambda r: [],
+            resolve_name=lambda n: n,
+        )
+        provider = main.ChatCompletionsProvider.__new__(main.ChatCompletionsProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kw: response)
+            )
+        )
+        result = provider.generate(role, "model", "CEO", [])
+        self.assertEqual(result, "Answer.")
+        self.assertEqual(role.runtime_thinking, "I deliberated")
+
+    def test_responses_provider_sets_runtime_thinking(self):
+        role = self._make_role()
+        part = SimpleNamespace(text="thought about it")
+        reasoning_item = SimpleNamespace(type="reasoning", content=[part], text=None)
+        text_item = SimpleNamespace(type="message", content=[SimpleNamespace(type="output_text", text="Done.")])
+        response = SimpleNamespace(id="r1", output=[reasoning_item, text_item], output_text=None)
+        registry = SimpleNamespace(as_responses_tools=lambda r: [])
+        provider = main.ResponsesProvider.__new__(main.ResponsesProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(
+            responses=SimpleNamespace(create=lambda **kw: response)
+        )
+        result = provider.generate(role, "model", "CEO", [])
+        self.assertEqual(result, "Done.")
+        self.assertEqual(role.runtime_thinking, "thought about it")
 
 
 class OrgChatReadToolTests(unittest.TestCase):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3264,6 +3264,26 @@ class ThinkingExtractionTests(unittest.TestCase):
         self.assertEqual(text, "Result.")
         self.assertEqual(thinking, "deep thoughts")
 
+    def test_inline_think_tags_multiple_blocks_stripped(self):
+        msg = SimpleNamespace(
+            content="A<think>t1</think>B<thinking>t2</thinking>C",
+            reasoning_content=None,
+            thinking=None,
+        )
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "ABC")
+        self.assertEqual(thinking, "t1\n\nt2")
+
+    def test_reasoning_content_and_inline_tags_both_captured(self):
+        msg = SimpleNamespace(
+            content="<think>inline</think>Answer.",
+            reasoning_content="field reasoning",
+            thinking=None,
+        )
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "Answer.")
+        self.assertEqual(thinking, "field reasoning\n\ninline")
+
     def test_no_thinking_returns_none(self):
         msg = SimpleNamespace(content="plain answer", reasoning_content=None, thinking=None)
         text, thinking = main._extract_thinking_chat(msg)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3378,6 +3378,103 @@ class ThinkingExtractionTests(unittest.TestCase):
         self.assertEqual(result, "Done.")
         self.assertEqual(role.runtime_thinking, "thought about it")
 
+    # --- thinking accumulated across agentic loop iterations ---
+
+    def test_chat_provider_accumulates_thinking_across_tool_iterations(self):
+        role = self._make_role()
+        role.employee_dict = {}
+        tool_call = SimpleNamespace(
+            id="call_1",
+            function=SimpleNamespace(name="noop", arguments="{}"),
+        )
+        msg1 = SimpleNamespace(
+            content="",
+            tool_calls=[tool_call],
+            reasoning_content="step 1 thinking",
+            thinking=None,
+            model_dump=lambda: {"role": "assistant", "content": "", "tool_calls": []},
+        )
+        msg2 = SimpleNamespace(
+            content="Final answer.",
+            tool_calls=None,
+            reasoning_content="step 2 thinking",
+            thinking=None,
+            model_dump=lambda: {},
+        )
+        responses_iter = iter([
+            SimpleNamespace(choices=[SimpleNamespace(message=msg1)]),
+            SimpleNamespace(choices=[SimpleNamespace(message=msg2)]),
+        ])
+        registry = SimpleNamespace(
+            as_chat_completion_tools=lambda r: [{"type": "function", "function": {"name": "noop"}}],
+            execute=lambda name, args, ed, caller=None: "ok",
+            resolve_name=lambda n: n,
+        )
+        provider = main.ChatCompletionsProvider.__new__(main.ChatCompletionsProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kw: next(responses_iter))
+            )
+        )
+        result = provider.generate(role, "model", "CEO", [])
+        self.assertEqual(result, "Final answer.")
+        self.assertIn("step 1 thinking", role.runtime_thinking)
+        self.assertIn("step 2 thinking", role.runtime_thinking)
+
+    def test_responses_provider_accumulates_thinking_across_tool_iterations(self):
+        role = self._make_role()
+        role.employee_dict = {}
+        # First response: reasoning item + function call
+        func_call = SimpleNamespace(type="function_call", call_id="c1", name="noop", arguments="{}")
+        r1_thinking = SimpleNamespace(type="reasoning", content=[], text="step 1 thinking", summary=[])
+        response1 = SimpleNamespace(id="r1", output=[r1_thinking, func_call], output_text=None)
+        # Second response: reasoning item + text message, no function calls
+        r2_thinking = SimpleNamespace(type="reasoning", content=[], text="step 2 thinking", summary=[])
+        text_item = SimpleNamespace(type="message", content=[SimpleNamespace(type="output_text", text="Done.")])
+        response2 = SimpleNamespace(id="r2", output=[r2_thinking, text_item], output_text=None)
+
+        call_count = [0]
+        def mock_create(**kw):
+            call_count[0] += 1
+            return response1 if call_count[0] == 1 else response2
+
+        registry = SimpleNamespace(
+            as_responses_tools=lambda r: [],
+            execute=lambda name, args, ed, caller=None: "ok",
+            resolve_name=lambda n: n,
+        )
+        provider = main.ResponsesProvider.__new__(main.ResponsesProvider)
+        provider.registry = registry
+        provider.client = SimpleNamespace(
+            responses=SimpleNamespace(create=mock_create)
+        )
+        result = provider.generate(role, "model", "CEO", [])
+        self.assertEqual(result, "Done.")
+        self.assertIn("step 1 thinking", role.runtime_thinking)
+        self.assertIn("step 2 thinking", role.runtime_thinking)
+
+    # --- P2: thinking block using text field instead of thinking field ---
+
+    def test_content_blocks_thinking_type_with_text_field(self):
+        blocks = [
+            {"type": "thinking", "text": "private via text field", "thinking": None},
+            {"type": "text", "text": "public answer"},
+        ]
+        msg = SimpleNamespace(content=blocks, reasoning_content=None, thinking=None)
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "public answer")
+        self.assertEqual(thinking, "private via text field")
+
+    # --- MEDIUM: provider-specific attrs checked even when content is a list ---
+
+    def test_content_blocks_list_with_reasoning_content_attr(self):
+        blocks = [{"type": "text", "text": "visible"}]
+        msg = SimpleNamespace(content=blocks, reasoning_content="structured reasoning", thinking=None)
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "visible")
+        self.assertEqual(thinking, "structured reasoning")
+
 
 class OrgChatReadToolTests(unittest.TestCase):
     """Tests for the org_chat_read function."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3290,6 +3290,29 @@ class ThinkingExtractionTests(unittest.TestCase):
         self.assertEqual(text, "plain answer")
         self.assertIsNone(thinking)
 
+    def test_multiple_think_blocks_all_collected(self):
+        msg = SimpleNamespace(
+            content="<think>block one</think>middle<think>block two</think>end.",
+            reasoning_content=None,
+            thinking=None,
+        )
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "middleend.")
+        self.assertIn("block one", thinking)
+        self.assertIn("block two", thinking)
+
+    def test_reasoning_content_plus_inline_tag_stripped(self):
+        # Some providers populate both reasoning_content AND embed a tag in content.
+        msg = SimpleNamespace(
+            content="<think>leaked tag</think>Final answer.",
+            reasoning_content="structured reasoning",
+            thinking=None,
+        )
+        text, thinking = main._extract_thinking_chat(msg)
+        self.assertEqual(text, "Final answer.")
+        self.assertIn("structured reasoning", thinking)
+        self.assertIn("leaked tag", thinking)
+
     # --- _extract_thinking_responses ---
 
     def test_reasoning_output_item(self):

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3274,10 +3274,17 @@ class ThinkingExtractionTests(unittest.TestCase):
 
     def test_reasoning_output_item(self):
         part = SimpleNamespace(text="reasoning text")
-        item = SimpleNamespace(type="reasoning", content=[part], text=None)
+        item = SimpleNamespace(type="reasoning", content=[part], text=None, summary=[])
         response = SimpleNamespace(output=[item])
         thinking = main._extract_thinking_responses(response)
         self.assertEqual(thinking, "reasoning text")
+
+    def test_reasoning_summary_text_item(self):
+        summary_part = SimpleNamespace(type="summary_text", text="brief summary of thinking")
+        item = SimpleNamespace(type="reasoning", summary=[summary_part], content=[], text=None)
+        response = SimpleNamespace(output=[item])
+        thinking = main._extract_thinking_responses(response)
+        self.assertEqual(thinking, "brief summary of thinking")
 
     def test_no_reasoning_output_returns_none(self):
         item = SimpleNamespace(type="message", content=[], text="hi")
@@ -3315,7 +3322,7 @@ class ThinkingExtractionTests(unittest.TestCase):
     def test_responses_provider_sets_runtime_thinking(self):
         role = self._make_role()
         part = SimpleNamespace(text="thought about it")
-        reasoning_item = SimpleNamespace(type="reasoning", content=[part], text=None)
+        reasoning_item = SimpleNamespace(type="reasoning", content=[part], text=None, summary=[])
         text_item = SimpleNamespace(type="message", content=[SimpleNamespace(type="output_text", text="Done.")])
         response = SimpleNamespace(id="r1", output=[reasoning_item, text_item], output_text=None)
         registry = SimpleNamespace(as_responses_tools=lambda r: [])


### PR DESCRIPTION
Closes #109

## Summary

- **`_extract_thinking_chat(message)`** — detects thinking from ChatCompletions responses via four mechanisms: `reasoning_content` field (DeepSeek/QwQ), `thinking` field, typed content blocks (`type: thinking`), and inline `<think>`/`<thinking>` tags. Returns `(clean_text, thinking | None)` so thinking is never mixed into `conversation_history`.
- **`_extract_thinking_responses(response)`** — extracts text from `output[*].type == "reasoning"` items in the Responses API.
- Both providers set `role.runtime_thinking` on the role before returning; `prepare_agent_runtime()` clears it to `None` each turn.
- **`Session.record_turn(thinking=...)`** — when a response message is stored and thinking is present, archives the thinking as a private `thought` (`source='model_thinking'`, `metadata.linked_message_id = response_message_id`). This keeps thinking out of digest content while making it embeddable for semantic search; the `linked_message_id` enables a future cascade from thinking hits back to the parent message.

## Notes on design decisions

- Thinking is stored in `thoughts` (not a new column on `messages`) to reuse the existing embedding pipeline with zero schema changes.
- Thinking is not stored when the response is empty (no committed output = no link target).
- Sub-agent thinking (`agent.spawn`) sets the attribute on a `SimpleNamespace` and is silently discarded, consistent with the issue's stateless sub-agent note.
- `search_semantic` cascade from thinking→message is deferred to a follow-up; the `linked_message_id` metadata is already written to make that straightforward.

## Tests

12 new tests covering:
- All four thinking-extraction paths for ChatCompletions
- Responses API reasoning item extraction  
- Provider sets `role.runtime_thinking` correctly
- `record_turn` stores thinking as thought linked to response message
- `record_turn` with no response does not store thinking

371 tests pass (6 skipped, none failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)