### PR TITLE
fix: use sub-agent own name in shell hint for workspace auth

### DIFF
--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -861,8 +861,9 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
         or _m.cheap_model
     )
     _task_stripped = task.strip()
+    _sub_agent_name = f"{caller_name}:subtask"
     _shell_hint = (
-        f" To run a shell command, call builtin.shell_run with agent_name='{caller_name}' and the command string."
+        f" To run a shell command, call builtin.shell_run with agent_name='{_sub_agent_name}' and the command string."
         if any(_task_stripped.startswith(p) for p in ("python", "bash", "sh ", "sh", "node", "run ", "execute "))
         or any(op in _task_stripped for op in ("python3 -c", "python -c", "bash -c"))
         else ""

--- a/robits/core/tool_functions.py
+++ b/robits/core/tool_functions.py
@@ -861,9 +861,8 @@ def agent_spawn(employee_dict, task, tools=None, model=None):
         or _m.cheap_model
     )
     _task_stripped = task.strip()
-    _sub_agent_name = f"{caller_name}:subtask"
     _shell_hint = (
-        f" To run a shell command, call builtin.shell_run with agent_name='{_sub_agent_name}' and the command string."
+        f" To run a shell command, call builtin.shell_run with agent_name='{sub_role.name}' and the command string."
         if any(_task_stripped.startswith(p) for p in ("python", "bash", "sh ", "sh", "node", "run ", "execute "))
         or any(op in _task_stripped for op in ("python3 -c", "python -c", "bash -c"))
         else ""

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2328,6 +2328,7 @@ class BuiltinToolTests(unittest.TestCase):
             main.agent_spawn({}, "python3 -c 'print(6*7)'")
         self.assertIn("builtin.shell_run", captured["system"])
         self.assertIn("agent_name=", captured["system"])
+        self.assertIn(":subtask", captured["system"])
 
     def test_agent_spawn_no_shell_hint_for_plain_task(self):
         """System prompt should NOT add the shell hint for non-shell tasks."""


### PR DESCRIPTION
## Summary

Follow-up to #120: the shell hint injected into sub-agent system prompts used `agent_name='{caller_name}'` but the sub-agent's `active_tool_caller_name` is `'{caller_name}:subtask'`. The workspace ownership check (`_caller_can_act_for_agent`) requires `caller_name == agent_name`, so the workspace access was always denied for SE-spawned sub-agents.

Fixed by using `agent_name='{caller_name}:subtask'` in the hint. `safe_agent_workspace_name` converts the colon to an underscore for a safe filesystem path.

Discovered via local single-persona integration test — `spawn_result` was 72 chars but the content was a workspace error message.

## Test plan
- [ ] Updated `test_agent_spawn_injects_shell_hint_for_shell_task` to assert `:subtask` appears in the agent_name in the hint
- [ ] All 380 tests pass

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)