### PR TITLE
feat: SE shell capability and stronger memory/spawn prompting

### DIFF
--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -85,7 +85,7 @@ class Role:
         turn_action_template = """
 On your turn, choose one useful action. You do not need to reply to every message.
 Only say that you created, changed, or called a tool after the runtime has returned a verified tool result. Without a verified result, describe the work as a request, proposal, or plan instead of a completed fact.
-When thinking, recalling past events, or forming memories, use your tools rather than relying on assumed knowledge.
+When recalling past events, experiences, or recent work — even if the answer seems available in context — call memory.list_digests first to retrieve the full picture, then use memory.expand_digest for any digest that sounds relevant before answering.
 """
         self.template = template + group_template_additions + turn_action_template
         self.employee_dict = employee_dict
@@ -231,8 +231,8 @@ class SoftwareEngineer(Role):
         template = """As a Software Engineer (SE), you are responsible for designing, developing, and maintaining software applications. You primarily propose trusted tools when requested by others in your organization."""
         group_template_additions = """You are part of the Engineering group. Tools are trusted functions described by namespaced OpenAI-compatible metadata. You can propose tools with working Python code using the `code` field in tools.propose. IMPORTANT CODE RULES: write the body as a sequence of simple statements ending with a single `return` — do NOT define nested functions or classes (lambdas and inline expressions are fine). The sandbox has no imports; available builtins: abs, bool, dict, enumerate, float, int, len, list, max, min, range, round, set, sorted, str, sum, tuple, zip. Available globals: get_caller_name() → calling agent's name; workspace_write/workspace_read/workspace_list/workspace_delete → agent files; org_chat_read → recent org chat; memory_search/memory_list_digests/memory_expand_digest → stored context; work_todo_add → task tracking; agent_think/agent_wait/agent_spawn → agent control; current_agent_context → runtime context; grant_tool_access/revoke_tool_access → permissions; propose_tool_change/list_tool_proposals/approve_tool_proposal/reject_tool_proposal/rollout_tool_proposal/approve_and_rollout_proposal → proposals; list_registered_tools → tool catalogue; create_lifecycle_role/pause_lifecycle_role/retire_lifecycle_role/archive_lifecycle_role/list_lifecycle_roles → org management; create_alarm/list_alarms/cancel_alarm → scheduling; builtin_web_search/builtin_url_fetch/builtin_file_search/builtin_shell_run/builtin_tool_search/builtin_mcp_call/builtin_computer_use/builtin_image_generation → external integrations. Example: `return f"{get_caller_name()}: {status}"`. Parameters use JSON Schema: {"type":"object","properties":{"status":{"type":"string"}},"required":["status"]}. Approved proposals with code are registered and activated at rollout without a restart."""
         super().__init__(self.__class__.__name__, template, employee_dict, group_template_additions)
-        self.capabilities = {"engineer"}
-        self.allowed_tools.update({"tools.list", "tools.list_proposals", "tools.propose"})
+        self.capabilities = {"engineer", "shell"}
+        self.allowed_tools.update({"tools.list", "tools.list_proposals", "tools.propose", "builtin.shell_run"})
 
     def interact(self, sender, prompt):
         """Respond using the costly model to handle complex engineering tasks."""

--- a/robits/core/roles.py
+++ b/robits/core/roles.py
@@ -85,7 +85,7 @@ class Role:
         turn_action_template = """
 On your turn, choose one useful action. You do not need to reply to every message.
 Only say that you created, changed, or called a tool after the runtime has returned a verified tool result. Without a verified result, describe the work as a request, proposal, or plan instead of a completed fact.
-When recalling past events, experiences, or recent work — even if the answer seems available in context — call memory.list_digests first to retrieve the full picture, then use memory.expand_digest for any digest that sounds relevant before answering.
+When recalling past events, experiences, or recent work — even if the answer seems available in context — use memory.search (for specific queries), memory.list_digests, or memory.expand_digest to retrieve the full picture before answering.
 """
         self.template = template + group_template_additions + turn_action_template
         self.employee_dict = employee_dict

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -862,8 +862,8 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
     )
     _task_stripped = task.strip()
     _shell_hint = (
-        " To run a shell command, call builtin.shell_run with the command string."
-        if any(_task_stripped.startswith(p) for p in ("python", "bash", "sh ", "node", "run ", "execute "))
+        f" To run a shell command, call builtin.shell_run with agent_name='{caller_name}' and the command string."
+        if any(_task_stripped.startswith(p) for p in ("python", "bash", "sh ", "sh", "node", "run ", "execute "))
         or any(op in _task_stripped for op in ("python3 -c", "python -c", "bash -c"))
         else ""
     )

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -860,6 +860,13 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
         else _m.spawn_model
         or _m.cheap_model
     )
