### PR TITLE
feat: ROBITS_SPAWN_MODEL, tool-result scoping, loop detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ For local models with embedding support, `sqlite-vec` is included in `requiremen
 | `ROBITS_MODEL` / `OPENAI_MODEL` | `gpt-4o-mini` | Default chat model |
 | `ROBITS_CHEAP_MODEL` | `ROBITS_MODEL` | Model for cheap interactions |
 | `ROBITS_COSTLY_MODEL` | `ROBITS_MODEL` | Model for SE and costly interactions |
+| `ROBITS_SPAWN_MODEL` | `ROBITS_CHEAP_MODEL` | Default model for `agent.spawn` sub-agents; overrides `ROBITS_CHEAP_MODEL` for spawned executors (e.g. `functiongemma-270m-it`) |
+| `ROBITS_LOOP_DETECT_THRESHOLD` | `3` | Consecutive identical idle responses (no tool calls, no directed routing) before the session halts with `session.loop_detected`; must be an integer ≥ 2 |
 | `ROBITS_PROVIDER_API` | `responses` | `responses` or `chat` / `chat_completions` |
 | `ROBITS_MAX_CONTEXT_TOKENS` | `0` (unlimited) | Trim conversation history to this token budget before each model call (~4 chars/token). Useful for small-context local models (e.g. `3500` for 4k-context models) |
 | `ROBITS_MEMORY_DB` | `~/.local/share/robits/memory.db` | SQLite path for memory storage |

--- a/personas-test-alex.yaml
+++ b/personas-test-alex.yaml
@@ -1,0 +1,34 @@
+# Single-persona test file: alex_chen + CEO only.
+# Rich episodic memories are seeded separately via scripts/seed_test_db.py,
+# which creates thought entries with a digest that references them — enabling
+# the full memory.list_digests → memory.expand_digest → granular-thought chain.
+#
+# Usage:
+#   python scripts/seed_test_db.py var/test-memory.db
+#   ROBITS_PERSONAS_FILE=personas-test-alex.yaml ROBITS_MEMORY_DB=var/test-memory.db ... python main.py
+
+- username: alex_chen
+  full_name: Alex Chen
+  role: SE
+  memories:
+    - kind: digest
+      digest_type: identity
+      content: >
+        Alex Chen is a pragmatic backend engineer with deep Python experience who values
+        clean APIs, strong test coverage, and minimal abstractions. Has led the
+        payment-gateway integration project and the billing-service reliability work.
+        Enjoys cooking Italian food and outdoor running outside of work hours.
+        Current focus: delivering the Stripe integration performance report.
+      relationship_type: personal
+
+- username: CEO
+  full_name: CEO
+  role: CEO
+  memories:
+    - kind: digest
+      digest_type: identity
+      content: >
+        CEO sets strategic direction, approves major decisions, and represents the
+        organisation's mission externally. Prioritises long-term impact over short-term
+        comfort. Currently awaiting a performance report on the payment system.
+      relationship_type: work

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -69,7 +69,10 @@ class Config:
         self.costly_model = env.get("ROBITS_COSTLY_MODEL", _default)
         self.cheap_model = env.get("ROBITS_CHEAP_MODEL", _default)
         self.spawn_model = env.get("ROBITS_SPAWN_MODEL", "").strip() or None
-        self.loop_detect_threshold = max(2, int(env.get("ROBITS_LOOP_DETECT_THRESHOLD", "3")))
+        try:
+            self.loop_detect_threshold = max(2, int(env.get("ROBITS_LOOP_DETECT_THRESHOLD", "3")))
+        except (ValueError, TypeError):
+            self.loop_detect_threshold = 3
         self.provider_api = env.get("ROBITS_PROVIDER_API", "responses").strip().lower()
         self.max_context_tokens = max(0, int(env.get("ROBITS_MAX_CONTEXT_TOKENS", "0")))
 

--- a/robits/core/config.py
+++ b/robits/core/config.py
@@ -68,6 +68,8 @@ class Config:
         _default = env.get("ROBITS_MODEL") or env.get("OPENAI_MODEL") or "gpt-4o-mini"
         self.costly_model = env.get("ROBITS_COSTLY_MODEL", _default)
         self.cheap_model = env.get("ROBITS_CHEAP_MODEL", _default)
+        self.spawn_model = env.get("ROBITS_SPAWN_MODEL", "").strip() or None
+        self.loop_detect_threshold = max(2, int(env.get("ROBITS_LOOP_DETECT_THRESHOLD", "3")))
         self.provider_api = env.get("ROBITS_PROVIDER_API", "responses").strip().lower()
         self.max_context_tokens = max(0, int(env.get("ROBITS_MAX_CONTEXT_TOKENS", "0")))
 

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -616,7 +616,8 @@ class Session:
         if not source_refs:
             return
         try:
-            for agent_id in list(self.participants):
+            agents = list(self.participants)
+            for agent_id in agents:
                 _m.memory_store.append_memory_digest(
                     content=content,
                     source_refs=source_refs,
@@ -627,6 +628,13 @@ class Session:
                     system_only=False,
                     metadata={"trigger_reasons": list(reasons or ["turn_interval"])},
                 )
+            trigger = ",".join(reasons or ["turn_interval"])
+            chars = len(content)
+            print(colored(
+                f"[memory] episodic digest — {len(agents)} agent(s) turn {self.turns_completed}"
+                f" ({len(window)} turns, {chars} chars, trigger: {trigger})",
+                "dark_grey",
+            ))
             self._last_digest_turn = self.turns_completed
             self._last_digest_at = time.monotonic()
         except Exception:
@@ -656,7 +664,8 @@ class Session:
         ]
         if not content_lines:
             return
-        for agent_id in list(self.participants):
+        agents = list(self.participants)
+        for agent_id in agents:
             try:
                 _m.memory_store.append_memory_digest(
                     content=f"Automatic {label} checkpoint:\n" + "\n".join(content_lines),
@@ -670,6 +679,10 @@ class Session:
                 )
             except Exception:
                 pass
+        print(colored(
+            f"[memory] {digest_type} digest — {len(agents)} agent(s) turn {self.turns_completed}",
+            "dark_grey",
+        ))
 
     def _write_org_chat_jsonl(self, entry):
         """Append a non-directed transcript entry as a JSONL line to the org workspace chat log."""
@@ -710,7 +723,8 @@ class Session:
             pass
         if not source_refs:
             return
-        for agent_id in list(self.participants):
+        agents = list(self.participants)
+        for agent_id in agents:
             try:
                 _m.memory_store.append_memory_digest(
                     content=content,
@@ -724,6 +738,11 @@ class Session:
                 )
             except Exception:
                 pass
+        print(colored(
+            f"[memory] org chat digest — {len(agents)} agent(s) turn {self.turns_completed}"
+            f" ({len(lines)} messages)",
+            "dark_grey",
+        ))
 
     def record_thought(self, agent_name, content, visibility="private"):
         """Persist a private thought to memory and emit a thought.recorded event."""

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -939,9 +939,19 @@ class Session:
             while effective_max_turns is None or self.turns_completed < effective_max_turns:
                 last_response = self.step(last_response)
                 _normalized = " ".join((last_response or "").lower().split())
-                _loop_window.append(_normalized)
-                if len(_loop_window) > _loop_threshold:
-                    _loop_window.pop(0)
+                # Only count idle turns — if this turn had tool calls or directed
+                # routing, useful work is happening, so reset the window.
+                _last_entry = self.transcript[-1] if self.transcript else None
+                _turn_was_active = _last_entry is not None and (
+                    bool(getattr(_last_entry, "system_events", None))
+                    or getattr(_last_entry, "directed", False)
+                )
+                if _turn_was_active:
+                    _loop_window.clear()
+                else:
+                    _loop_window.append(_normalized)
+                    if len(_loop_window) > _loop_threshold:
+                        _loop_window.pop(0)
                 if (
                     len(_loop_window) >= _loop_threshold
                     and len(set(_loop_window)) == 1
@@ -949,7 +959,7 @@ class Session:
                 ):
                     print(colored(
                         f"\n[Loop detector] {_loop_threshold} identical consecutive responses "
-                        f"detected — possible greeting loop. Halting.",
+                        f"detected with no tool calls or directed routing — possible greeting loop. Halting.",
                         "yellow",
                     ))
                     self.event_stream.emit(

--- a/robits/core/session.py
+++ b/robits/core/session.py
@@ -871,7 +871,7 @@ class Session:
             prompt = f"[Note: you were mentioned in this message]\n{prompt}"
         raw_prompt = prepend_verified_tool_results(
             prompt,
-            self.recent_system_events() + system_events,
+            system_events,
         )
         effective_org_lines = _m.org_chat_context_lines if self._effective_clock_state() == "on" else 0
         org_context = format_org_chat_context(self.transcript, effective_org_lines)
@@ -914,9 +914,31 @@ class Session:
         if last_response is None:
             last_response = ""
 
+        _loop_window: list[str] = []
+        _loop_threshold = _m.loop_detect_threshold
         try:
             while effective_max_turns is None or self.turns_completed < effective_max_turns:
                 last_response = self.step(last_response)
+                _normalized = " ".join((last_response or "").lower().split())
+                _loop_window.append(_normalized)
+                if len(_loop_window) > _loop_threshold:
+                    _loop_window.pop(0)
+                if (
+                    len(_loop_window) >= _loop_threshold
+                    and len(set(_loop_window)) == 1
+                    and _normalized
+                ):
+                    print(colored(
+                        f"\n[Loop detector] {_loop_threshold} identical consecutive responses "
+                        f"detected — possible greeting loop. Halting.",
+                        "yellow",
+                    ))
+                    self.event_stream.emit(
+                        "session.loop_detected",
+                        self.run_id,
+                        {"response": last_response, "consecutive": _loop_threshold},
+                    )
+                    break
         except SystemExit:
             print(colored("\nSession ended by CEO.", "yellow"))
 

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -854,7 +854,11 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
         runtime_tool_results=[],
     )
 
-    use_model = model if isinstance(model, str) and model.strip() else _m.cheap_model
+    use_model = (
+        model if isinstance(model, str) and model.strip()
+        else _m.spawn_model
+        or _m.cheap_model
+    )
     messages = [
         {
             "role": "system",

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -872,11 +872,17 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
     ]
 
     from robits.core.providers import ChatCompletionsProvider
+    from termcolor import colored
+    task_preview = task.strip()[:80]
+    print(colored(f"[spawn] {sub_role.name} ({use_model}) — \"{task_preview}\"", "dark_grey"))
     provider = ChatCompletionsProvider(_m.client, _m.tool_registry)
     try:
         result = provider.generate(sub_role, use_model, caller_name, messages)
     except Exception as exc:
+        print(colored(f"[spawn] {sub_role.name} -> error: {exc}", "dark_grey"))
         return f"Error: sub-agent failed: {exc}"
+    char_count = len(result or "")
+    print(colored(f"[spawn] {sub_role.name} -> {char_count} chars", "dark_grey"))
     return result or "Error: sub-agent returned no response."
 
 

--- a/scripts/seed_test_db.py
+++ b/scripts/seed_test_db.py
@@ -1,0 +1,125 @@
+"""Seed a fresh robits SQLite memory DB for single-persona memory testing.
+
+Usage:
+    python scripts/seed_test_db.py [db_path]
+
+Default db_path: var/test-memory.db
+
+Creates:
+  - Session record "seed-session"
+  - alex_chen identity digest (via persona seeding)
+  - Five granular thought records covering specific past work
+  - One episodic digest that summarises those thoughts, with each thought
+    as a distinct source ref — enabling memory.expand_digest to reveal the
+    granular detail behind the summary
+
+The DB is fully self-contained. Point ROBITS_MEMORY_DB at it and run with
+ROBITS_PERSONAS_FILE=personas-test-alex.yaml to skip re-seeding at startup
+(seed_persona skips if any memory already exists for the agent).
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from robits.memory.sqlite import SQLiteMemoryStore
+
+DB_PATH = sys.argv[1] if len(sys.argv) > 1 else "var/test-memory.db"
+AGENT = "alex_chen"
+SESSION = "seed-session"
+
+os.makedirs(os.path.dirname(DB_PATH) if os.path.dirname(DB_PATH) else ".", exist_ok=True)
+
+store = SQLiteMemoryStore(DB_PATH)
+store.upsert_agent(AGENT, role="SE", full_name="Alex Chen", username=AGENT)
+store.create_session(SESSION)
+
+print(f"Seeding {DB_PATH} for agent {AGENT!r} ...")
+
+# --- identity digest ---
+identity_content = (
+    "Alex Chen is a pragmatic backend engineer with deep Python experience who values "
+    "clean APIs, strong test coverage, and minimal abstractions. Has led the "
+    "payment-gateway integration project and billing-service reliability work. "
+    "Enjoys cooking Italian food and outdoor running outside of work hours. "
+    "Current focus: delivering the Stripe integration performance report."
+)
+store.seed_memory_digest(
+    "identity",
+    identity_content,
+    agent_id=AGENT,
+    session_id=SESSION,
+    relationship_type="personal",
+)
+print("  identity digest seeded")
+
+# --- granular work thoughts ---
+thoughts = [
+    (
+        "Completed Stripe payment-gateway integration on 2026-04-10. "
+        "Used idempotency keys (header: Idempotency-Key) on POST /v1/charges to make "
+        "retries safe under network failures. Latency p99 is 320 ms."
+    ),
+    (
+        "Fixed webhook HMAC validation bug in billing-service (commit a3f9b1c, 2026-04-08). "
+        "Root cause: STRIPE_WEBHOOK_SECRET env var was missing in staging, so the signature "
+        "check was silently skipped. Added a startup assertion to fail fast if the secret is absent."
+    ),
+    (
+        "CEO requested a performance report on the payment system by 2026-04-18 (end of sprint). "
+        "Key metrics to include: throughput (req/s), p50/p95/p99 latency, error rate, "
+        "and webhook delivery success rate."
+    ),
+    (
+        "Jordan (HR) mentioned new engineer Priya Patel starts 2026-04-14. "
+        "Need to set up her dev environment: clone payment-gateway repo, provision a Stripe test account, "
+        "and add her to the #payments Slack channel."
+    ),
+    (
+        "Investigated memory leak in the billing-worker process (2026-04-05). "
+        "Found that SQLAlchemy sessions were not being closed after each job. "
+        "Fixed with a context manager; worker RSS now stays flat over 24 h."
+    ),
+]
+
+thought_ids = []
+for content in thoughts:
+    tid = store.append_thought(
+        agent_id=AGENT,
+        content=content,
+        session_id=SESSION,
+        visibility="private",
+        source="seed_script",
+        relationship_type="work",
+    )
+    thought_ids.append(tid)
+    print(f"  thought {tid}: {content[:60]}...")
+
+# --- episodic digest referencing all five thoughts ---
+episodic_summary = (
+    "Work summary — April 2026:\n"
+    "• Completed Stripe payment-gateway integration (2026-04-10): idempotency keys, p99 latency 320 ms.\n"
+    "• Fixed billing-service webhook HMAC validation bug (commit a3f9b1c, 2026-04-08).\n"
+    "• CEO performance report due 2026-04-18: throughput, latency p50/p95/p99, error rate, webhook delivery.\n"
+    "• Priya Patel joins 2026-04-14 — needs dev env, Stripe test account, #payments Slack access.\n"
+    "• Fixed billing-worker memory leak (2026-04-05): SQLAlchemy sessions not closed; resolved with context manager."
+)
+source_refs = [{"source_table": "thoughts", "source_id": tid} for tid in thought_ids]
+digest_id = store.append_memory_digest(
+    content=episodic_summary,
+    source_refs=source_refs,
+    agent_id=AGENT,
+    session_id=SESSION,
+    digest_type="episodic",
+    accessibility="agent",
+    system_only=False,
+    source="seed_script",
+    relationship_type="work",
+)
+print(f"  episodic digest {digest_id} created, sources: {thought_ids}")
+
+print(f"\nDone. Run with:")
+print(f"  ROBITS_MEMORY_DB={DB_PATH} ROBITS_PERSONAS_FILE=personas-test-alex.yaml \\")
+print(f"  ROBITS_SPAWN_MODEL=functiongemma-270m-it ROBITS_PROVIDER_API=chat \\")
+print(f"  ROBITS_LOOP_DETECT_THRESHOLD=3 ROBITS_DIGEST_INTERVAL=2 \\")
+print(f"  PYTHONUTF8=1 python main.py")

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1938,7 +1938,8 @@ class RuntimeTests(unittest.TestCase):
         self.assertEqual(session.transcript[0].response, "")
         self.assertIn("tool_call.executed: agent__context", session.transcript[0].system_events[0])
 
-    def test_recent_verified_events_are_included_in_next_agent_prompt(self):
+    def test_prior_turn_tool_results_not_injected_into_unrelated_agent_prompt(self):
+        # Tool results from HR→Ops in a prior turn must not pollute SE's prompt.
         participants = build_fake_participants()
         session = main.Session(participants=participants, run_id="session-1")
         session.transcript.append(
@@ -1956,8 +1957,32 @@ class RuntimeTests(unittest.TestCase):
         with redirect_stdout(StringIO()):
             session.step("SE, what changed?")
 
-        self.assertIn("Verified runtime results", participants["SE"].received[0][1])
-        self.assertIn("Created a new role: QA", participants["SE"].received[0][1])
+        self.assertNotIn("Verified runtime results", participants["SE"].received[0][1])
+        self.assertNotIn("Created a new role: QA", participants["SE"].received[0][1])
+
+    def test_loop_detector_halts_on_identical_consecutive_responses(self):
+        class GreetingRole:
+            """Always replies with the same greeting — simulates a stuck model."""
+            def __init__(self, name):
+                self.name = name
+                self.group_conversation_history = {}
+            def interact(self, sender=None, prompt=None):
+                return "Hi! How can I help you today?"
+            def update_group_conversations(self, msg):
+                pass
+
+        participants = {"CEO": GreetingRole("CEO"), "SE": GreetingRole("SE")}
+        with patch.object(main._config, "loop_detect_threshold", 3):
+            session = main.Session(participants=participants, run_id="loop-test")
+            with redirect_stdout(StringIO()):
+                session.run(initial_message="Hi!", max_turns=20)
+        # Loop detector should halt before max_turns.
+        self.assertLess(session.turns_completed, 20)
+        loop_events = [
+            e for e in session.event_stream._events
+            if getattr(e, "event_type", None) == "session.loop_detected"
+        ]
+        self.assertTrue(loop_events, "Expected session.loop_detected event")
 
     def test_session_returns_native_tool_events_to_agent_context(self):
         class NativeToolEventProvider:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1984,6 +1984,44 @@ class RuntimeTests(unittest.TestCase):
         ]
         self.assertTrue(loop_events, "Expected session.loop_detected event")
 
+    def test_loop_detector_resets_on_turn_with_tool_calls(self):
+        """Loop window must clear when a turn produces system_events (tool calls)."""
+        turn = [0]
+
+        class MixedRole:
+            def __init__(self, name):
+                self.name = name
+                self.group_conversation_history = {}
+            def interact(self, sender=None, prompt=None):
+                turn[0] += 1
+                return "Hi! How can I help you today?"
+            def update_group_conversations(self, msg):
+                pass
+
+        participants = {"CEO": MixedRole("CEO"), "SE": MixedRole("SE")}
+        with patch.object(main._config, "loop_detect_threshold", 3):
+            session = main.Session(participants=participants, run_id="loop-reset-test")
+            # Inject a fake tool event into turn 2 to simulate a turn with tool activity.
+            original_step = session.step
+            call_count = [0]
+            def patched_step(msg):
+                call_count[0] += 1
+                resp = original_step(msg)
+                if call_count[0] == 2 and session.transcript:
+                    session.transcript[-1].system_events.append("tool_call.executed: fake({}) -> ok")
+                return resp
+            session.step = patched_step
+            with redirect_stdout(StringIO()):
+                session.run(initial_message="Hi!", max_turns=20)
+        loop_events = [
+            e for e in session.event_stream._events
+            if getattr(e, "event_type", None) == "session.loop_detected"
+        ]
+        # Turn 2 had a tool event so window resets — loop should not fire until
+        # 3 more idle turns, requiring more than 4 total turns.
+        self.assertGreater(session.turns_completed, 4)
+        self.assertTrue(loop_events, "Loop should still eventually be detected")
+
     def test_session_returns_native_tool_events_to_agent_context(self):
         class NativeToolEventProvider:
             def generate(self, role, *_):


### PR DESCRIPTION
Closes #112

## Summary

- **`ROBITS_SPAWN_MODEL` env var** — `agent.spawn` now falls back to this before `ROBITS_CHEAP_MODEL`, so operators can pre-configure `functiongemma-270m-it` (or any dedicated tool-calling model) without each persona needing to pass `model=` explicitly.

- **Tool-result residue scoping** — removed `recent_system_events()` from the verified-tool-results block injected into every receiver's prompt. Prior-turn tool results from *other* agents no longer bleed into unrelated agents' context as authoritative facts. Results remain visible in the org chat transcript.

- **Greeting-loop detector** — `session.run()` tracks the last N normalised responses (N = `ROBITS_LOOP_DETECT_THRESHOLD`, default 3). If all N are identical and non-empty, the loop halts with a console warning and emits a `session.loop_detected` event. Prevents the 35-turn "Hi! How can I help?" cycle observed in live testing.

## Test plan

- [x] `test_prior_turn_tool_results_not_injected_into_unrelated_agent_prompt` — asserts scoped behaviour (replaces/inverts old test)
- [x] `test_loop_detector_halts_on_identical_consecutive_responses` — verifies halt + event emission before `max_turns`
- [x] 273 total tests passing, 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)