+    _task_stripped = task.strip()
+    _shell_hint = (
+        " To run a shell command, call builtin.shell_run with the command string."
+        if any(_task_stripped.startswith(p) for p in ("python", "bash", "sh ", "node", "run ", "execute "))
+        or any(op in _task_stripped for op in ("python3 -c", "python -c", "bash -c"))
+        else ""
+    )
     messages = [
         {
             "role": "system",
@@ -867,9 +874,10 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
                 f"You are a focused task executor working on behalf of {caller_name}. "
                 "Perform the given task using available tools and return a concise result. "
                 "Do not ask clarifying questions. Do not retain memory between calls."
+                + _shell_hint
             ),
         },
-        {"role": "user", "content": task.strip()},
+        {"role": "user", "content": _task_stripped},
     ]
 
     from robits.core.providers import ChatCompletionsProvider

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2327,6 +2327,7 @@ class BuiltinToolTests(unittest.TestCase):
         with patch("robits.core.providers.ChatCompletionsProvider.generate", fake_generate):
             main.agent_spawn({}, "python3 -c 'print(6*7)'")
         self.assertIn("builtin.shell_run", captured["system"])
+        self.assertIn("agent_name=", captured["system"])
 
     def test_agent_spawn_no_shell_hint_for_plain_task(self):
         """System prompt should NOT add the shell hint for non-shell tasks."""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2315,6 +2315,32 @@ class BuiltinToolTests(unittest.TestCase):
         self.assertIn("builtin.url_fetch", captured["allowed_tools"])
         self.assertNotIn("memory.search", captured["allowed_tools"])
 
+    def test_agent_spawn_injects_shell_hint_for_shell_task(self):
+        """System prompt should mention builtin.shell_run when task starts with python/bash."""
+        captured = {}
+
+        def fake_generate(self_provider, sub_role, model, caller, messages):
+            captured["system"] = next(m["content"] for m in messages if m["role"] == "system")
+            return "42"
+
+        from unittest.mock import patch
+        with patch("robits.core.providers.ChatCompletionsProvider.generate", fake_generate):
+            main.agent_spawn({}, "python3 -c 'print(6*7)'")
+        self.assertIn("builtin.shell_run", captured["system"])
+
+    def test_agent_spawn_no_shell_hint_for_plain_task(self):
+        """System prompt should NOT add the shell hint for non-shell tasks."""
+        captured = {}
+
+        def fake_generate(self_provider, sub_role, model, caller, messages):
+            captured["system"] = next(m["content"] for m in messages if m["role"] == "system")
+            return "ok"
+
+        from unittest.mock import patch
+        with patch("robits.core.providers.ChatCompletionsProvider.generate", fake_generate):
+            main.agent_spawn({}, "summarise the readme")
+        self.assertNotIn("builtin.shell_run", captured["system"])
+
     # ── builtin.tool_search ──────────────────────────────────────────────────
 
     def test_tool_search_finds_tools_by_name_fragment(self):
@@ -4092,6 +4118,18 @@ class PersonaRedesignTests(unittest.TestCase):
         self.assertIn("eng1", d)
         self.assertIn("eng2", d)
         self.assertNotIn("SE", d)
+
+    def test_se_has_shell_capability(self):
+        """SoftwareEngineer must carry the 'shell' capability so sub-agents can call builtin.shell_run."""
+        from robits.core.roles import SoftwareEngineer
+        se = SoftwareEngineer({})
+        self.assertIn("shell", se.capabilities)
+
+    def test_se_has_shell_run_in_allowed_tools(self):
+        """SoftwareEngineer.allowed_tools must include builtin.shell_run explicitly."""
+        from robits.core.roles import SoftwareEngineer
+        se = SoftwareEngineer({})
+        self.assertIn("builtin.shell_run", se.allowed_tools)
 
     def test_mention_detection_at_username(self):
         from robits.core.session import Session


### PR DESCRIPTION
## Summary

- **SE shell capability** (#118, #119): `SoftwareEngineer` now has `{"engineer", "shell"}` capabilities and `builtin.shell_run` in `allowed_tools`. Sub-agents spawned by SE inherit the caller's capabilities, so they can now call `builtin.shell_run` without hitting a capability denial.
- **Memory prompting** (#119): The turn-action template now explicitly directs agents to call `memory.list_digests` + `memory.expand_digest` before answering questions about past work, even when a summary is available in context. This combats small-model passivity where models answer from identity digest context without reaching for tool-retrieved detail.
- **Spawn shell hint** (#118): `agent_spawn` detects shell-like task strings (`python3 -c`, `bash -c`, `python ...`, etc.) and injects a one-line reminder into the sub-agent system prompt to call `builtin.shell_run`.

## Test plan
- [ ] `test_se_has_shell_capability` — SE carries `"shell"` in capabilities
- [ ] `test_se_has_shell_run_in_allowed_tools` — SE allowed_tools includes `builtin.shell_run`
- [ ] `test_agent_spawn_injects_shell_hint_for_shell_task` — system prompt includes shell hint for `python3 -c` tasks
- [ ] `test_agent_spawn_no_shell_hint_for_plain_task` — system prompt does NOT include shell hint for plain tasks
- [ ] Full suite: 380 passed, 6 skipped

Closes #118, Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)